### PR TITLE
Fix TypeError when pressing arrow keys on an empty entry list

### DIFF
--- a/lib/components/ItemList.tsx
+++ b/lib/components/ItemList.tsx
@@ -169,6 +169,8 @@ export const ItemList = ({
 
   useEffect(() => {
     const handler: EventListener = (event: KeyboardEvent) => {
+      if (entries.length === 0) return
+
       switch (event.code) {
         case 'ArrowUp':
         case 'KeyW': {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feeds-fetcher",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "Websites feed fetcher and static feeds aggregator",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
## Problem

`ItemList`'s `keydown` handler is registered on `document` unconditionally, so it stays live in states where the list renders no items. `entries` is empty both in the "No items to display" state and while `pageState === 'loading'`, but the ArrowUp/KeyW and ArrowDown/KeyS branches both do:

```js
if (!selectedEntryHash) {
  selectEntryHash(entries[0].key)   // entries[0] is undefined
  return
}
```

Pressing ArrowDown or `S` on an empty list throws `TypeError: Cannot read properties of undefined (reading 'key')`.

This is pre-existing and not introduced by the design-system restyle in #908 — it was surfaced during review of that PR and left out of its scope.

**Scope note:** the original report described this as unmounting the React tree and blanking the reader. It does not. The listener is a plain `addEventListener`, not a React synthetic handler, so error boundaries never see the throw, and it happens before any `setState`. The real impact is an uncaught `TypeError`, a silently dead keypress, and the Next.js dev overlay badge — which is likely what read as the app breaking. Still a real bug, just not a blank-screen-until-reload one.

## Fix

Guard on `entries.length` at the top of the handler, matching the `entries.length === 0` guards already used for the two other `entries[0]` dereferences in `lib/page.tsx`. Placing it above the `switch` also skips `preventDefault()` when there is nothing to navigate, so arrow keys keep their normal page-scroll behaviour on an empty list.

With the guard in place `entries[0]` is provably defined, so the optional-access variant (`entries[0]?.key`) would be redundant.

## Verification

There is no UI test harness in this repo (ava only; `lib/utils.test.ts` covers just `parseLocation`), so this was verified by driving the running dev server in a browser against a throwaway fixture in the gitignored `public/data`. Re-run in full after the rebase onto the restyled `main`:

| Scenario | Before | After |
| --- | --- | --- |
| Empty category, ArrowDown | `TypeError: Cannot read properties of undefined (reading 'key')` | no error, UI intact |
| Empty category, 12 presses across all four keys | — | no errors |
| Populated list, ArrowDown x3 | — | e1 → e2 → e3 |
| ArrowDown past end / KeyW past top | — | clamps correctly |
| Empty → populated navigation | — | selection works, no stale state |

Method caveat: the automation's OS-level key injection did not populate `event.code`, so the repro used a dispatched `KeyboardEvent` with `code: 'ArrowDown'`. The handler branches solely on `event.code`, so this is faithful to a real keypress.

`yarn test`: one failure in `action/repository.test.ts`, which asserts the checkout directory is named `feeds` and fails because this work was done in a git worktree. Confirmed pre-existing by stashing the change and rerunning — identical failure. Prettier clean.

## Version

Patch bump to 4.2.1, rebased from the original 4.1.1 after #908 took `main` to 4.2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)