### PR TITLE
Serve feed images from the site instead of hotlinking them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,4 +42,5 @@ lab.js
 # feeds content
 *.sqlite3
 public/data
+public/media
 contents

--- a/action/feeds/http.ts
+++ b/action/feeds/http.ts
@@ -1,0 +1,4 @@
+/**
+ * Identifies this action to the servers it fetches feeds and images from.
+ */
+export const USER_AGENT = 'llun/feed'

--- a/action/feeds/index.ts
+++ b/action/feeds/index.ts
@@ -1,6 +1,10 @@
 import fs from 'fs/promises'
 import path from 'path'
-import { getActionInput, getWorkspacePath } from '../repository'
+import {
+  getActionInput,
+  getWorkspacePath,
+  restorePublishedMedia
+} from '../repository'
 import {
   cleanup,
   copyExistingDatabase,
@@ -16,7 +20,31 @@ import {
   loadOPMLAndWriteFiles,
   prepareDirectories
 } from './file'
+import {
+  cleanupUnusedMediaFiles,
+  collectReferencedMediaFromContents,
+  collectReferencedMediaFromEntryDirectory,
+  createMediaStore,
+  getMediaDirectory
+} from './media'
 import { loadFeed, readOpml } from './opml'
+import type { Site } from './parsers'
+
+function getPublicPath(githubActionPath: string) {
+  return githubActionPath ? path.join(githubActionPath, 'public') : 'public'
+}
+
+async function createLocalizingFeedLoader(githubActionPath: string) {
+  await restorePublishedMedia(getPublicPath(githubActionPath))
+  const mediaDirectory = getMediaDirectory(githubActionPath)
+  const store = createMediaStore({ mediaDirectory })
+  const feedLoader = async (title: string, url: string) => {
+    const site: Site | null = await loadFeed(title, url)
+    if (!site) return null
+    return store.localizeSite(site)
+  }
+  return { feedLoader, mediaDirectory }
+}
 
 export async function createFeedDatabase(githubActionPath: string) {
   try {
@@ -28,13 +56,22 @@ export async function createFeedDatabase(githubActionPath: string) {
       await fs.readFile(path.join(getWorkspacePath(), feedsFile))
     ).toString('utf8')
     const opml = await readOpml(opmlContent)
-    const publicPath = githubActionPath
-      ? path.join(githubActionPath, 'public')
-      : 'public'
+    const publicPath = getPublicPath(githubActionPath)
+    const { feedLoader, mediaDirectory } =
+      await createLocalizingFeedLoader(githubActionPath)
     await copyExistingDatabase(publicPath)
     const database = getDatabase(publicPath)
     await createTables(database)
-    await createOrUpdateDatabase(database, opml, loadFeed)
+    await createOrUpdateDatabase(database, opml, feedLoader)
+    const entryContents = (await database('Entries').select('content')) as {
+      content: string
+    }[]
+    await cleanupUnusedMediaFiles(
+      mediaDirectory,
+      collectReferencedMediaFromContents(
+        entryContents.map((entry) => entry.content)
+      )
+    )
     await cleanup(database)
     await database.destroy()
   } catch (error: any) {
@@ -53,9 +90,12 @@ export async function createFeedFiles(githubActionPath: string) {
     const publicPath = githubActionPath
       ? path.join(githubActionPath, 'contents')
       : path.join('contents')
+    const { feedLoader, mediaDirectory } =
+      await createLocalizingFeedLoader(githubActionPath)
     await loadOPMLAndWriteFiles(
       publicPath,
-      path.join(getWorkspacePath(), feedsFile)
+      path.join(getWorkspacePath(), feedsFile),
+      feedLoader
     )
     const customDomainName = getActionInput('customDomain')
     const githubRootName = process.env['GITHUB_REPOSITORY'] || ''
@@ -64,6 +104,12 @@ export async function createFeedFiles(githubActionPath: string) {
     await createRepositoryData(DEFAULT_PATHS, githubRootName, customDomainName)
     await createCategoryData(DEFAULT_PATHS)
     await createAllEntriesData()
+    await cleanupUnusedMediaFiles(
+      mediaDirectory,
+      await collectReferencedMediaFromEntryDirectory(
+        DEFAULT_PATHS.entriesDataPath
+      )
+    )
   } catch (error: any) {
     console.error(error.message)
     console.error(error.stack)

--- a/action/feeds/media.test.ts
+++ b/action/feeds/media.test.ts
@@ -1,0 +1,405 @@
+import test from 'ava'
+import crypto from 'crypto'
+import fs from 'fs/promises'
+import os from 'os'
+import path from 'path'
+import sinon from 'sinon'
+
+import {
+  cleanupUnusedMediaFiles,
+  collectImageUrls,
+  collectReferencedMediaFromContents,
+  collectReferencedMediaFromEntryDirectory,
+  createMediaStore,
+  getMediaDirectory,
+  rewriteImageUrls
+} from './media'
+import type { Site } from './parsers'
+
+async function createMediaDirectory(prefix: string) {
+  const rootPath = await fs.mkdtemp(path.join(os.tmpdir(), prefix))
+  return path.join(rootPath, 'media')
+}
+
+function createSite(...contents: string[]): Site {
+  return {
+    title: 'Demo Site',
+    link: 'https://example.com/',
+    description: '',
+    updatedAt: 1700000000000,
+    generator: '',
+    entries: contents.map((content, index) => ({
+      title: `Entry ${index + 1}`,
+      link: `https://example.com/posts/entry-${index + 1}`,
+      date: 1700000000000,
+      author: 'author',
+      content
+    }))
+  }
+}
+
+function imageResponse(body = 'image-bytes', contentType = 'image/png') {
+  return new Response(Buffer.from(body), {
+    status: 200,
+    headers: { 'content-type': contentType }
+  })
+}
+
+function mediaHash(url: string) {
+  return crypto.createHash('sha256').update(url).digest('hex')
+}
+
+async function listMediaFiles(mediaDirectory: string) {
+  try {
+    return (await fs.readdir(mediaDirectory)).sort()
+  } catch {
+    return []
+  }
+}
+
+test('#getMediaDirectory places media inside the action public directory', (t) => {
+  t.is(getMediaDirectory('/action'), path.join('/action', 'public', 'media'))
+  t.is(getMediaDirectory(''), path.join('public', 'media'))
+})
+
+test('#localizeSite downloads images and rewrites src and srcset', async (t) => {
+  const mediaDirectory = await createMediaDirectory('feeds-media-')
+  const fetchStub = sinon.stub().callsFake(async (input: string) => {
+    if (input === 'https://example.com/images/one.png') return imageResponse()
+    if (input === 'https://cdn.example.com/two.webp')
+      return imageResponse('two', 'image/webp')
+    return new Response('not found', { status: 404 })
+  })
+
+  const store = createMediaStore({ mediaDirectory, fetch: fetchStub as any })
+  const localized = await store.localizeSite(
+    createSite(
+      '<p><a href="https://example.com/images/one.png"><img src="https://example.com/images/one.png" srcset="https://example.com/images/one.png 1x, https://cdn.example.com/two.webp 2x" /></a></p>'
+    )
+  )
+
+  const content = localized.entries[0].content
+  t.regex(content, /src="\/media\/[a-f0-9]{64}\.png"/)
+  t.regex(
+    content,
+    /srcset="\/media\/[a-f0-9]{64}\.png 1x, \/media\/[a-f0-9]{64}\.webp 2x"/
+  )
+  t.true(content.includes('href="https://example.com/images/one.png"'))
+  t.deepEqual(await listMediaFiles(mediaDirectory), [
+    `${mediaHash('https://cdn.example.com/two.webp')}.webp`,
+    `${mediaHash('https://example.com/images/one.png')}.png`
+  ].sort())
+  t.is(fetchStub.callCount, 2)
+})
+
+test('#localizeSite downloads each url once across entries', async (t) => {
+  const mediaDirectory = await createMediaDirectory('feeds-media-dedupe-')
+  const fetchStub = sinon.stub().resolves(imageResponse())
+
+  const store = createMediaStore({ mediaDirectory, fetch: fetchStub as any })
+  await store.localizeSite(
+    createSite(
+      '<img src="https://example.com/a.png" />',
+      '<img src="https://example.com/a.png" srcset="https://example.com/a.png 2x" />'
+    )
+  )
+  await store.localizeSite(createSite('<img src="https://example.com/a.png" />'))
+
+  t.is(fetchStub.callCount, 1)
+})
+
+test('#localizeSite keeps the remote url when the download fails', async (t) => {
+  const mediaDirectory = await createMediaDirectory('feeds-media-failure-')
+  const fetchStub = sinon.stub().resolves(new Response('nope', { status: 403 }))
+
+  const store = createMediaStore({ mediaDirectory, fetch: fetchStub as any })
+  const localized = await store.localizeSite(
+    createSite('<p><img src="https://example.com/a.png" alt="kept" /></p>')
+  )
+
+  t.true(
+    localized.entries[0].content.includes('src="https://example.com/a.png"')
+  )
+  t.true(localized.entries[0].content.includes('alt="kept"'))
+  t.deepEqual(await listMediaFiles(mediaDirectory), [])
+})
+
+test('#localizeSite keeps the remote url when fetch rejects', async (t) => {
+  const mediaDirectory = await createMediaDirectory('feeds-media-reject-')
+  const fetchStub = sinon.stub().rejects(new Error('socket hang up'))
+
+  const store = createMediaStore({ mediaDirectory, fetch: fetchStub as any })
+  const localized = await store.localizeSite(
+    createSite('<img src="https://example.com/a.png" />')
+  )
+
+  t.true(
+    localized.entries[0].content.includes('src="https://example.com/a.png"')
+  )
+})
+
+test('#localizeSite reuses media restored from the published branch', async (t) => {
+  const mediaDirectory = await createMediaDirectory('feeds-media-seeded-')
+  const url = 'https://example.com/a.png'
+  await fs.mkdir(mediaDirectory, { recursive: true })
+  await fs.writeFile(path.join(mediaDirectory, `${mediaHash(url)}.png`), 'seed')
+  const fetchStub = sinon.stub().resolves(imageResponse())
+
+  const store = createMediaStore({ mediaDirectory, fetch: fetchStub as any })
+  const localized = await store.localizeSite(createSite(`<img src="${url}" />`))
+
+  t.is(fetchStub.callCount, 0)
+  t.true(
+    localized.entries[0].content.includes(`src="/media/${mediaHash(url)}.png"`)
+  )
+})
+
+test('#localizeSite leaves data uri images untouched', async (t) => {
+  const mediaDirectory = await createMediaDirectory('feeds-media-data-')
+  const fetchStub = sinon.stub().resolves(imageResponse())
+  const dataUri =
+    'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
+
+  const store = createMediaStore({ mediaDirectory, fetch: fetchStub as any })
+  const localized = await store.localizeSite(
+    createSite(`<img src="${dataUri}" />`)
+  )
+
+  t.is(fetchStub.callCount, 0)
+  t.true(localized.entries[0].content.includes(dataUri))
+})
+
+test('#localizeSite keeps the remote url for non image responses', async (t) => {
+  const mediaDirectory = await createMediaDirectory('feeds-media-html-')
+  const fetchStub = sinon
+    .stub()
+    .resolves(
+      new Response('<html>blocked</html>', {
+        status: 200,
+        headers: { 'content-type': 'text/html' }
+      })
+    )
+
+  const store = createMediaStore({ mediaDirectory, fetch: fetchStub as any })
+  const localized = await store.localizeSite(
+    createSite('<img src="https://example.com/photo" />')
+  )
+
+  t.true(
+    localized.entries[0].content.includes('src="https://example.com/photo"')
+  )
+  t.deepEqual(await listMediaFiles(mediaDirectory), [])
+})
+
+test('#localizeSite names files from the content type when the url has no extension', async (t) => {
+  const mediaDirectory = await createMediaDirectory('feeds-media-content-type-')
+  const url = 'https://example.com/photo?id=1'
+  const fetchStub = sinon
+    .stub()
+    .resolves(imageResponse('webp', 'image/webp; charset=binary'))
+
+  const store = createMediaStore({ mediaDirectory, fetch: fetchStub as any })
+  const localized = await store.localizeSite(createSite(`<img src="${url}" />`))
+
+  t.deepEqual(await listMediaFiles(mediaDirectory), [`${mediaHash(url)}.webp`])
+  t.true(
+    localized.entries[0].content.includes(`src="/media/${mediaHash(url)}.webp"`)
+  )
+})
+
+test('#localizeSite skips svg images', async (t) => {
+  const mediaDirectory = await createMediaDirectory('feeds-media-svg-')
+  const fetchStub = sinon
+    .stub()
+    .resolves(imageResponse('<svg />', 'image/svg+xml'))
+
+  const store = createMediaStore({ mediaDirectory, fetch: fetchStub as any })
+  const localized = await store.localizeSite(
+    createSite(
+      '<img src="https://example.com/logo.svg" /><img src="https://example.com/inline" />'
+    )
+  )
+
+  t.is(fetchStub.callCount, 1, 'only the extensionless url is fetched')
+  t.true(
+    localized.entries[0].content.includes('src="https://example.com/logo.svg"')
+  )
+  t.true(
+    localized.entries[0].content.includes('src="https://example.com/inline"')
+  )
+  t.deepEqual(await listMediaFiles(mediaDirectory), [])
+})
+
+test('#localizeSite rejects media larger than the size limit', async (t) => {
+  const mediaDirectory = await createMediaDirectory('feeds-media-size-')
+  const fetchStub = sinon.stub().resolves(
+    new Response(Buffer.from('small'), {
+      status: 200,
+      headers: {
+        'content-type': 'image/png',
+        'content-length': `${64 * 1024 * 1024}`
+      }
+    })
+  )
+
+  const store = createMediaStore({ mediaDirectory, fetch: fetchStub as any })
+  const localized = await store.localizeSite(
+    createSite('<img src="https://example.com/huge.png" />')
+  )
+
+  t.true(
+    localized.entries[0].content.includes('src="https://example.com/huge.png"')
+  )
+  t.deepEqual(await listMediaFiles(mediaDirectory), [])
+})
+
+test('#localizeSite rejects oversized media without a content length', async (t) => {
+  const mediaDirectory = await createMediaDirectory('feeds-media-stream-')
+  const chunk = Buffer.alloc(1024 * 1024)
+  let sentChunks = 0
+  const fetchStub = sinon.stub().resolves(
+    new Response(
+      new ReadableStream({
+        pull(controller) {
+          sentChunks++
+          controller.enqueue(chunk)
+        }
+      }),
+      { status: 200, headers: { 'content-type': 'image/png' } }
+    )
+  )
+
+  const store = createMediaStore({ mediaDirectory, fetch: fetchStub as any })
+  const localized = await store.localizeSite(
+    createSite('<img src="https://example.com/stream.png" />')
+  )
+
+  t.true(sentChunks <= 22, 'stops reading once the cap is exceeded')
+  t.true(
+    localized.entries[0].content.includes('src="https://example.com/stream.png"')
+  )
+  t.deepEqual(await listMediaFiles(mediaDirectory), [])
+})
+
+test('#localizeSite rejects empty media', async (t) => {
+  const mediaDirectory = await createMediaDirectory('feeds-media-empty-')
+  const fetchStub = sinon.stub().resolves(imageResponse(''))
+
+  const store = createMediaStore({ mediaDirectory, fetch: fetchStub as any })
+  const localized = await store.localizeSite(
+    createSite('<img src="https://example.com/empty.png" />')
+  )
+
+  t.true(
+    localized.entries[0].content.includes('src="https://example.com/empty.png"')
+  )
+  t.deepEqual(await listMediaFiles(mediaDirectory), [])
+})
+
+test('#localizeSite limits how many downloads run at the same time', async (t) => {
+  const mediaDirectory = await createMediaDirectory('feeds-media-concurrency-')
+  let inFlight = 0
+  let maxInFlight = 0
+  const fetchStub = sinon.stub().callsFake(async () => {
+    inFlight++
+    maxInFlight = Math.max(maxInFlight, inFlight)
+    await new Promise((resolve) => setTimeout(resolve, 5))
+    inFlight--
+    return imageResponse()
+  })
+
+  const store = createMediaStore({ mediaDirectory, fetch: fetchStub as any })
+  await store.localizeSite(
+    createSite(
+      ...Array.from(
+        { length: 12 },
+        (_, index) => `<img src="https://host-${index}.example.com/a.png" />`
+      )
+    )
+  )
+
+  t.is(fetchStub.callCount, 12)
+  t.true(maxInFlight <= 4, `expected at most 4 downloads, saw ${maxInFlight}`)
+})
+
+test('#localizeSite stops downloading after the deadline', async (t) => {
+  const mediaDirectory = await createMediaDirectory('feeds-media-deadline-')
+  const fetchStub = sinon.stub().resolves(imageResponse())
+  let currentTime = 0
+
+  const store = createMediaStore({
+    mediaDirectory,
+    fetch: fetchStub as any,
+    now: () => currentTime
+  })
+  currentTime = 11 * 60 * 1000
+  const localized = await store.localizeSite(
+    createSite('<img src="https://example.com/a.png" />')
+  )
+
+  t.is(fetchStub.callCount, 0)
+  t.true(
+    localized.entries[0].content.includes('src="https://example.com/a.png"')
+  )
+})
+
+test('#collectImageUrls returns absolute image urls only', (t) => {
+  const urls = collectImageUrls(
+    '<img src="https://example.com/a.png" srcset="https://example.com/b.png 2x, data:image/gif;base64,AAA 3x" />' +
+      '<img src="/media/local.png" /><a href="https://example.com/c.png">link</a>'
+  )
+
+  t.deepEqual(
+    [...urls].sort(),
+    ['https://example.com/a.png', 'https://example.com/b.png']
+  )
+})
+
+test('#rewriteImageUrls only replaces mapped urls', (t) => {
+  const content = rewriteImageUrls(
+    '<img src="https://example.com/a.png" srcset="https://example.com/a.png 1x, https://example.com/b.png 2x" />',
+    new Map([['https://example.com/a.png', '/media/a.png']])
+  )
+
+  t.true(content.includes('src="/media/a.png"'))
+  t.true(
+    content.includes('srcset="/media/a.png 1x, https://example.com/b.png 2x"')
+  )
+})
+
+test('#collectReferencedMediaFromContents returns local image references', (t) => {
+  const media = collectReferencedMediaFromContents([
+    '<p><img src="/media/a.jpg" srcset="/media/b.webp 1x, /media/c.png 2x" /><a href="/media/d.gif">Download</a></p>',
+    '<img src="https://example.com/remote.png" />'
+  ])
+
+  t.deepEqual([...media].sort(), ['a.jpg', 'b.webp', 'c.png'])
+})
+
+test('#collectReferencedMediaFromEntryDirectory reads entry files', async (t) => {
+  const rootPath = await fs.mkdtemp(path.join(os.tmpdir(), 'feeds-media-entry-'))
+  await fs.writeFile(
+    path.join(rootPath, 'one.json'),
+    JSON.stringify({ content: '<img src="/media/a.jpg" />' })
+  )
+  await fs.writeFile(path.join(rootPath, 'broken.json'), 'not json')
+
+  const media = await collectReferencedMediaFromEntryDirectory(rootPath)
+  t.deepEqual([...media], ['a.jpg'])
+
+  const missing = await collectReferencedMediaFromEntryDirectory(
+    path.join(rootPath, 'missing')
+  )
+  t.deepEqual([...missing], [])
+})
+
+test('#cleanupUnusedMediaFiles removes stale media files', async (t) => {
+  const mediaDirectory = await createMediaDirectory('feeds-media-clean-')
+  await fs.mkdir(mediaDirectory, { recursive: true })
+  await fs.writeFile(path.join(mediaDirectory, 'used.jpg'), 'used')
+  await fs.writeFile(path.join(mediaDirectory, 'stale.jpg'), 'stale')
+
+  await cleanupUnusedMediaFiles(mediaDirectory, new Set(['used.jpg']))
+
+  t.deepEqual(await listMediaFiles(mediaDirectory), ['used.jpg'])
+})

--- a/action/feeds/media.ts
+++ b/action/feeds/media.ts
@@ -1,0 +1,438 @@
+import crypto from 'crypto'
+import { Dirent } from 'fs'
+import fs from 'fs/promises'
+import path from 'path'
+
+import sanitizeHtml from 'sanitize-html'
+
+import { ENTRY_CONTENT_SANITIZE_OPTIONS, type Site } from './parsers'
+
+export const LOCAL_MEDIA_DIRECTORY = '/media'
+
+const DEFAULT_USER_AGENT = 'llun/feed'
+const MAX_MEDIA_BYTES = 20 * 1024 * 1024
+const DOWNLOAD_TIMEOUT_MS = 15_000
+const MAX_CONCURRENT_DOWNLOADS = 4
+const MAX_CONCURRENT_DOWNLOADS_PER_HOST = 2
+const LOCALIZE_DEADLINE_MS = 10 * 60 * 1000
+
+// SVG is deliberately absent from both maps. Localized files are navigable on
+// the published origin, and a feed could otherwise plant a scripted SVG there.
+const KNOWN_IMAGE_EXTENSIONS = new Set([
+  '.avif',
+  '.gif',
+  '.heic',
+  '.heif',
+  '.jpeg',
+  '.jpg',
+  '.jxl',
+  '.png',
+  '.tif',
+  '.tiff',
+  '.webp'
+])
+
+const CONTENT_TYPE_EXTENSIONS: Record<string, string> = {
+  'image/avif': '.avif',
+  'image/gif': '.gif',
+  'image/heic': '.heic',
+  'image/heif': '.heif',
+  'image/jpeg': '.jpg',
+  'image/jxl': '.jxl',
+  'image/png': '.png',
+  'image/tiff': '.tiff',
+  'image/webp': '.webp'
+}
+
+interface EntryWithContent {
+  content: string
+}
+
+interface MediaStoreOptions {
+  mediaDirectory: string
+  fetch?: typeof globalThis.fetch
+  now?: () => number
+}
+
+export function getMediaDirectory(githubActionPath: string) {
+  return githubActionPath
+    ? path.join(githubActionPath, 'public', 'media')
+    : path.join('public', 'media')
+}
+
+function createMediaHash(input: string) {
+  return crypto.createHash('sha256').update(input).digest('hex')
+}
+
+function normalizeImageExtension(extension?: string | null) {
+  if (!extension) return null
+  const normalized = extension.trim().toLowerCase()
+  if (!KNOWN_IMAGE_EXTENSIONS.has(normalized)) return null
+  return normalized
+}
+
+export function extensionFromContentType(contentType?: string | null) {
+  if (!contentType) return null
+  const normalizedType = contentType.split(';')[0].trim().toLowerCase()
+  return CONTENT_TYPE_EXTENSIONS[normalizedType] ?? null
+}
+
+export function extensionFromUrl(url: string) {
+  try {
+    const parsed = new URL(url)
+    return normalizeImageExtension(path.extname(parsed.pathname))
+  } catch {
+    return null
+  }
+}
+
+function isSvgUrl(url: string) {
+  try {
+    const parsed = new URL(url)
+    return path.extname(parsed.pathname).toLowerCase() === '.svg'
+  } catch {
+    return false
+  }
+}
+
+export function splitSrcSet(srcSet: string) {
+  return srcSet
+    .split(',')
+    .map((candidate) => candidate.trim())
+    .filter((candidate) => candidate.length > 0)
+}
+
+function isDownloadableUrl(url: string) {
+  try {
+    const parsed = new URL(url)
+    return ['http:', 'https:'].includes(parsed.protocol)
+  } catch {
+    return false
+  }
+}
+
+function extractMediaFileNameFromLocalPath(value: string) {
+  const trimmed = value.trim()
+  if (!trimmed) return null
+  const pathWithQuery = trimmed.startsWith('/') ? trimmed.substring(1) : trimmed
+  if (!pathWithQuery.startsWith('media/')) return null
+  const fileName = pathWithQuery
+    .substring('media/'.length)
+    .split('?')[0]
+    .split('#')[0]
+    .trim()
+  return fileName || null
+}
+
+/**
+ * Walks entry content with the same sanitizer configuration used to store it,
+ * visiting every image URL in `src` and `srcset`. sanitize-html transforms are
+ * synchronous, so downloading happens between a collect pass and a rewrite pass
+ * instead of inside the transform itself.
+ */
+function walkImageUrls(
+  content: string,
+  visitImageUrl: (url: string) => string | void
+) {
+  const visit = (url: string) => {
+    const nextUrl = visitImageUrl(url)
+    return typeof nextUrl === 'string' ? nextUrl : url
+  }
+
+  return sanitizeHtml(content, {
+    ...ENTRY_CONTENT_SANITIZE_OPTIONS,
+    transformTags: {
+      img: (tagName, attribs) => {
+        const nextAttribs = { ...attribs }
+        if (nextAttribs.src) {
+          nextAttribs.src = visit(nextAttribs.src)
+        }
+        if (nextAttribs.srcset) {
+          nextAttribs.srcset = splitSrcSet(nextAttribs.srcset)
+            .map((candidate) => {
+              const [urlPart, ...descriptorParts] = candidate.split(/\s+/)
+              const descriptor = descriptorParts.join(' ').trim()
+              const nextUrl = visit(urlPart)
+              return descriptor ? `${nextUrl} ${descriptor}` : nextUrl
+            })
+            .join(', ')
+        }
+        return { tagName, attribs: nextAttribs }
+      }
+    }
+  })
+}
+
+export function collectImageUrls(content: string) {
+  const urls = new Set<string>()
+  if (!content) return urls
+  walkImageUrls(content, (url) => {
+    if (isDownloadableUrl(url)) urls.add(url)
+  })
+  return urls
+}
+
+export function rewriteImageUrls(
+  content: string,
+  replacements: Map<string, string>
+) {
+  if (!content) return content
+  return walkImageUrls(content, (url) => replacements.get(url))
+}
+
+async function fileExists(filePath: string) {
+  try {
+    await fs.stat(filePath)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function resolveExistingMediaFile(
+  mediaDirectory: string,
+  mediaHash: string,
+  expectedExtension: string | null
+) {
+  if (expectedExtension) {
+    const expectedName = `${mediaHash}${expectedExtension}`
+    if (await fileExists(path.join(mediaDirectory, expectedName))) {
+      return expectedName
+    }
+  }
+
+  try {
+    const files = await fs.readdir(mediaDirectory)
+    return files.find((fileName) => fileName.startsWith(`${mediaHash}.`)) || null
+  } catch {
+    return null
+  }
+}
+
+async function readBodyWithinLimit(
+  response: Response,
+  controller: AbortController
+) {
+  const declaredLength = Number(response.headers.get('content-length'))
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_MEDIA_BYTES) {
+    throw new Error(`Media is larger than ${MAX_MEDIA_BYTES} bytes`)
+  }
+  if (!response.body) throw new Error('Media response has no body')
+
+  const chunks: Buffer[] = []
+  let total = 0
+  for await (const chunk of response.body as unknown as AsyncIterable<Uint8Array>) {
+    total += chunk.length
+    // Servers can omit or lie about content-length, so the cap is enforced
+    // while streaming rather than after buffering the whole response.
+    if (total > MAX_MEDIA_BYTES) {
+      controller.abort()
+      throw new Error(`Media is larger than ${MAX_MEDIA_BYTES} bytes`)
+    }
+    chunks.push(Buffer.from(chunk))
+  }
+  return Buffer.concat(chunks)
+}
+
+export interface MediaStore {
+  localizeSite(site: Site): Promise<Site>
+}
+
+export function createMediaStore({
+  mediaDirectory,
+  fetch: fetchMedia = globalThis.fetch,
+  now = Date.now
+}: MediaStoreOptions): MediaStore {
+  const localPaths = new Map<string, Promise<string | null>>()
+  const deadline = now() + LOCALIZE_DEADLINE_MS
+  let activeDownloads = 0
+  const activeDownloadsByHost = new Map<string, number>()
+  const waiting: (() => void)[] = []
+
+  function hasCapacity(host: string) {
+    return (
+      activeDownloads < MAX_CONCURRENT_DOWNLOADS &&
+      (activeDownloadsByHost.get(host) ?? 0) < MAX_CONCURRENT_DOWNLOADS_PER_HOST
+    )
+  }
+
+  async function withDownloadSlot<T>(host: string, download: () => Promise<T>) {
+    while (!hasCapacity(host)) {
+      await new Promise<void>((resolve) => waiting.push(resolve))
+    }
+    activeDownloads++
+    activeDownloadsByHost.set(host, (activeDownloadsByHost.get(host) ?? 0) + 1)
+    try {
+      return await download()
+    } finally {
+      activeDownloads--
+      activeDownloadsByHost.set(host, (activeDownloadsByHost.get(host) ?? 1) - 1)
+      // Every waiter re-checks its own host limit, so waking all of them keeps
+      // the queue free of head-of-line blocking on a single busy host.
+      waiting.splice(0).forEach((resume) => resume())
+    }
+  }
+
+  async function downloadMedia(url: string): Promise<string | null> {
+    const mediaHash = createMediaHash(url)
+    const urlExtension = extensionFromUrl(url)
+    const existingFileName = await resolveExistingMediaFile(
+      mediaDirectory,
+      mediaHash,
+      urlExtension
+    )
+    if (existingFileName) {
+      return `${LOCAL_MEDIA_DIRECTORY}/${existingFileName}`
+    }
+
+    if (isSvgUrl(url)) return null
+    if (now() > deadline) {
+      console.error(`Skip media ${url}: localization deadline exceeded`)
+      return null
+    }
+
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), DOWNLOAD_TIMEOUT_MS)
+    try {
+      const response = await fetchMedia(url, {
+        headers: { 'User-Agent': DEFAULT_USER_AGENT },
+        signal: controller.signal
+      })
+      if (!response.ok) {
+        throw new Error(`Unexpected response status ${response.status}`)
+      }
+
+      const contentTypeExtension = extensionFromContentType(
+        response.headers.get('content-type')
+      )
+      const extension = contentTypeExtension || urlExtension
+      if (!extension) {
+        throw new Error(
+          `Unsupported media type ${response.headers.get('content-type')}`
+        )
+      }
+
+      const buffer = await readBodyWithinLimit(response, controller)
+      if (buffer.length === 0) throw new Error('Media response is empty')
+
+      const fileName = `${mediaHash}${extension}`
+      await fs.mkdir(mediaDirectory, { recursive: true })
+      await fs.writeFile(path.join(mediaDirectory, fileName), buffer)
+      return `${LOCAL_MEDIA_DIRECTORY}/${fileName}`
+    } catch (error: any) {
+      console.error(`Fail to download media ${url}: ${error.message}`)
+      return null
+    } finally {
+      clearTimeout(timeout)
+    }
+  }
+
+  function localPathFor(url: string) {
+    const existing = localPaths.get(url)
+    if (existing) return existing
+
+    const host = new URL(url).host
+    // Failures are cached for the run too, so one dead host costs a single
+    // timeout no matter how many entries reference it.
+    const localPath = withDownloadSlot(host, () => downloadMedia(url))
+    localPaths.set(url, localPath)
+    return localPath
+  }
+
+  async function localizeSite(site: Site) {
+    const urls = new Set<string>()
+    for (const entry of site.entries) {
+      for (const url of collectImageUrls(entry.content)) urls.add(url)
+    }
+
+    const replacements = new Map<string, string>()
+    await Promise.all(
+      [...urls].map(async (url) => {
+        const localPath = await localPathFor(url)
+        if (localPath) replacements.set(url, localPath)
+      })
+    )
+
+    return {
+      ...site,
+      entries: site.entries.map((entry) => ({
+        ...entry,
+        content: rewriteImageUrls(entry.content, replacements)
+      }))
+    }
+  }
+
+  return { localizeSite }
+}
+
+export function extractLocalMediaReferences(content: string) {
+  const references = new Set<string>()
+  if (!content) return references
+  walkImageUrls(content, (url) => {
+    const mediaFile = extractMediaFileNameFromLocalPath(url)
+    if (mediaFile) references.add(mediaFile)
+  })
+  return references
+}
+
+export function collectReferencedMediaFromContents(contents: string[]) {
+  const references = new Set<string>()
+  for (const content of contents) {
+    for (const mediaFile of extractLocalMediaReferences(content)) {
+      references.add(mediaFile)
+    }
+  }
+  return references
+}
+
+export async function collectReferencedMediaFromEntryDirectory(
+  entriesDirectory: string
+) {
+  const references = new Set<string>()
+  let files: string[] = []
+  try {
+    files = await fs.readdir(entriesDirectory)
+  } catch {
+    return references
+  }
+
+  for (const fileName of files) {
+    if (!fileName.endsWith('.json')) continue
+    try {
+      const content = await fs.readFile(
+        path.join(entriesDirectory, fileName),
+        'utf-8'
+      )
+      const parsed = JSON.parse(content) as EntryWithContent
+      if (!parsed.content) continue
+      for (const mediaFile of extractLocalMediaReferences(parsed.content)) {
+        references.add(mediaFile)
+      }
+    } catch {
+      continue
+    }
+  }
+  return references
+}
+
+export async function cleanupUnusedMediaFiles(
+  mediaDirectory: string,
+  referencedFiles: Iterable<string>
+) {
+  const references = new Set(referencedFiles)
+  let entries: Dirent[] = []
+  try {
+    entries = await fs.readdir(mediaDirectory, { withFileTypes: true })
+  } catch {
+    return
+  }
+
+  await Promise.all(
+    entries
+      .filter((entry) => entry.isFile())
+      .map(async (entry) => {
+        if (references.has(entry.name)) return
+        await fs.rm(path.join(mediaDirectory, entry.name), { force: true })
+      })
+  )
+}

--- a/action/feeds/media.ts
+++ b/action/feeds/media.ts
@@ -5,19 +5,20 @@ import path from 'path'
 
 import sanitizeHtml from 'sanitize-html'
 
+import { LOCAL_MEDIA_PATH, mapSrcSet } from '../../lib/media'
+import { USER_AGENT } from './http'
 import { ENTRY_CONTENT_SANITIZE_OPTIONS, type Site } from './parsers'
 
-export const LOCAL_MEDIA_DIRECTORY = '/media'
-
-const DEFAULT_USER_AGENT = 'llun/feed'
 const MAX_MEDIA_BYTES = 20 * 1024 * 1024
 const DOWNLOAD_TIMEOUT_MS = 15_000
 const MAX_CONCURRENT_DOWNLOADS = 4
 const MAX_CONCURRENT_DOWNLOADS_PER_HOST = 2
 const LOCALIZE_DEADLINE_MS = 10 * 60 * 1000
 
-// SVG is deliberately absent from both maps. Localized files are navigable on
-// the published origin, and a feed could otherwise plant a scripted SVG there.
+// Which images may be downloaded and served from our own origin. SVG is
+// deliberately absent from both maps: a localized file is navigable on the
+// published origin, and a feed could otherwise plant a scripted SVG there.
+// parsers.ts keeps a wider list for URL resolution; do not merge the two.
 const KNOWN_IMAGE_EXTENSIONS = new Set([
   '.avif',
   '.gif',
@@ -95,13 +96,6 @@ function isSvgUrl(url: string) {
   }
 }
 
-export function splitSrcSet(srcSet: string) {
-  return srcSet
-    .split(',')
-    .map((candidate) => candidate.trim())
-    .filter((candidate) => candidate.length > 0)
-}
-
 function isDownloadableUrl(url: string) {
   try {
     const parsed = new URL(url)
@@ -112,12 +106,11 @@ function isDownloadableUrl(url: string) {
 }
 
 function extractMediaFileNameFromLocalPath(value: string) {
+  const prefix = `${LOCAL_MEDIA_PATH}/`
   const trimmed = value.trim()
-  if (!trimmed) return null
-  const pathWithQuery = trimmed.startsWith('/') ? trimmed.substring(1) : trimmed
-  if (!pathWithQuery.startsWith('media/')) return null
-  const fileName = pathWithQuery
-    .substring('media/'.length)
+  if (!trimmed.startsWith(prefix)) return null
+  const fileName = trimmed
+    .substring(prefix.length)
     .split('?')[0]
     .split('#')[0]
     .trim()
@@ -148,14 +141,7 @@ function walkImageUrls(
           nextAttribs.src = visit(nextAttribs.src)
         }
         if (nextAttribs.srcset) {
-          nextAttribs.srcset = splitSrcSet(nextAttribs.srcset)
-            .map((candidate) => {
-              const [urlPart, ...descriptorParts] = candidate.split(/\s+/)
-              const descriptor = descriptorParts.join(' ').trim()
-              const nextUrl = visit(urlPart)
-              return descriptor ? `${nextUrl} ${descriptor}` : nextUrl
-            })
-            .join(', ')
+          nextAttribs.srcset = mapSrcSet(nextAttribs.srcset, visit)
         }
         return { tagName, attribs: nextAttribs }
       }
@@ -282,7 +268,7 @@ export function createMediaStore({
       urlExtension
     )
     if (existingFileName) {
-      return `${LOCAL_MEDIA_DIRECTORY}/${existingFileName}`
+      return `${LOCAL_MEDIA_PATH}/${existingFileName}`
     }
 
     if (isSvgUrl(url)) return null
@@ -295,7 +281,7 @@ export function createMediaStore({
     const timeout = setTimeout(() => controller.abort(), DOWNLOAD_TIMEOUT_MS)
     try {
       const response = await fetchMedia(url, {
-        headers: { 'User-Agent': DEFAULT_USER_AGENT },
+        headers: { 'User-Agent': USER_AGENT },
         signal: controller.signal
       })
       if (!response.ok) {
@@ -318,7 +304,7 @@ export function createMediaStore({
       const fileName = `${mediaHash}${extension}`
       await fs.mkdir(mediaDirectory, { recursive: true })
       await fs.writeFile(path.join(mediaDirectory, fileName), buffer)
-      return `${LOCAL_MEDIA_DIRECTORY}/${fileName}`
+      return `${LOCAL_MEDIA_PATH}/${fileName}`
     } catch (error: any) {
       console.error(`Fail to download media ${url}: ${error.message}`)
       return null

--- a/action/feeds/opml.ts
+++ b/action/feeds/opml.ts
@@ -1,9 +1,10 @@
+import { USER_AGENT } from './http'
 import { parseAtom, parseRss, parseXML } from './parsers'
 
 export async function loadFeed(title: string, url: string) {
   try {
     const response = await fetch(url, {
-      headers: { 'User-Agent': 'llun/feed' }
+      headers: { 'User-Agent': USER_AGENT }
     })
     const text = await response.text()
     const xml = await parseXML(text)

--- a/action/feeds/parsers.ts
+++ b/action/feeds/parsers.ts
@@ -1,6 +1,8 @@
 import { parseString } from 'xml2js'
 import sanitizeHtml from 'sanitize-html'
 
+import { mapSrcSet } from '../../lib/media'
+
 export interface Entry {
   title: string
   link: string
@@ -19,6 +21,9 @@ export interface Site {
 }
 
 type Values = string[] | { _: string; $: { type: 'text' } }[] | null
+// Which links look like an image, so their URL is worth resolving. This is
+// deliberately not the list of images media.ts downloads: svg belongs here but
+// must never be served from our own origin. Keep the two lists apart.
 const IMAGE_EXTENSION_REGEX =
   /\.(avif|gif|heic|heif|jpeg|jpg|jxl|png|svg|tif|tiff|webp)$/i
 
@@ -69,17 +74,7 @@ function resolveMediaUrl(inputUrl: string, siteLink: string, entryLink: string) 
 }
 
 function resolveSrcSet(srcSet: string, siteLink: string, entryLink: string) {
-  return srcSet
-    .split(',')
-    .map((candidate) => candidate.trim())
-    .filter((candidate) => candidate.length > 0)
-    .map((candidate) => {
-      const [urlPart, ...descriptorParts] = candidate.split(/\s+/)
-      const resolvedUrl = resolveMediaUrl(urlPart, siteLink, entryLink)
-      const descriptor = descriptorParts.join(' ').trim()
-      return descriptor ? `${resolvedUrl} ${descriptor}` : resolvedUrl
-    })
-    .join(', ')
+  return mapSrcSet(srcSet, (url) => resolveMediaUrl(url, siteLink, entryLink))
 }
 
 function isImageLikeUrl(url: string) {

--- a/action/feeds/parsers.ts
+++ b/action/feeds/parsers.ts
@@ -87,19 +87,23 @@ function isImageLikeUrl(url: string) {
   return IMAGE_EXTENSION_REGEX.test(pathOnly)
 }
 
+export const ENTRY_CONTENT_SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
+  allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img']),
+  allowedAttributes: {
+    ...sanitizeHtml.defaults.allowedAttributes,
+    img: ['src', 'alt', 'title', 'width', 'height', 'loading', 'srcset']
+  },
+  allowedSchemes: ['http', 'https', 'mailto', 'data'],
+  allowedSchemesByTag: {
+    img: ['http', 'https', 'data']
+  },
+  disallowedTagsMode: 'discard',
+  enforceHtmlBoundary: true
+}
+
 function sanitizeEntryContent(content: string, siteLink: string, entryLink: string) {
   return sanitizeHtml(content, {
-    allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img']),
-    allowedAttributes: {
-      ...sanitizeHtml.defaults.allowedAttributes,
-      img: ['src', 'alt', 'title', 'width', 'height', 'loading', 'srcset']
-    },
-    allowedSchemes: ['http', 'https', 'mailto', 'data'],
-    allowedSchemesByTag: {
-      img: ['http', 'https', 'data']
-    },
-    disallowedTagsMode: 'discard',
-    enforceHtmlBoundary: true,
+    ...ENTRY_CONTENT_SANITIZE_OPTIONS,
     transformTags: {
       img: (tagName, attribs) => {
         const nextAttribs = { ...attribs }

--- a/action/repository.test.ts
+++ b/action/repository.test.ts
@@ -3,7 +3,8 @@ import path from 'path'
 import {
   getActionInput,
   getGithubActionPath,
-  resolveSourceBranch
+  resolveSourceBranch,
+  restorePublishedMedia
 } from './repository'
 
 test('#resolveSourceBranch uses workflow branch ref', (t) => {
@@ -38,6 +39,20 @@ test('#getActionInput reads from action input environment', (t) => {
 
   process.env['INPUT_STORAGETYPE'] = 'sqlite'
   t.is(getActionInput('storageType'), 'sqlite')
+})
+
+test('#restorePublishedMedia skips when there is no workspace', async (t) => {
+  const originalWorkspace = process.env['GITHUB_WORKSPACE']
+  t.teardown(() => {
+    if (originalWorkspace === undefined) {
+      delete process.env['GITHUB_WORKSPACE']
+      return
+    }
+    process.env['GITHUB_WORKSPACE'] = originalWorkspace
+  })
+
+  delete process.env['GITHUB_WORKSPACE']
+  t.false(await restorePublishedMedia('public'))
 })
 
 test('#getActionInput uses configured defaults', (t) => {

--- a/action/repository.ts
+++ b/action/repository.ts
@@ -1,5 +1,6 @@
 import { spawnSync, type SpawnSyncReturns } from 'child_process'
 import fs from 'fs'
+import os from 'os'
 import path from 'path'
 import { fileURLToPath } from 'url'
 
@@ -103,6 +104,69 @@ export function resolveSourceBranch(
     return ref.substring(branchPrefix.length)
   }
   return defaultBranch
+}
+
+/**
+ * Copies the media files of the published branch into the public directory so
+ * a run only downloads images it has never seen before.
+ *
+ * The fetch deliberately runs inside the workspace repository rather than a
+ * throwaway clone: publish() pushes from the workspace, and git can only leave
+ * existing blobs out of the push pack when the local repository can walk the
+ * remote tip. Seeding anywhere else would re-upload every media file each run.
+ */
+export async function restorePublishedMedia(publicDirectory: string) {
+  const workSpace = getWorkspacePath()
+  if (!workSpace) return false
+
+  const branch = getActionInput('branch', { required: true })
+  validateBranchName(branch)
+
+  const fetchResult = runCommand(
+    ['git', 'fetch', '--depth=1', 'origin', branch],
+    workSpace
+  )
+  if (isCommandFailed(fetchResult)) {
+    console.log(`No published ${branch} branch to restore media from`)
+    return false
+  }
+
+  // git archive reads the fetched commit directly, so the workspace index and
+  // working tree that publish() later commits stay untouched. The archive is
+  // written outside the workspace because git archive creates its output file
+  // before it resolves the pathspec, and publish() force adds everything it
+  // finds in the workspace.
+  const archiveDirectory = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'feeds-media-')
+  )
+  const archivePath = path.join(archiveDirectory, 'media.tar')
+  try {
+    const archiveResult = runCommand(
+      ['git', 'archive', '--output', archivePath, 'FETCH_HEAD', 'media'],
+      workSpace
+    )
+    if (isCommandFailed(archiveResult)) {
+      console.log(`No published media to restore from ${branch} branch`)
+      return false
+    }
+
+    fs.mkdirSync(publicDirectory, { recursive: true })
+    const extractResult = runCommand([
+      'tar',
+      '-xf',
+      archivePath,
+      '-C',
+      publicDirectory
+    ])
+    if (isCommandFailed(extractResult)) {
+      console.log('Fail to extract published media')
+      return false
+    }
+    console.log(`Restore published media from ${branch} branch`)
+    return true
+  } finally {
+    fs.rmSync(archiveDirectory, { recursive: true, force: true })
+  }
 }
 
 export async function buildSite() {

--- a/lib/components/ItemContent.tsx
+++ b/lib/components/ItemContent.tsx
@@ -4,6 +4,7 @@ import { formatDistance } from 'date-fns'
 import { ExternalLink } from 'lucide-react'
 import { BackButton } from './BackButton'
 import parse from 'html-react-parser'
+import { isLocalMediaPath, rewriteLocalSrcSet, withBasePath } from '../media'
 
 interface ReactParserNode {
   name: string
@@ -18,6 +19,7 @@ interface ItemContentProps {
 }
 
 export const ItemContent = ({ content, selectBack }: ItemContentProps) => {
+  const basePath = process.env.NEXT_PUBLIC_BASE_PATH || ''
   let element: HTMLElement | null = null
   useEffect(() => {
     if (!element) return
@@ -79,6 +81,21 @@ export const ItemContent = ({ content, selectBack }: ItemContentProps) => {
               if (node.attribs && node.name === 'a') {
                 node.attribs.target = '_blank'
                 node.attribs.rel = 'noopener noreferrer'
+                return node
+              }
+              if (node.attribs && node.name === 'img') {
+                const { src, srcset } = node.attribs
+                if (src?.startsWith('data:')) return node
+                // Images that could not be downloaded still point at their
+                // origin, where a referrer often triggers hotlink protection.
+                node.attribs.referrerpolicy = 'no-referrer'
+                node.attribs.loading = node.attribs.loading || 'lazy'
+                if (isLocalMediaPath(src)) {
+                  node.attribs.src = withBasePath(src, basePath)
+                }
+                if (srcset) {
+                  node.attribs.srcset = rewriteLocalSrcSet(srcset, basePath)
+                }
                 return node
               }
               return domNode

--- a/lib/media.test.ts
+++ b/lib/media.test.ts
@@ -1,0 +1,35 @@
+import test from 'ava'
+
+import { isLocalMediaPath, rewriteLocalSrcSet, withBasePath } from './media'
+
+test('#isLocalMediaPath matches downloaded media paths only', (t) => {
+  t.true(isLocalMediaPath('/media/a.png'))
+  t.false(isLocalMediaPath('/media/'))
+  t.false(isLocalMediaPath('https://example.com/media/a.png'))
+  t.false(isLocalMediaPath('data:image/gif;base64,AAA'))
+  t.false(isLocalMediaPath(''))
+  t.false(isLocalMediaPath(undefined))
+})
+
+test('#withBasePath prefixes local media only', (t) => {
+  t.is(withBasePath('/media/a.png', '/feeds'), '/feeds/media/a.png')
+  t.is(withBasePath('/media/a.png', ''), '/media/a.png')
+  t.is(
+    withBasePath('https://example.com/a.png', '/feeds'),
+    'https://example.com/a.png'
+  )
+})
+
+test('#rewriteLocalSrcSet keeps remote candidates and descriptors', (t) => {
+  t.is(
+    rewriteLocalSrcSet(
+      '/media/a.png 1x, https://example.com/b.png 2x, /media/c.png',
+      '/feeds'
+    ),
+    '/feeds/media/a.png 1x, https://example.com/b.png 2x, /feeds/media/c.png'
+  )
+  t.is(
+    rewriteLocalSrcSet('/media/a.png 1x', ''),
+    '/media/a.png 1x'
+  )
+})

--- a/lib/media.ts
+++ b/lib/media.ts
@@ -1,0 +1,30 @@
+const LOCAL_MEDIA_PREFIX = '/media/'
+
+export function isLocalMediaPath(url?: string) {
+  if (!url) return false
+  const trimmed = url.trim()
+  return trimmed.startsWith(LOCAL_MEDIA_PREFIX) && trimmed.length > LOCAL_MEDIA_PREFIX.length
+}
+
+export function withBasePath(url: string, basePath: string) {
+  if (!basePath || !isLocalMediaPath(url)) return url
+  return `${basePath}${url.trim()}`
+}
+
+/**
+ * Images that fail to download keep their remote URL, so a srcset can mix local
+ * and remote candidates. Only the local ones get the base path.
+ */
+export function rewriteLocalSrcSet(srcSet: string, basePath: string) {
+  return srcSet
+    .split(',')
+    .map((candidate) => candidate.trim())
+    .filter((candidate) => candidate.length > 0)
+    .map((candidate) => {
+      const [urlPart, ...descriptorParts] = candidate.split(/\s+/)
+      const url = withBasePath(urlPart, basePath)
+      const descriptor = descriptorParts.join(' ').trim()
+      return descriptor ? `${url} ${descriptor}` : url
+    })
+    .join(', ')
+}

--- a/lib/media.ts
+++ b/lib/media.ts
@@ -1,9 +1,35 @@
-const LOCAL_MEDIA_PREFIX = '/media/'
+/**
+ * Shared between the action that downloads feed images and the reader that
+ * renders them, so both sides always agree on where media lives.
+ */
+export const LOCAL_MEDIA_PATH = '/media'
+
+const LOCAL_MEDIA_PREFIX = `${LOCAL_MEDIA_PATH}/`
+
+/**
+ * Rewrites every candidate URL of a srcset, keeping its descriptor.
+ */
+export function mapSrcSet(srcSet: string, mapUrl: (url: string) => string) {
+  return srcSet
+    .split(',')
+    .map((candidate) => candidate.trim())
+    .filter((candidate) => candidate.length > 0)
+    .map((candidate) => {
+      const [urlPart, ...descriptorParts] = candidate.split(/\s+/)
+      const url = mapUrl(urlPart)
+      const descriptor = descriptorParts.join(' ').trim()
+      return descriptor ? `${url} ${descriptor}` : url
+    })
+    .join(', ')
+}
 
 export function isLocalMediaPath(url?: string) {
   if (!url) return false
   const trimmed = url.trim()
-  return trimmed.startsWith(LOCAL_MEDIA_PREFIX) && trimmed.length > LOCAL_MEDIA_PREFIX.length
+  return (
+    trimmed.startsWith(LOCAL_MEDIA_PREFIX) &&
+    trimmed.length > LOCAL_MEDIA_PREFIX.length
+  )
 }
 
 export function withBasePath(url: string, basePath: string) {
@@ -16,15 +42,5 @@ export function withBasePath(url: string, basePath: string) {
  * and remote candidates. Only the local ones get the base path.
  */
 export function rewriteLocalSrcSet(srcSet: string, basePath: string) {
-  return srcSet
-    .split(',')
-    .map((candidate) => candidate.trim())
-    .filter((candidate) => candidate.length > 0)
-    .map((candidate) => {
-      const [urlPart, ...descriptorParts] = candidate.split(/\s+/)
-      const url = withBasePath(urlPart, basePath)
-      const descriptor = descriptorParts.join(' ').trim()
-      return descriptor ? `${url} ${descriptor}` : url
-    })
-    .join(', ')
+  return mapSrcSet(srcSet, (url) => withBasePath(url, basePath))
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feeds-fetcher",
-  "version": "4.2.1",
+  "version": "4.3.0",
   "description": "Websites feed fetcher and static feeds aggregator",
   "main": "index.js",
   "type": "module",

--- a/readme.md
+++ b/readme.md
@@ -28,6 +28,14 @@ After this, enable GitHub Pages on the `contents` branch and the content will be
 
 The action always reads the OPML file from the branch that triggered the workflow (for example `main`), then publishes generated output to the configured `branch`.
 
+## Images in feed content
+
+Images referenced by feed entries are downloaded while the feeds are loaded and published alongside the site under `/media`, so the reader never hotlinks a publisher's server. This avoids hotlink protection, mixed content and cross-origin resource policy blocking.
+
+Images that cannot be downloaded keep their original URL and are rendered with `referrerpolicy="no-referrer"`. Because feeds are re-read on every run, a publisher that was temporarily unavailable is picked up again on a later run. SVG images are always kept remote, since a published SVG would be a script running on the site's own origin.
+
+Each run restores the media files of the published branch before downloading, so only images that have not been seen before are fetched, and files no longer referenced by any entry are removed. Schedule only one run at a time (a workflow `concurrency` group) because the publish step force pushes the whole site.
+
 ## Configurations
 
 This action can be configured to use a custom domain and different types of storage. Here are the available configuration options:


### PR DESCRIPTION
## Summary

Feed entry images pointed at the publisher's origin, where hotlink protection, `Cross-Origin-Resource-Policy` and mixed content all break them on the published static site. This downloads them while the feeds are loaded and publishes them under `/media/<sha256(url)>.<ext>` alongside the site.

This is a second attempt at #739, which was reverted in #744. The two things that made the first version painful are addressed:

- **Failed downloads no longer remove the image.** The entry keeps the original URL and renders it with `referrerpolicy="no-referrer"`, so a publisher that is temporarily unavailable is picked up again on a later run instead of disappearing from the entry.
- **Media is no longer re-downloaded every run.** Each run restores the media of the published branch first, so only images that have not been seen before are fetched. The restore fetches into the workspace repository rather than a throwaway clone, so the publish step can still send a thin pack.

Media no longer referenced by any entry is removed at the end of the run, in both `files` and `sqlite` mode, so the directory plateaus instead of growing.

## Notable decisions

- **Only `<img>` `src`/`srcset` are rewritten.** Anchors keep their original URLs; they open in a new tab, so there is nothing to fix there. The first version rewrote image-like `<a href>` too.
- **SVG is never localized.** A published SVG would be script running on the site's own origin, and GitHub Pages offers no CSP to contain it. SVGs stay remote with `no-referrer`.
- **No `jsdom`.** `sanitize-html` transforms are synchronous, so URLs are collected in one pass, downloaded, then rewritten in a second pass with the same sanitizer options the content was stored with. No new dependencies.
- Downloads are capped at 20 MB (enforced while streaming, since `content-length` can be absent or wrong), time out after 15s, run at most 4 at a time and 2 per host, and are rejected unless the response is a supported image type.

## Testing

- `yarn test` — 20 new tests in `action/feeds/media.test.ts` and 3 in `lib/media.test.ts`, all with stubbed fetch and no network. The one pre-existing failure (`#getGithubActionPath resolves action repository root path`) asserts the checkout directory is named `feeds` and fails the same way on `main` from a worktree.
- `yarn loadFile` against `feeds.opml`: 117 images downloaded, 118 local references, and the single 503 kept its remote URL. A second run re-downloaded nothing, healed the 503, and a planted orphan file was collected.
- `yarn build` and served the export, with and without a `basePath`: all 25 images of an entry load from `/media/...` (`/feeds/media/...` under a base path) carrying `referrerpolicy="no-referrer"`.
- `restorePublishedMedia` exercised against a local git remote for the restore, first-run (no `media` in the tree) and missing-branch cases, confirming the workspace is left clean in each.

Bumps to 4.3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)