### PR TITLE
Fallback to local corepack install when enabling corepack fails

### DIFF
--- a/action.mjs
+++ b/action.mjs
@@ -41,6 +41,12 @@ function getGithubActionPath() {
   return path.dirname(fileURLToPath(import.meta.url))
 }
 
+
+function getLocalCommand(command, cwd) {
+  const extension = process.platform === 'win32' ? '.cmd' : ''
+  return path.join(cwd, 'node_modules', '.bin', `${command}${extension}`)
+}
+
 // Main
 console.log('Action: ', process.env['GITHUB_ACTION'])
 if (
@@ -52,18 +58,23 @@ if (
   if (isCommandFailed(nodeVersionResult)) {
     throw new Error('Fail to check node version')
   }
-  const corepackCommand = getRuntimeCommand('corepack')
-  const enableCorepackResult = runCommand(
-    [corepackCommand, 'enable'],
-    actionPath
-  )
+  let corepackCommand = getRuntimeCommand('corepack')
+  let enableCorepackResult = runCommand([corepackCommand, 'enable'], actionPath)
+  if (isCommandFailed(enableCorepackResult)) {
+    const installCorepackResult = runCommand(
+      [getRuntimeCommand('npm'), 'install', '--no-save', 'corepack'],
+      actionPath
+    )
+    if (isCommandFailed(installCorepackResult)) {
+      throw new Error('Fail to install corepack')
+    }
+    corepackCommand = getLocalCommand('corepack', actionPath)
+    enableCorepackResult = runCommand([corepackCommand, 'enable'], actionPath)
+  }
   if (isCommandFailed(enableCorepackResult)) {
     throw new Error('Fail to enable corepack')
   }
-  const dependenciesResult = runCommand(
-    [corepackCommand, 'yarn', 'install'],
-    actionPath
-  )
+  const dependenciesResult = runCommand([corepackCommand, 'yarn', 'install'], actionPath)
   if (isCommandFailed(dependenciesResult)) {
     throw new Error('Fail to run setup')
   }


### PR DESCRIPTION
### Motivation
- Ensure the GitHub Action can enable and run `corepack` even when `corepack` is not available in the runtime by falling back to installing a local copy and using the local binary, with Windows `.cmd` handling.

### Description
- Add `getLocalCommand` to resolve a `node_modules/.bin` command path and append `.cmd` on Windows.
- Try to run `corepack enable` using the runtime binary and if it fails, run `npm install --no-save corepack` and retry enable using the local `corepack` binary.
- Keep existing `runCommand` and `isCommandFailed` checks and throw clear errors on failure to install, enable, or install dependencies.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9badfd0c08328bda9f04135a9dabb)