### PR TITLE
Upgrade dependencies

### DIFF
--- a/action/feeds/database.test.ts
+++ b/action/feeds/database.test.ts
@@ -3,6 +3,7 @@ import fs from 'fs'
 import knex, { type Knex } from 'knex'
 import path from 'path'
 import sinon from 'sinon'
+import { fileURLToPath } from 'url'
 import {
   createOrUpdateDatabase,
   createTables,
@@ -22,6 +23,8 @@ import {
 } from './database'
 import { readOpml } from './opml'
 import { Entry, Site } from './parsers'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 const test = anyTest as TestFn<{
   db: Knex

--- a/action/feeds/opml.test.ts
+++ b/action/feeds/opml.test.ts
@@ -3,6 +3,7 @@ import fs from 'fs/promises'
 import knex from 'knex'
 import path from 'path'
 import sinon from 'sinon'
+import { fileURLToPath } from 'url'
 import {
   createTables,
   getAllCategories,
@@ -10,6 +11,8 @@ import {
   removeOldCategories
 } from './database'
 import { readOpml } from './opml'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 test('#readOpml returns categories and sites in OPML file', async (t) => {
   const data = (

--- a/action/feeds/parsers#parseAtom.test.ts
+++ b/action/feeds/parsers#parseAtom.test.ts
@@ -2,7 +2,10 @@ import test from 'ava'
 import fs from 'fs'
 import path from 'path'
 import sinon from 'sinon'
+import { fileURLToPath } from 'url'
 import { parseAtom, parseXML } from './parsers'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 test('#parseAtom returns site information with empty string for fields that does not have information', async (t) => {
   const data = fs

--- a/action/feeds/parsers#parseRss.test.ts
+++ b/action/feeds/parsers#parseRss.test.ts
@@ -2,7 +2,10 @@ import test from 'ava'
 import fs from 'fs'
 import path from 'path'
 import sinon from 'sinon'
+import { fileURLToPath } from 'url'
 import { parseRss, parseXML } from './parsers'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 test('#parseAtom returns site information with empty string for fields that does not have information', async (t) => {
   const data = fs

--- a/lib/storage/sqlite.ts
+++ b/lib/storage/sqlite.ts
@@ -1,6 +1,9 @@
-import { createDbWorker, WorkerHttpvfs } from 'sql.js-httpvfs'
-import { SplitFileConfig } from 'sql.js-httpvfs/dist/sqlite.worker'
-import { Category, Content, SiteEntry, Storage } from './types'
+import sqlJsHttpvfs from 'sql.js-httpvfs'
+import type { WorkerHttpvfs } from 'sql.js-httpvfs'
+import type { SplitFileConfig } from 'sql.js-httpvfs/dist/sqlite.worker'
+import type { Category, Content, SiteEntry, Storage } from './types'
+
+const { createDbWorker } = sqlJsHttpvfs as typeof import('sql.js-httpvfs')
 
 const CONTENT_PER_PAGE = 30
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "start": "next start",
     "load": "INPUT_OPMLFILE='feeds.opml' node --import tsx index.ts",
     "loadFile": "INPUT_OPMLFILE='feeds.opml' INPUT_STORAGETYPE='files' node --import tsx index.ts",
-    "test": "NODE_OPTIONS='--import tsx' ava"
+    "test": "ava"
   },
   "ava": {
     "extensions": [
@@ -21,7 +21,11 @@
       "tsx",
       "js"
     ],
-    "failWithoutAssertions": false
+    "failWithoutAssertions": false,
+    "nodeArguments": [
+      "--import=tsx"
+    ],
+    "workerThreads": false
   },
   "dependencies": {
     "@actions/core": "^3.0.1",
@@ -33,17 +37,17 @@
     "autoprefixer": "^10.5.0",
     "date-fns": "^4.1.0",
     "history": "^5.3.0",
-    "html-react-parser": "^6.0.1",
+    "html-react-parser": "^6.1.0",
     "knex": "^3.2.10",
-    "lucide-react": "^1.8.0",
+    "lucide-react": "^1.14.0",
     "next": "^16.2.4",
     "next-themes": "^0.4.6",
     "node-fetch": "^3.3.2",
-    "postcss": "^8.5.13",
-    "react": "^19.2.4",
+    "postcss": "^8.5.14",
+    "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "sanitize-html": "^2.17.3",
-    "shadcn": "^4.6.0",
+    "shadcn": "^4.7.0",
     "sql.js-httpvfs": "^0.8.12",
     "sqlite3": "^6.0.1",
     "tailwindcss": "^4.2.4",
@@ -59,9 +63,9 @@
     "@types/sanitize-html": "^2.16.1",
     "@types/sinon": "^21.0.1",
     "@types/xml2js": "^0.4.14",
-    "ava": "^7.0.0",
+    "ava": "^8.0.0",
     "prettier": "^3.8.3",
-    "sinon": "^21.1.2",
+    "sinon": "^22.0.0",
     "typescript": "^6.0.3"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1533,12 +1533,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sinonjs/fake-timers@npm:^15.3.2":
-  version: 15.3.2
-  resolution: "@sinonjs/fake-timers@npm:15.3.2"
+"@sinonjs/fake-timers@npm:^15.4.0":
+  version: 15.4.0
+  resolution: "@sinonjs/fake-timers@npm:15.4.0"
   dependencies:
     "@sinonjs/commons": "npm:^3.0.1"
-  checksum: 10c0/fea39af47e70acf7f6b431b857dc5b50886e1a19d48189bc7f9cf90806a9fdfd4931c04343558724772d429c47fb53df640fc8c8d6ddf6ad66164bd7cbd3220a
+  checksum: 10c0/de4522afe0699fa8d3ae9d1715cbaa4b47e518c707bb7988a9ec6c7c67557d9f6df451f6be0338598b984a86f65aab9fab38dd9ce75a3c0ffb801a9500d5b10d
   languageName: node
   linkType: hard
 
@@ -1861,9 +1861,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vercel/nft@npm:^1.3.2":
-  version: 1.3.2
-  resolution: "@vercel/nft@npm:1.3.2"
+"@vercel/nft@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "@vercel/nft@npm:1.5.0"
   dependencies:
     "@mapbox/node-pre-gyp": "npm:^2.0.0"
     "@rollup/pluginutils": "npm:^5.1.3"
@@ -1879,7 +1879,7 @@ __metadata:
     resolve-from: "npm:^5.0.0"
   bin:
     nft: out/cli.js
-  checksum: 10c0/5f2d167cf43eef92776e7dfd7231891e319770d06bdff0f86fb9b55cd2163346551d44000d5490a7a260ef1098812a2a5bf27febb1f97dbf6320390e1535326c
+  checksum: 10c0/e44f2bb41908f11ece98aa5c4f33b7ff6575a5102ab2db2675f4ee74bcc62439dce4d363a393f80a677898f63f7cac5741685653ee97a924e61e75c9d5b504d6
   languageName: node
   linkType: hard
 
@@ -2163,48 +2163,49 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ava@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "ava@npm:7.0.0"
+"ava@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "ava@npm:8.0.0"
   dependencies:
-    "@vercel/nft": "npm:^1.3.2"
+    "@vercel/nft": "npm:^1.5.0"
     acorn: "npm:^8.16.0"
     acorn-walk: "npm:^8.3.5"
     ansi-styles: "npm:^6.2.3"
     arrgv: "npm:^1.0.2"
     arrify: "npm:^3.0.0"
     callsites: "npm:^4.2.0"
-    cbor: "npm:^10.0.11"
+    cbor: "npm:^10.0.12"
     chalk: "npm:^5.6.2"
     chunkd: "npm:^2.0.1"
     ci-info: "npm:^4.4.0"
     ci-parallel-vars: "npm:^1.0.1"
-    cli-truncate: "npm:^5.1.1"
+    cli-truncate: "npm:^6.0.0"
     code-excerpt: "npm:^4.0.0"
     common-path-prefix: "npm:^3.0.0"
     concordance: "npm:^5.0.4"
     currently-unhandled: "npm:^0.4.1"
     debug: "npm:^4.4.3"
-    emittery: "npm:^1.2.0"
+    emittery: "npm:^2.0.0"
     figures: "npm:^6.1.0"
-    globby: "npm:^16.1.1"
+    globby: "npm:^16.2.0"
     ignore-by-default: "npm:^2.1.0"
     indent-string: "npm:^5.0.0"
     is-plain-object: "npm:^5.0.0"
     is-promise: "npm:^4.0.0"
     matcher: "npm:^6.0.0"
-    memoize: "npm:^10.2.0"
+    memoize: "npm:^11.0.0"
     ms: "npm:^2.1.3"
     p-map: "npm:^7.0.4"
     package-config: "npm:^5.0.0"
-    picomatch: "npm:^4.0.3"
+    picomatch: "npm:^4.0.4"
     plur: "npm:^6.0.0"
     pretty-ms: "npm:^9.3.0"
     resolve-cwd: "npm:^3.0.0"
+    slash: "npm:^5.1.0"
     stack-utils: "npm:^2.0.6"
     supertap: "npm:^3.0.1"
     temp-dir: "npm:^3.0.0"
-    write-file-atomic: "npm:^7.0.0"
+    write-file-atomic: "npm:^7.0.1"
     yargs: "npm:^18.0.0"
   peerDependencies:
     "@ava/typescript": "*"
@@ -2212,8 +2213,8 @@ __metadata:
     "@ava/typescript":
       optional: true
   bin:
-    ava: entrypoints/cli.mjs
-  checksum: 10c0/19c5e494bac1cc8140e78cb1440f299f9ae07baea50740c4d66daec3e2af048e71b8b5313e4834e100aeead7182d9bfe1b7acaad3dab7317ef2a00f23d39bc92
+    ava: entrypoints/cli.js
+  checksum: 10c0/510bd02cd9192c3da3ec47da5122c3748711c481bdfe6d8ff97e89ba3500f2f1e0edc59fa39c3b291cf4b29b66da55626cd1dea1b13cd5cd1aad3e9873a2d57b
   languageName: node
   linkType: hard
 
@@ -2485,12 +2486,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cbor@npm:^10.0.11":
-  version: 10.0.11
-  resolution: "cbor@npm:10.0.11"
+"cbor@npm:^10.0.12":
+  version: 10.0.12
+  resolution: "cbor@npm:10.0.12"
   dependencies:
     nofilter: "npm:^3.0.2"
-  checksum: 10c0/0cb6fb3d5e98c7af4443200ff107049f6132b5649b8a0e586940ca811e5ab5622bf3d0a36f154f43107acfd9685cc462e6eac77876ef4c060bcec96c71b90d8a
+  checksum: 10c0/4c197d783415cade31565725a5e6b2b967d856285eacdb0b5f5ec0687d93c12f2ee9c6cc05aa7be02e8bbf0fe3ba40d22be69b56bd2ab1be2cc0a59370f14246
   languageName: node
   linkType: hard
 
@@ -2588,13 +2589,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cli-truncate@npm:^5.1.1":
-  version: 5.2.0
-  resolution: "cli-truncate@npm:5.2.0"
+"cli-truncate@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "cli-truncate@npm:6.0.0"
   dependencies:
-    slice-ansi: "npm:^8.0.0"
+    slice-ansi: "npm:^9.0.0"
     string-width: "npm:^8.2.0"
-  checksum: 10c0/0d4ec94702ca85b64522ac93633837fb5ea7db17b79b1322a60f6045e6ae2b8cd7bd4c1d19ac7d1f9e10e3bbda1112e172e439b68c02b785ee00da8d6a5c5471
+  checksum: 10c0/e0abb91a00dd20c64b93345e0235e780a5f2cf182c529235bae83f1ab1488b90b047838c1e72b9b472cb5cd6f294f017dac6afed511fa3996d710d3675dec6f7
   languageName: node
   linkType: hard
 
@@ -3077,10 +3078,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"diff@npm:^8.0.4":
-  version: 8.0.4
-  resolution: "diff@npm:8.0.4"
-  checksum: 10c0/7ee5d03926db4039be7252ac3b0abaae1bd122a2ca971e5ca7270e444e36ff83dd906fad1a719740ca347e97ed5dc8f458a76a8391dbcd7aff363bdafb348a00
+"diff@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "diff@npm:9.0.0"
+  checksum: 10c0/a971cc88f66071a33bd3942db2f51b57d484e9856265ae45cf44fb28ab2fde91f132d9c26d8be0fb6082d2be94d29e1295c1adb251b7461935d6a2dd304cd161
   languageName: node
   linkType: hard
 
@@ -3232,10 +3233,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"emittery@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "emittery@npm:1.2.0"
-  checksum: 10c0/3b16d67b2cbbc19d44fa124684039956dc94c376cefa8c7b29f4c934d9d370e6819f642cddaa343b83b1fc03fda554a1498e12f5861caf9d6f6394ff4b6e808a
+"emittery@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "emittery@npm:2.0.0"
+  checksum: 10c0/b8b5836e9fd368670e1ce5cb948feef30351ecebfbf589ac807c1f6b38c90d6556b2d48883f9b3c371fad59c92519b333dc3919a8ff5e351aea0f8b424203826
   languageName: node
   linkType: hard
 
@@ -3724,22 +3725,22 @@ __metadata:
     "@types/xml2js": "npm:^0.4.14"
     "@vscode/sqlite3": "npm:^5.1.12-vscode"
     autoprefixer: "npm:^10.5.0"
-    ava: "npm:^7.0.0"
+    ava: "npm:^8.0.0"
     date-fns: "npm:^4.1.0"
     history: "npm:^5.3.0"
-    html-react-parser: "npm:^6.0.1"
+    html-react-parser: "npm:^6.1.0"
     knex: "npm:^3.2.10"
-    lucide-react: "npm:^1.8.0"
+    lucide-react: "npm:^1.14.0"
     next: "npm:^16.2.4"
     next-themes: "npm:^0.4.6"
     node-fetch: "npm:^3.3.2"
-    postcss: "npm:^8.5.13"
+    postcss: "npm:^8.5.14"
     prettier: "npm:^3.8.3"
-    react: "npm:^19.2.4"
+    react: "npm:^19.2.5"
     react-dom: "npm:^19.2.5"
     sanitize-html: "npm:^2.17.3"
-    shadcn: "npm:^4.6.0"
-    sinon: "npm:^21.1.2"
+    shadcn: "npm:^4.7.0"
+    sinon: "npm:^22.0.0"
     sql.js-httpvfs: "npm:^0.8.12"
     sqlite3: "npm:^6.0.1"
     tailwindcss: "npm:^4.2.4"
@@ -4069,9 +4070,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globby@npm:^16.1.1":
-  version: 16.1.1
-  resolution: "globby@npm:16.1.1"
+"globby@npm:^16.2.0":
+  version: 16.2.0
+  resolution: "globby@npm:16.2.0"
   dependencies:
     "@sindresorhus/merge-streams": "npm:^4.0.0"
     fast-glob: "npm:^3.3.3"
@@ -4079,7 +4080,7 @@ __metadata:
     is-path-inside: "npm:^4.0.0"
     slash: "npm:^5.1.0"
     unicorn-magic: "npm:^0.4.0"
-  checksum: 10c0/2fbed8e5c59639a98b9b9c700afe5bcedf14742b43c25950cfd34a032db0cce4b440d8436beb4a936d211744e0b7330646f086b95cd8054251162c5d83001600
+  checksum: 10c0/fc0675e01dc1da5095f30dccc46a3047fc38d45ca08c21c1aa871bd79d38682f507d84a159be168019db5fffaa09c5663c3679c29190a2d4f999dc91d7ff6406
   languageName: node
   linkType: hard
 
@@ -4171,22 +4172,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"html-dom-parser@npm:7.0.1":
-  version: 7.0.1
-  resolution: "html-dom-parser@npm:7.0.1"
+"html-dom-parser@npm:7.1.0":
+  version: 7.1.0
+  resolution: "html-dom-parser@npm:7.1.0"
   dependencies:
     domhandler: "npm:6.0.1"
     htmlparser2: "npm:12.0.0"
-  checksum: 10c0/54e6af1fe7f6db49b1cac794489a0e219fccaac5e9927d7a771c3d3618f7c41c155cbb7cea3d0a8101b88e49180814fa0e98d47ecb8d4299ba1ddd56cc7554b2
+  checksum: 10c0/e73b0c2e8bbe809ff877bf2483f6547f4797ee55c1c6d0f486d54ce7310e799c36986328f11dde1ce99608939a06efdf1d02c45a0abd0ec40b405b230c3dffdf
   languageName: node
   linkType: hard
 
-"html-react-parser@npm:^6.0.1":
-  version: 6.0.1
-  resolution: "html-react-parser@npm:6.0.1"
+"html-react-parser@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "html-react-parser@npm:6.1.0"
   dependencies:
     domhandler: "npm:6.0.1"
-    html-dom-parser: "npm:7.0.1"
+    html-dom-parser: "npm:7.1.0"
     react-property: "npm:2.0.2"
     style-to-js: "npm:1.1.21"
   peerDependencies:
@@ -4195,7 +4196,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10c0/4899ec0fd39da4a0a5d8564cd1c8d4b1cdf9bd3c3c87f7e09dacfe43f5f9d674f455ce86fd6f0548a26f04dc22eafe5a192f2942a4ec72a1d260b80ffe8c1ab8
+  checksum: 10c0/1626454d3e3edf01b8e626b6f4a150b9ab013b4d379e5038506c93c3ce7cfb09a78abff079512ecbd4dd6d840c0bbcd55f722ee3302a70400c760e9109891b49
   languageName: node
   linkType: hard
 
@@ -5020,12 +5021,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lucide-react@npm:^1.8.0":
-  version: 1.8.0
-  resolution: "lucide-react@npm:1.8.0"
+"lucide-react@npm:^1.14.0":
+  version: 1.14.0
+  resolution: "lucide-react@npm:1.14.0"
   peerDependencies:
     react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
-  checksum: 10c0/f7398f89a0f5b2cbfd1b7a7f6b2f00b0abd05d4b21d948bbd281ab141c42cdff9f1d2aed4e32b78b4bbdfa78308b6577705698af8bf9945bad23ed7d56e255b4
+  checksum: 10c0/25c5dd878945842ffb519532f1a66f59f2d461e7be7bd322091b0ecd3cd32561c1ae3d9b50161432d39a72bf8c8f1a039268f2f20a035e520dd3f49dd46ffaf2
   languageName: node
   linkType: hard
 
@@ -5089,12 +5090,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"memoize@npm:^10.2.0":
-  version: 10.2.0
-  resolution: "memoize@npm:10.2.0"
+"memoize@npm:^11.0.0":
+  version: 11.0.0
+  resolution: "memoize@npm:11.0.0"
   dependencies:
     mimic-function: "npm:^5.0.1"
-  checksum: 10c0/8a5891f313e8db82bab4bb9694752aab40c11ce3bf9b8cc32228ebaf87e14e8109a23b37ceef32baadbedc09af2c4dd0d361a93e9e591bb0ed9e23f728e1ce9f
+  checksum: 10c0/4a64923d7369bb625f2551fcab0d44447b472d15573b5c8dca57d09be23ac8a13adf5da404e36de84db2a2dd6fc8dac876286139d8864cf1e5ab44aa5fb59334
   languageName: node
   linkType: hard
 
@@ -5891,6 +5892,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"picomatch@npm:^4.0.4":
+  version: 4.0.4
+  resolution: "picomatch@npm:4.0.4"
+  checksum: 10c0/e2c6023372cc7b5764719a5ffb9da0f8e781212fa7ca4bd0562db929df8e117460f00dff3cb7509dacfc06b86de924b247f504d0ce1806a37fac4633081466b0
+  languageName: node
+  linkType: hard
+
 "pkce-challenge@npm:^5.0.0":
   version: 5.0.0
   resolution: "pkce-challenge@npm:5.0.0"
@@ -6012,14 +6020,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.5.13":
-  version: 8.5.13
-  resolution: "postcss@npm:8.5.13"
+"postcss@npm:^8.5.14":
+  version: 8.5.14
+  resolution: "postcss@npm:8.5.14"
   dependencies:
     nanoid: "npm:^3.3.11"
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
-  checksum: 10c0/3aa7c8cbdfbfd99b34406a433cef56d164dd135fc9cb9e63d487cc363291f877a55ec7b8ff6ec15348c17c2d98a43be46bfad671e6340403041a3e79f70c2f2f
+  checksum: 10c0/48138207cf5ef5581be1bfe2cb65ccfe0ac75e43888ba045afc8ed6043d7b56aeb3b9a9fe5b353ff554be943cd0cc15d826ccb991525159175971e5ee8ab0237
   languageName: node
   linkType: hard
 
@@ -6244,10 +6252,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react@npm:^19.2.4":
-  version: 19.2.4
-  resolution: "react@npm:19.2.4"
-  checksum: 10c0/cd2c9ff67a720799cc3b38a516009986f7fc4cb8d3e15716c6211cf098d1357ee3e348ab05ad0600042bbb0fd888530ba92e329198c92eafa0994f5213396596
+"react@npm:^19.2.5":
+  version: 19.2.5
+  resolution: "react@npm:19.2.5"
+  checksum: 10c0/4b5f231dbef92886f602533c9ce3bde04d99f0e71dfb5d794c43e02726efaad0421c08688f75fc98a6d6e1dc017372e1af7abbfecdc86a79968f461675931a7a
   languageName: node
   linkType: hard
 
@@ -6574,9 +6582,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shadcn@npm:^4.6.0":
-  version: 4.6.0
-  resolution: "shadcn@npm:4.6.0"
+"shadcn@npm:^4.7.0":
+  version: 4.7.0
+  resolution: "shadcn@npm:4.7.0"
   dependencies:
     "@babel/core": "npm:^7.28.0"
     "@babel/parser": "npm:^7.28.0"
@@ -6614,7 +6622,7 @@ __metadata:
     zod-to-json-schema: "npm:^3.24.6"
   bin:
     shadcn: dist/index.js
-  checksum: 10c0/2f4620bccce7ff04b8e76e377f016737308bd314548343b0f50839207262ee11f1f0d6e707fb42fe8b24d3294a6ada916926a487ebaed090284cbf59d327b6d6
+  checksum: 10c0/0766956e9f15d4755b6e9ee2a0ce231c6c251c6ae5e9611bfe8fffda91359c411720dc64a2f64981cc25f17687b9a81f3684d59ba169b5d3d482feedb5d6d08e
   languageName: node
   linkType: hard
 
@@ -6807,15 +6815,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sinon@npm:^21.1.2":
-  version: 21.1.2
-  resolution: "sinon@npm:21.1.2"
+"sinon@npm:^22.0.0":
+  version: 22.0.0
+  resolution: "sinon@npm:22.0.0"
   dependencies:
     "@sinonjs/commons": "npm:^3.0.1"
-    "@sinonjs/fake-timers": "npm:^15.3.2"
+    "@sinonjs/fake-timers": "npm:^15.4.0"
     "@sinonjs/samsam": "npm:^10.0.2"
-    diff: "npm:^8.0.4"
-  checksum: 10c0/d33aaf68f9bd78ad32f68ace36b7437e1e1f93ea341c4c2fd814935b3bf6788169ebd6258c8bce195d3adb13198814f28048470d80fa239cf2ffbf50dfd3082b
+    diff: "npm:^9.0.0"
+  checksum: 10c0/66d087069330f30bbd3d32694bd60d8318491094a5400cedabd77c94ce79455972ec92aab5036c4bbb3ab186f42767a9109740b5af7e4cac17bb528899948523
   languageName: node
   linkType: hard
 
@@ -6833,13 +6841,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"slice-ansi@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "slice-ansi@npm:8.0.0"
+"slice-ansi@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "slice-ansi@npm:9.0.0"
   dependencies:
     ansi-styles: "npm:^6.2.3"
     is-fullwidth-code-point: "npm:^5.1.0"
-  checksum: 10c0/0ce4aa91febb7cea4a00c2c27bb820fa53b6d2862ce0f80f7120134719f7914fc416b0ed966cf35250a3169e152916392f35917a2d7cad0fcc5d8b841010fa9a
+  checksum: 10c0/fd97f0e3a48386dbf1cbc2f10134f1e345c161188adb6928856079b4c0117c221a5405a7bff341e1a6e428721c5236353ab26b7d777a4f2f35a8ed2a91d82e7a
   languageName: node
   linkType: hard
 
@@ -7753,7 +7761,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"write-file-atomic@npm:^7.0.0":
+"write-file-atomic@npm:^7.0.1":
   version: 7.0.1
   resolution: "write-file-atomic@npm:7.0.1"
   dependencies:


### PR DESCRIPTION
## Summary

- Ran `ncu -u` and refreshed `yarn.lock` with Yarn 4.12.0.
- Upgraded the current outdated dependencies: `ava`, `sinon`, `html-react-parser`, `lucide-react`, `postcss`, `react`, and `shadcn`.
- Updated the AVA test setup for AVA v8's ESM `import()` loading path, including fixture path handling and `tsx` loader configuration.
- Switched `sql.js-httpvfs` runtime import to default CJS interop while preserving exported TypeScript types.

## Major Upgrade Notes

- AVA 8.0.0 release notes: https://github.com/avajs/ava/releases/tag/v8.0.0
  - Node requirement is now 22.20, 24.12, or newer. This branch was verified on Node 24.13.0.
  - Tests are now loaded via `import()`, so the AVA config now passes `--import=tsx` through `nodeArguments` and fixture tests use `import.meta.url`-based paths.
- Sinon 22.0.0 tag: https://github.com/sinonjs/sinon/releases/tag/v22.0.0
  - GitHub has a tag for v22.0.0 but no release body, and the public changelog currently stops at 21.1.2: https://sinonjs.org/releases/changelog
  - I reviewed the official compare for `v21.1.2...v22.0.0`; the branch includes dependency updates such as fake timers 15.4, Temporal API work, Node 26 dev baseline changes, and bug fixes. Existing Sinon usage in this repo is assertion/matcher based and passes under v22.

## Validation

- `npx ncu` -> all dependencies match the latest package versions.
- `yarn install --immutable`
- `yarn test` -> 49 tests passed.
- `yarn build` -> Next.js production build completed successfully.

Note: the pre-existing local `package.json` version bump from `4.0.2` to `4.0.3` was left uncommitted and is not part of this PR.