### PR TITLE
[codex] Fix action Corepack bootstrap

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -28,9 +28,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
       - name: Run Action
-        uses: ./
+        uses: llun/feeds@codex/fix-corepack-install-debug
         with:
           storageType: files

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -24,11 +24,12 @@ jobs:
   sample:
     runs-on: ubuntu-latest
     needs: [test]
+    if: github.ref == 'refs/heads/main'
     name: Sample
     permissions:
       contents: write
     steps:
       - name: Run Action
-        uses: llun/feeds@codex/fix-corepack-install-debug
+        uses: llun/feeds@main
         with:
           storageType: files

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -24,12 +24,13 @@ jobs:
   sample:
     runs-on: ubuntu-latest
     needs: [test]
-    if: github.ref == 'refs/heads/main'
     name: Sample
     permissions:
       contents: write
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Run Action
-        uses: llun/feeds@main
+        uses: ./
         with:
           storageType: files

--- a/action.mjs
+++ b/action.mjs
@@ -106,6 +106,47 @@ async function getYarnCommand(/** @type {string} */ actionPath) {
   return downloadPath
 }
 
+async function exposeYarnOnPath(/** @type {string} */ yarnCommand) {
+  const shimDirectory = path.join(
+    process.env['RUNNER_TEMP'] || path.dirname(yarnCommand),
+    'feeds-action-bin'
+  )
+  await fs.mkdir(shimDirectory, { recursive: true })
+
+  if (process.platform === 'win32') {
+    const shimPath = path.join(shimDirectory, 'yarn.cmd')
+    await fs.writeFile(
+      shimPath,
+      `@echo off\r\n"${process.execPath}" "${yarnCommand}" %*\r\n`
+    )
+    console.log('[feeds-action] yarn shim:', shimPath)
+  } else {
+    const shimPath = path.join(shimDirectory, 'yarn')
+    const yarnCommandArguments = JSON.stringify([yarnCommand])
+    await fs.writeFile(
+      shimPath,
+      `#!/usr/bin/env node
+const { spawnSync } = require('node:child_process')
+const result = spawnSync(process.execPath, ${yarnCommandArguments}.concat(process.argv.slice(2)), { stdio: 'inherit' })
+if (result.error) {
+  console.error(result.error.message)
+  process.exit(1)
+}
+if (result.signal) {
+  process.kill(process.pid, result.signal)
+}
+process.exit(result.status ?? 1)
+`
+    )
+    await fs.chmod(shimPath, 0o755)
+    console.log('[feeds-action] yarn shim:', shimPath)
+  }
+
+  process.env['PATH'] = [shimDirectory, process.env['PATH'] || '']
+    .filter(Boolean)
+    .join(path.delimiter)
+}
+
 // Main
 console.log('Action: ', process.env['GITHUB_ACTION'])
 if (
@@ -114,6 +155,7 @@ if (
 ) {
   const actionPath = getGithubActionPath()
   const yarnCommand = await getYarnCommand(actionPath)
+  await exposeYarnOnPath(yarnCommand)
   console.log('[feeds-action] action path:', actionPath)
   console.log('[feeds-action] node executable:', process.execPath)
   console.log('[feeds-action] runtime bin:', path.dirname(process.execPath))

--- a/action.mjs
+++ b/action.mjs
@@ -1,5 +1,4 @@
 // @ts-check
-import fs from 'node:fs/promises'
 import path from 'node:path'
 import { spawnSync } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
@@ -63,90 +62,6 @@ function getGithubActionPath() {
   return path.dirname(fileURLToPath(import.meta.url))
 }
 
-async function pathExists(/** @type {string} */ filePath) {
-  try {
-    await fs.access(filePath)
-    return true
-  } catch {
-    return false
-  }
-}
-
-async function getPackageManagerVersion(/** @type {string} */ actionPath) {
-  const packageJsonPath = path.join(actionPath, 'package.json')
-  const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8'))
-  const packageManager = packageJson.packageManager
-  const yarnMatch =
-    typeof packageManager === 'string' && packageManager.match(/^yarn@(.+)$/)
-  if (!yarnMatch) {
-    throw new Error(`Unsupported packageManager: ${packageManager}`)
-  }
-  return yarnMatch[1]
-}
-
-async function getYarnCommand(/** @type {string} */ actionPath) {
-  const yarnVersion = await getPackageManagerVersion(actionPath)
-  const downloadPath = path.join(
-    process.env['RUNNER_TEMP'] || actionPath,
-    `feeds-action-yarn-${yarnVersion}.cjs`
-  )
-  if (!(await pathExists(downloadPath))) {
-    const yarnUrl = `https://repo.yarnpkg.com/${yarnVersion}/packages/yarnpkg-cli/bin/yarn.js`
-    console.log(`[feeds-action] download yarn: ${yarnUrl}`)
-    const response = await fetch(yarnUrl)
-    if (!response.ok) {
-      throw new Error(
-        `Fail to download yarn ${yarnVersion} (${response.status} ${response.statusText})`
-      )
-    }
-    await fs.mkdir(path.dirname(downloadPath), { recursive: true })
-    await fs.writeFile(downloadPath, await response.text())
-  }
-  console.log('[feeds-action] yarn command:', downloadPath)
-  return downloadPath
-}
-
-async function exposeYarnOnPath(/** @type {string} */ yarnCommand) {
-  const shimDirectory = path.join(
-    process.env['RUNNER_TEMP'] || path.dirname(yarnCommand),
-    'feeds-action-bin'
-  )
-  await fs.mkdir(shimDirectory, { recursive: true })
-
-  if (process.platform === 'win32') {
-    const shimPath = path.join(shimDirectory, 'yarn.cmd')
-    await fs.writeFile(
-      shimPath,
-      `@echo off\r\n"${process.execPath}" "${yarnCommand}" %*\r\n`
-    )
-    console.log('[feeds-action] yarn shim:', shimPath)
-  } else {
-    const shimPath = path.join(shimDirectory, 'yarn')
-    const yarnCommandArguments = JSON.stringify([yarnCommand])
-    await fs.writeFile(
-      shimPath,
-      `#!/usr/bin/env node
-const { spawnSync } = require('node:child_process')
-const result = spawnSync(process.execPath, ${yarnCommandArguments}.concat(process.argv.slice(2)), { stdio: 'inherit' })
-if (result.error) {
-  console.error(result.error.message)
-  process.exit(1)
-}
-if (result.signal) {
-  process.kill(process.pid, result.signal)
-}
-process.exit(result.status ?? 1)
-`
-    )
-    await fs.chmod(shimPath, 0o755)
-    console.log('[feeds-action] yarn shim:', shimPath)
-  }
-
-  process.env['PATH'] = [shimDirectory, process.env['PATH'] || '']
-    .filter(Boolean)
-    .join(path.delimiter)
-}
-
 // Main
 console.log('Action: ', process.env['GITHUB_ACTION'])
 if (
@@ -154,23 +69,31 @@ if (
   process.env['GITHUB_ACTION'] === '__llun_feeds'
 ) {
   const actionPath = getGithubActionPath()
-  const yarnCommand = await getYarnCommand(actionPath)
-  await exposeYarnOnPath(yarnCommand)
+  const corepackCommand = getRuntimeCommand('corepack')
   console.log('[feeds-action] action path:', actionPath)
   console.log('[feeds-action] node executable:', process.execPath)
   console.log('[feeds-action] runtime bin:', path.dirname(process.execPath))
+  console.log('[feeds-action] corepack command:', corepackCommand)
 
   assertCommandSucceeded(
     'check node version',
     runCommand('check node version', [process.execPath, '--version'], actionPath)
   )
   assertCommandSucceeded(
-    'run setup',
+    'install corepack',
     runCommand(
-      'run setup',
-      [process.execPath, yarnCommand, 'install'],
+      'install corepack',
+      ['npm', 'install', '-g', 'corepack'],
       actionPath
     )
+  )
+  assertCommandSucceeded(
+    'enable corepack',
+    runCommand('enable corepack', [corepackCommand, 'enable'], actionPath)
+  )
+  assertCommandSucceeded(
+    'run setup',
+    runCommand('run setup', [corepackCommand, 'yarn', 'install'], actionPath)
   )
   assertCommandSucceeded(
     'site builder',

--- a/action.mjs
+++ b/action.mjs
@@ -1,4 +1,5 @@
 // @ts-check
+import fs from 'node:fs/promises'
 import path from 'node:path'
 import { spawnSync } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
@@ -10,11 +11,6 @@ function withRuntimeNodePath() {
   const pathEntries = currentPath.split(pathDelimiter).filter(Boolean)
   const sanitizedEntries = pathEntries.filter((entry) => entry !== runtimeBinPath)
   return [runtimeBinPath, ...sanitizedEntries].join(pathDelimiter)
-}
-
-function getRuntimeCommand(command) {
-  const extension = process.platform === 'win32' ? '.cmd' : ''
-  return path.join(path.dirname(process.execPath), `${command}${extension}`)
 }
 
 function formatCommand(/** @type {string[]} */ commands) {
@@ -67,6 +63,49 @@ function getGithubActionPath() {
   return path.dirname(fileURLToPath(import.meta.url))
 }
 
+async function pathExists(/** @type {string} */ filePath) {
+  try {
+    await fs.access(filePath)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function getPackageManagerVersion(/** @type {string} */ actionPath) {
+  const packageJsonPath = path.join(actionPath, 'package.json')
+  const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8'))
+  const packageManager = packageJson.packageManager
+  const yarnMatch =
+    typeof packageManager === 'string' && packageManager.match(/^yarn@(.+)$/)
+  if (!yarnMatch) {
+    throw new Error(`Unsupported packageManager: ${packageManager}`)
+  }
+  return yarnMatch[1]
+}
+
+async function getYarnCommand(/** @type {string} */ actionPath) {
+  const yarnVersion = await getPackageManagerVersion(actionPath)
+  const downloadPath = path.join(
+    process.env['RUNNER_TEMP'] || actionPath,
+    `feeds-action-yarn-${yarnVersion}.cjs`
+  )
+  if (!(await pathExists(downloadPath))) {
+    const yarnUrl = `https://repo.yarnpkg.com/${yarnVersion}/packages/yarnpkg-cli/bin/yarn.js`
+    console.log(`[feeds-action] download yarn: ${yarnUrl}`)
+    const response = await fetch(yarnUrl)
+    if (!response.ok) {
+      throw new Error(
+        `Fail to download yarn ${yarnVersion} (${response.status} ${response.statusText})`
+      )
+    }
+    await fs.mkdir(path.dirname(downloadPath), { recursive: true })
+    await fs.writeFile(downloadPath, await response.text())
+  }
+  console.log('[feeds-action] yarn command:', downloadPath)
+  return downloadPath
+}
+
 // Main
 console.log('Action: ', process.env['GITHUB_ACTION'])
 if (
@@ -74,11 +113,10 @@ if (
   process.env['GITHUB_ACTION'] === '__llun_feeds'
 ) {
   const actionPath = getGithubActionPath()
-  const corepackCommand = getRuntimeCommand('corepack')
+  const yarnCommand = await getYarnCommand(actionPath)
   console.log('[feeds-action] action path:', actionPath)
   console.log('[feeds-action] node executable:', process.execPath)
   console.log('[feeds-action] runtime bin:', path.dirname(process.execPath))
-  console.log('[feeds-action] corepack command:', corepackCommand)
 
   assertCommandSucceeded(
     'check node version',
@@ -86,7 +124,11 @@ if (
   )
   assertCommandSucceeded(
     'run setup',
-    runCommand('run setup', [corepackCommand, 'yarn', 'install'], actionPath)
+    runCommand(
+      'run setup',
+      [process.execPath, yarnCommand, 'install'],
+      actionPath
+    )
   )
   assertCommandSucceeded(
     'site builder',

--- a/action.mjs
+++ b/action.mjs
@@ -17,12 +17,27 @@ function getRuntimeCommand(command) {
   return path.join(path.dirname(process.execPath), `${command}${extension}`)
 }
 
+function formatCommand(/** @type {string[]} */ commands) {
+  return commands
+    .map((part) => (/\s/.test(part) ? JSON.stringify(part) : part))
+    .join(' ')
+}
+
+function getCommandResultSummary(/** @type {ReturnType<typeof spawnSync>} */ result) {
+  const status = result.status === null ? 'null' : String(result.status)
+  const signal = result.signal || 'none'
+  const error = result.error ? result.error.message : 'none'
+  return `status=${status} signal=${signal} error=${error}`
+}
+
 // Duplicate code from action/repository, keep this until
 // found a better way to include typescript without transpiles
 function runCommand(
+  /** @type {string} */ label,
   /** @type {string[]} */ commands,
   /** @type {string} */ cwd
 ) {
+  console.log(`[feeds-action] ${label}: ${formatCommand(commands)}`)
   return spawnSync(commands[0], commands.slice(1), {
     stdio: 'inherit',
     cwd,
@@ -37,6 +52,17 @@ function isCommandFailed(result) {
   return Boolean(result.error || result.signal || result.status !== 0)
 }
 
+function assertCommandSucceeded(
+  /** @type {string} */ label,
+  /** @type {ReturnType<typeof spawnSync>} */ result
+) {
+  const resultSummary = getCommandResultSummary(result)
+  console.log(`[feeds-action] ${label}: ${resultSummary}`)
+  if (isCommandFailed(result)) {
+    throw new Error(`Fail to ${label} (${resultSummary})`)
+  }
+}
+
 function getGithubActionPath() {
   return path.dirname(fileURLToPath(import.meta.url))
 }
@@ -48,38 +74,26 @@ if (
   process.env['GITHUB_ACTION'] === '__llun_feeds'
 ) {
   const actionPath = getGithubActionPath()
-  const nodeVersionResult = runCommand([process.execPath, '--version'], actionPath)
-  if (isCommandFailed(nodeVersionResult)) {
-    throw new Error('Fail to check node version')
-  }
-  const npmCommand = getRuntimeCommand('npm')
-  const installCorepackResult = runCommand(
-    [npmCommand, 'install', '-g', 'corepack'],
-    actionPath
-  )
-  if (isCommandFailed(installCorepackResult)) {
-    throw new Error('Fail to install corepack')
-  }
   const corepackCommand = getRuntimeCommand('corepack')
-  const enableCorepackResult = runCommand(
-    [corepackCommand, 'enable'],
-    actionPath
+  console.log('[feeds-action] action path:', actionPath)
+  console.log('[feeds-action] node executable:', process.execPath)
+  console.log('[feeds-action] runtime bin:', path.dirname(process.execPath))
+  console.log('[feeds-action] corepack command:', corepackCommand)
+
+  assertCommandSucceeded(
+    'check node version',
+    runCommand('check node version', [process.execPath, '--version'], actionPath)
   )
-  if (isCommandFailed(enableCorepackResult)) {
-    throw new Error('Fail to enable corepack')
-  }
-  const dependenciesResult = runCommand(
-    [corepackCommand, 'yarn', 'install'],
-    actionPath
+  assertCommandSucceeded(
+    'run setup',
+    runCommand('run setup', [corepackCommand, 'yarn', 'install'], actionPath)
   )
-  if (isCommandFailed(dependenciesResult)) {
-    throw new Error('Fail to run setup')
-  }
-  const executeResult = runCommand(
-    [process.execPath, '--import', 'tsx', 'index.ts'],
-    actionPath
+  assertCommandSucceeded(
+    'site builder',
+    runCommand(
+      'site builder',
+      [process.execPath, '--import', 'tsx', 'index.ts'],
+      actionPath
+    )
   )
-  if (isCommandFailed(executeResult)) {
-    throw new Error('Fail to site builder')
-  }
 }

--- a/action.mjs
+++ b/action.mjs
@@ -12,6 +12,11 @@ function withRuntimeNodePath() {
   return [runtimeBinPath, ...sanitizedEntries].join(pathDelimiter)
 }
 
+function getRuntimeCommand(command) {
+  const extension = process.platform === 'win32' ? '.cmd' : ''
+  return path.join(path.dirname(process.execPath), `${command}${extension}`)
+}
+
 function formatCommand(/** @type {string[]} */ commands) {
   return commands
     .map((part) => (/\s/.test(part) ? JSON.stringify(part) : part))

--- a/action.mjs
+++ b/action.mjs
@@ -12,11 +12,6 @@ function withRuntimeNodePath() {
   return [runtimeBinPath, ...sanitizedEntries].join(pathDelimiter)
 }
 
-function getRuntimeCommand(command) {
-  const extension = process.platform === 'win32' ? '.cmd' : ''
-  return path.join(path.dirname(process.execPath), `${command}${extension}`)
-}
-
 function formatCommand(/** @type {string[]} */ commands) {
   return commands
     .map((part) => (/\s/.test(part) ? JSON.stringify(part) : part))
@@ -38,7 +33,7 @@ function runCommand(
   /** @type {string} */ cwd
 ) {
   console.log(`[feeds-action] ${label}: ${formatCommand(commands)}`)
-  return spawnSync(commands[0], commands.slice(1), {
+  const result = spawnSync(commands[0], commands.slice(1), {
     stdio: 'inherit',
     cwd,
     env: {
@@ -46,6 +41,7 @@ function runCommand(
       PATH: withRuntimeNodePath()
     }
   })
+  return { label, result }
 }
 
 function isCommandFailed(result) {
@@ -53,9 +49,9 @@ function isCommandFailed(result) {
 }
 
 function assertCommandSucceeded(
-  /** @type {string} */ label,
-  /** @type {ReturnType<typeof spawnSync>} */ result
+  /** @type {{ label: string, result: ReturnType<typeof spawnSync> }} */ commandResult
 ) {
+  const { label, result } = commandResult
   const resultSummary = getCommandResultSummary(result)
   console.log(`[feeds-action] ${label}: ${resultSummary}`)
   if (isCommandFailed(result)) {
@@ -74,18 +70,11 @@ if (
   process.env['GITHUB_ACTION'] === '__llun_feeds'
 ) {
   const actionPath = getGithubActionPath()
-  const corepackCommand = getRuntimeCommand('corepack')
-  console.log('[feeds-action] action path:', actionPath)
-  console.log('[feeds-action] node executable:', process.execPath)
-  console.log('[feeds-action] runtime bin:', path.dirname(process.execPath))
-  console.log('[feeds-action] corepack command:', corepackCommand)
 
   assertCommandSucceeded(
-    'check node version',
     runCommand('check node version', [process.execPath, '--version'], actionPath)
   )
   assertCommandSucceeded(
-    'install corepack',
     runCommand(
       'install corepack',
       ['npm', 'install', '-g', 'corepack'],
@@ -93,15 +82,12 @@ if (
     )
   )
   assertCommandSucceeded(
-    'enable corepack',
-    runCommand('enable corepack', [corepackCommand, 'enable'], actionPath)
+    runCommand('enable corepack', ['corepack', 'enable'], actionPath)
   )
   assertCommandSucceeded(
-    'run setup',
-    runCommand('run setup', [corepackCommand, 'yarn', 'install'], actionPath)
+    runCommand('run setup', ['corepack', 'yarn', 'install'], actionPath)
   )
   assertCommandSucceeded(
-    'site builder',
     runCommand(
       'site builder',
       [process.execPath, '--import', 'tsx', 'index.ts'],

--- a/action.mjs
+++ b/action.mjs
@@ -12,6 +12,11 @@ function withRuntimeNodePath() {
   return [runtimeBinPath, ...sanitizedEntries].join(pathDelimiter)
 }
 
+function getPathCommand(command) {
+  const extension = process.platform === 'win32' ? '.cmd' : ''
+  return `${command}${extension}`
+}
+
 function formatCommand(/** @type {string[]} */ commands) {
   return commands
     .map((part) => (/\s/.test(part) ? JSON.stringify(part) : part))
@@ -70,6 +75,8 @@ if (
   process.env['GITHUB_ACTION'] === '__llun_feeds'
 ) {
   const actionPath = getGithubActionPath()
+  const npmCommand = getPathCommand('npm')
+  const corepackCommand = getPathCommand('corepack')
 
   assertCommandSucceeded(
     runCommand('check node version', [process.execPath, '--version'], actionPath)
@@ -77,15 +84,15 @@ if (
   assertCommandSucceeded(
     runCommand(
       'install corepack',
-      ['npm', 'install', '-g', 'corepack'],
+      [npmCommand, 'install', '-g', 'corepack'],
       actionPath
     )
   )
   assertCommandSucceeded(
-    runCommand('enable corepack', ['corepack', 'enable'], actionPath)
+    runCommand('enable corepack', [corepackCommand, 'enable'], actionPath)
   )
   assertCommandSucceeded(
-    runCommand('run setup', ['corepack', 'yarn', 'install'], actionPath)
+    runCommand('run setup', [corepackCommand, 'yarn', 'install'], actionPath)
   )
   assertCommandSucceeded(
     runCommand(

--- a/action.test.js
+++ b/action.test.js
@@ -11,4 +11,5 @@ test('uses downloaded yarn without mutating the action runtime install', async (
   t.false(source.includes("getRuntimeCommand('corepack')"))
 
   t.true(source.includes("process.execPath, yarnCommand, 'install'"))
+  t.true(source.includes("process.env['PATH'] ="))
 })

--- a/action.test.js
+++ b/action.test.js
@@ -8,14 +8,23 @@ test('installs corepack before enabling and running yarn from PATH', async (t) =
 
   t.false(source.includes("getRuntimeCommand('npm')"))
   t.false(source.includes("getRuntimeCommand('corepack')"))
+  t.true(source.includes("process.platform === 'win32' ? '.cmd' : ''"))
 
-  const installIndex = source.indexOf("'npm', 'install', '-g', 'corepack'")
-  const enableIndex = source.indexOf("'corepack', 'enable'")
-  const yarnIndex = source.indexOf("'corepack', 'yarn', 'install'")
+  const npmCommandIndex = source.indexOf("const npmCommand = getPathCommand('npm')")
+  const corepackCommandIndex = source.indexOf(
+    "const corepackCommand = getPathCommand('corepack')"
+  )
+  const installIndex = source.indexOf("npmCommand, 'install', '-g', 'corepack'")
+  const enableIndex = source.indexOf("corepackCommand, 'enable'")
+  const yarnIndex = source.indexOf("corepackCommand, 'yarn', 'install'")
 
+  t.not(npmCommandIndex, -1)
+  t.not(corepackCommandIndex, -1)
   t.not(installIndex, -1)
   t.not(enableIndex, -1)
   t.not(yarnIndex, -1)
+  t.true(npmCommandIndex < installIndex)
+  t.true(corepackCommandIndex < enableIndex)
   t.true(installIndex < enableIndex)
   t.true(enableIndex < yarnIndex)
 })

--- a/action.test.js
+++ b/action.test.js
@@ -6,6 +6,7 @@ test('installs corepack with npm from PATH before using runtime corepack', async
   const actionPath = path.join(import.meta.dirname, 'action.mjs')
   const source = await fs.readFile(actionPath, 'utf8')
 
+  t.true(source.includes('function getRuntimeCommand(command)'))
   t.false(source.includes("getRuntimeCommand('npm')"))
   t.true(source.includes("'npm', 'install', '-g', 'corepack'"))
   t.true(source.includes("const corepackCommand = getRuntimeCommand('corepack')"))

--- a/action.test.js
+++ b/action.test.js
@@ -2,13 +2,12 @@ import fs from 'node:fs/promises'
 import path from 'node:path'
 import test from 'ava'
 
-test('installs corepack before enabling it', async (t) => {
+test('uses bundled corepack without mutating the action runtime install', async (t) => {
   const actionPath = path.join(import.meta.dirname, 'action.mjs')
   const source = await fs.readFile(actionPath, 'utf8')
 
-  const installCorepackIndex = source.indexOf("'install', '-g', 'corepack'")
-  const enableCorepackIndex = source.indexOf("'enable'")
+  t.false(source.includes("'install', '-g', 'corepack'"))
+  t.false(source.includes("'enable'"))
 
-  t.not(installCorepackIndex, -1)
-  t.true(installCorepackIndex < enableCorepackIndex)
+  t.true(source.includes("'yarn', 'install'"))
 })

--- a/action.test.js
+++ b/action.test.js
@@ -2,15 +2,20 @@ import fs from 'node:fs/promises'
 import path from 'node:path'
 import test from 'ava'
 
-test('installs corepack with npm from PATH before using runtime corepack', async (t) => {
+test('installs corepack before enabling and running yarn from PATH', async (t) => {
   const actionPath = path.join(import.meta.dirname, 'action.mjs')
   const source = await fs.readFile(actionPath, 'utf8')
 
-  t.true(source.includes('function getRuntimeCommand(command)'))
   t.false(source.includes("getRuntimeCommand('npm')"))
-  t.true(source.includes("'npm', 'install', '-g', 'corepack'"))
-  t.true(source.includes("const corepackCommand = getRuntimeCommand('corepack')"))
+  t.false(source.includes("getRuntimeCommand('corepack')"))
 
-  t.true(source.includes("'enable'"))
-  t.true(source.includes("corepackCommand, 'yarn', 'install'"))
+  const installIndex = source.indexOf("'npm', 'install', '-g', 'corepack'")
+  const enableIndex = source.indexOf("'corepack', 'enable'")
+  const yarnIndex = source.indexOf("'corepack', 'yarn', 'install'")
+
+  t.not(installIndex, -1)
+  t.not(enableIndex, -1)
+  t.not(yarnIndex, -1)
+  t.true(installIndex < enableIndex)
+  t.true(enableIndex < yarnIndex)
 })

--- a/action.test.js
+++ b/action.test.js
@@ -2,14 +2,14 @@ import fs from 'node:fs/promises'
 import path from 'node:path'
 import test from 'ava'
 
-test('uses downloaded yarn without mutating the action runtime install', async (t) => {
+test('installs corepack with npm from PATH before using runtime corepack', async (t) => {
   const actionPath = path.join(import.meta.dirname, 'action.mjs')
   const source = await fs.readFile(actionPath, 'utf8')
 
-  t.false(source.includes("'install', '-g', 'corepack'"))
-  t.false(source.includes("'enable'"))
-  t.false(source.includes("getRuntimeCommand('corepack')"))
+  t.false(source.includes("getRuntimeCommand('npm')"))
+  t.true(source.includes("'npm', 'install', '-g', 'corepack'"))
+  t.true(source.includes("const corepackCommand = getRuntimeCommand('corepack')"))
 
-  t.true(source.includes("process.execPath, yarnCommand, 'install'"))
-  t.true(source.includes("process.env['PATH'] ="))
+  t.true(source.includes("'enable'"))
+  t.true(source.includes("corepackCommand, 'yarn', 'install'"))
 })

--- a/action.test.js
+++ b/action.test.js
@@ -2,12 +2,13 @@ import fs from 'node:fs/promises'
 import path from 'node:path'
 import test from 'ava'
 
-test('uses bundled corepack without mutating the action runtime install', async (t) => {
+test('uses downloaded yarn without mutating the action runtime install', async (t) => {
   const actionPath = path.join(import.meta.dirname, 'action.mjs')
   const source = await fs.readFile(actionPath, 'utf8')
 
   t.false(source.includes("'install', '-g', 'corepack'"))
   t.false(source.includes("'enable'"))
+  t.false(source.includes("getRuntimeCommand('corepack')"))
 
-  t.true(source.includes("'yarn', 'install'"))
+  t.true(source.includes("process.execPath, yarnCommand, 'install'"))
 })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feeds-fetcher",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "description": "Websites feed fetcher and static feeds aggregator",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
## Summary

Fixes the GitHub Action bootstrap for Node 24 hosted runner actions without downloading Yarn manually.

The original failure came from resolving npm with `getRuntimeCommand('npm')`, which builds an absolute path next to `process.execPath`. On the hosted action runtime that directory contains `node`, but not `npm` or `corepack`, so the absolute npm path failed with `ENOENT` even though `npm install -g corepack` works when npm is resolved from `PATH`.

This PR now:

- keeps the action runtime Node directory first on `PATH` for spawned setup commands
- resolves bootstrap package-manager commands from `PATH` instead of the runtime-local bin directory
- uses Windows-safe command shims for `spawnSync` without `shell: true` (`npm` / `npm.cmd`, `corepack` / `corepack.cmd`)
- installs Corepack with `npm install -g corepack`
- runs `corepack enable` before `corepack yarn install`
- keeps scoped command/status logs and carries command labels with spawn results
- tests the critical guards: no runtime-local npm/corepack lookup, Windows `.cmd` suffix support, and install -> enable -> yarn ordering

The temporary workflow changes used to run `Sample` from branch refs are not in the final diff; the `main` guard is restored.

## Validation

- `node --check action.mjs`
- `yarn test action.test.js`
- `yarn test` (50 tests)
- Diagnostic run proving the original absolute runtime npm path fails with ENOENT while PATH npm succeeds: https://github.com/llun/feeds/actions/runs/25512251416
- Branch-ref sample run passed with the smaller Corepack fix: https://github.com/llun/feeds/actions/runs/25512570152
- Latest PR checks pass via `gh pr checks 819`:
  - `test`: https://github.com/llun/feeds/actions/runs/25513815228/job/74879396181
  - `Analyze (actions)`: https://github.com/llun/feeds/actions/runs/25513813614/job/74879402928
  - `Analyze (javascript)`: https://github.com/llun/feeds/actions/runs/25513813614/job/74879402836
  - `CodeQL`: https://github.com/llun/feeds/runs/74879531395
