### PR TITLE
Resolve relative URLs in entry content against the source site

### DIFF
--- a/action/feeds/images.test.ts
+++ b/action/feeds/images.test.ts
@@ -25,9 +25,6 @@ test('svg is downloadable by neither, which keeps it off our origin', (t) => {
   t.false(hasDownloadableImageExtension('https://e.example/x.svg'))
   t.is(normalizeImageExtension('.svg'), null)
   t.is(extensionFromContentType('image/svg+xml'), null)
-  // The guard that matters is the routing, not the map's current contents: an
-  // svg entry added to the map still comes back null.
-  t.is(normalizeImageExtension(CONTENT_TYPE_EXTENSIONS['image/svg+xml']), null)
 })
 
 test('#hasDownloadableImageExtension reads the path, not the whole URL', (t) => {

--- a/action/feeds/images.test.ts
+++ b/action/feeds/images.test.ts
@@ -4,27 +4,16 @@ import {
   hasDownloadableImageExtension,
   normalizeImageExtension
 } from './images'
-import { extensionFromContentType } from './media'
-
-const DOWNLOADABLE_CONTENT_TYPES = [
-  'image/avif',
-  'image/gif',
-  'image/heic',
-  'image/heif',
-  'image/jpeg',
-  'image/jxl',
-  'image/png',
-  'image/tiff',
-  'image/webp'
-]
+import { CONTENT_TYPE_EXTENSIONS, extensionFromContentType } from './media'
 
 test('every content type the store writes also picks the media base for links', (t) => {
-  // The link and the image have to agree on a base or the link stops matching
-  // the copy on disk, so an extension the store can write has to be one the
-  // resolver treats as media.
-  for (const contentType of DOWNLOADABLE_CONTENT_TYPES) {
-    const extension = extensionFromContentType(contentType)
-    t.truthy(extension, contentType)
+  // Driven off the map itself rather than a copy of it, so adding a content
+  // type without adding its extension to images.ts fails here instead of
+  // silently refusing every download of that format.
+  for (const [contentType, extension] of Object.entries(
+    CONTENT_TYPE_EXTENSIONS
+  )) {
+    t.is(extensionFromContentType(contentType), extension, contentType)
     t.true(
       hasDownloadableImageExtension(`https://e.example/x${extension}`),
       `${contentType} writes ${extension}, which links do not resolve as media`
@@ -36,6 +25,9 @@ test('svg is downloadable by neither, which keeps it off our origin', (t) => {
   t.false(hasDownloadableImageExtension('https://e.example/x.svg'))
   t.is(normalizeImageExtension('.svg'), null)
   t.is(extensionFromContentType('image/svg+xml'), null)
+  // The guard that matters is the routing, not the map's current contents: an
+  // svg entry added to the map still comes back null.
+  t.is(normalizeImageExtension(CONTENT_TYPE_EXTENSIONS['image/svg+xml']), null)
 })
 
 test('#hasDownloadableImageExtension reads the path, not the whole URL', (t) => {

--- a/action/feeds/images.test.ts
+++ b/action/feeds/images.test.ts
@@ -1,0 +1,49 @@
+import test from 'ava'
+
+import {
+  hasDownloadableImageExtension,
+  normalizeImageExtension
+} from './images'
+import { extensionFromContentType } from './media'
+
+const DOWNLOADABLE_CONTENT_TYPES = [
+  'image/avif',
+  'image/gif',
+  'image/heic',
+  'image/heif',
+  'image/jpeg',
+  'image/jxl',
+  'image/png',
+  'image/tiff',
+  'image/webp'
+]
+
+test('every content type the store writes also picks the media base for links', (t) => {
+  // The link and the image have to agree on a base or the link stops matching
+  // the copy on disk, so an extension the store can write has to be one the
+  // resolver treats as media.
+  for (const contentType of DOWNLOADABLE_CONTENT_TYPES) {
+    const extension = extensionFromContentType(contentType)
+    t.truthy(extension, contentType)
+    t.true(
+      hasDownloadableImageExtension(`https://e.example/x${extension}`),
+      `${contentType} writes ${extension}, which links do not resolve as media`
+    )
+  }
+})
+
+test('svg is downloadable by neither, which keeps it off our origin', (t) => {
+  t.false(hasDownloadableImageExtension('https://e.example/x.svg'))
+  t.is(normalizeImageExtension('.svg'), null)
+  t.is(extensionFromContentType('image/svg+xml'), null)
+})
+
+test('#hasDownloadableImageExtension reads the path, not the whole URL', (t) => {
+  t.true(hasDownloadableImageExtension('https://e.example/x.PNG'))
+  t.true(hasDownloadableImageExtension('https://e.example/x.png?v=2#f'))
+  t.false(
+    hasDownloadableImageExtension('https://e.example/download?file=x.png')
+  )
+  t.false(hasDownloadableImageExtension('https://e.example/v1.2/page'))
+  t.false(hasDownloadableImageExtension('https://e.example/noextension'))
+})

--- a/action/feeds/images.ts
+++ b/action/feeds/images.ts
@@ -32,8 +32,11 @@ export function normalizeImageExtension(extension?: string | null) {
 }
 
 /**
- * Whether a URL points at an image the action may download, which is what makes
- * a link to it resolve against the same base as the image itself.
+ * Whether a URL's extension names an image the action may download, which is
+ * what makes a link to it resolve against the same base as the image itself.
+ *
+ * Extension-less URLs the store fetches by content type are not covered, so a
+ * link to one is not aligned with its image and simply never localizes.
  */
 export function hasDownloadableImageExtension(url: string) {
   const pathOnly = url.trim().split('#')[0].split('?')[0]

--- a/action/feeds/images.ts
+++ b/action/feeds/images.ts
@@ -35,8 +35,11 @@ export function normalizeImageExtension(extension?: string | null) {
  * Whether a URL's extension names an image the action may download, which is
  * what makes a link to it resolve against the same base as the image itself.
  *
- * Extension-less URLs the store fetches by content type are not covered, so a
- * link to one is not aligned with its image and simply never localizes.
+ * Extension-less URLs the store fetches by content type are not covered here,
+ * so a link to one aligns with its image only when both already resolve to the
+ * same absolute URL -- which they do when the URL is absolute or root-relative.
+ * A path-relative one takes the entry base while the image takes the site base,
+ * and that pair never localizes.
  */
 export function hasDownloadableImageExtension(url: string) {
   const pathOnly = url.trim().split('#')[0].split('?')[0]

--- a/action/feeds/images.ts
+++ b/action/feeds/images.ts
@@ -1,0 +1,43 @@
+/**
+ * Which images the action may download and serve from our own origin.
+ *
+ * Two modules need this and neither can own it: media.ts downloads by it, and
+ * parsers.ts picks a link's base by it -- a link to a downloadable image has to
+ * resolve exactly like the image itself or it stops matching the copy on disk
+ * and silently keeps hotlinking. media.ts already imports parsers.ts, so the
+ * list lives here rather than in either of them, and there is only ever one.
+ *
+ * SVG is deliberately absent: a localized file is navigable on the published
+ * origin, and a feed could otherwise plant a scripted SVG there.
+ */
+const DOWNLOADABLE_IMAGE_EXTENSIONS = new Set([
+  '.avif',
+  '.gif',
+  '.heic',
+  '.heif',
+  '.jpeg',
+  '.jpg',
+  '.jxl',
+  '.png',
+  '.tif',
+  '.tiff',
+  '.webp'
+])
+
+export function normalizeImageExtension(extension?: string | null) {
+  if (!extension) return null
+  const normalized = extension.trim().toLowerCase()
+  if (!DOWNLOADABLE_IMAGE_EXTENSIONS.has(normalized)) return null
+  return normalized
+}
+
+/**
+ * Whether a URL points at an image the action may download, which is what makes
+ * a link to it resolve against the same base as the image itself.
+ */
+export function hasDownloadableImageExtension(url: string) {
+  const pathOnly = url.trim().split('#')[0].split('?')[0]
+  const dot = pathOnly.lastIndexOf('.')
+  if (dot < 0) return false
+  return DOWNLOADABLE_IMAGE_EXTENSIONS.has(pathOnly.slice(dot).toLowerCase())
+}

--- a/action/feeds/media.test.ts
+++ b/action/feeds/media.test.ts
@@ -14,7 +14,7 @@ import {
   getMediaDirectory,
   rewriteLocalizedUrls
 } from './media'
-import type { Site } from './parsers'
+import { parseRss, type Site } from './parsers'
 
 async function createMediaDirectory(prefix: string) {
   const rootPath = await fs.mkdtemp(path.join(os.tmpdir(), prefix))
@@ -90,10 +90,13 @@ test('#localizeSite downloads images and rewrites src and srcset', async (t) => 
       `href="/media/${mediaHash('https://example.com/images/one.png')}.png"`
     )
   )
-  t.deepEqual(await listMediaFiles(mediaDirectory), [
-    `${mediaHash('https://cdn.example.com/two.webp')}.webp`,
-    `${mediaHash('https://example.com/images/one.png')}.png`
-  ].sort())
+  t.deepEqual(
+    await listMediaFiles(mediaDirectory),
+    [
+      `${mediaHash('https://cdn.example.com/two.webp')}.webp`,
+      `${mediaHash('https://example.com/images/one.png')}.png`
+    ].sort()
+  )
   t.is(fetchStub.callCount, 2)
 })
 
@@ -108,7 +111,9 @@ test('#localizeSite downloads each url once across entries', async (t) => {
       '<img src="https://example.com/a.png" srcset="https://example.com/a.png 2x" />'
     )
   )
-  await store.localizeSite(createSite('<img src="https://example.com/a.png" />'))
+  await store.localizeSite(
+    createSite('<img src="https://example.com/a.png" />')
+  )
 
   t.is(fetchStub.callCount, 1)
 })
@@ -166,6 +171,43 @@ test('#localizeSite writes files the reference walker still recognises', async (
 
   await cleanupUnusedMediaFiles(mediaDirectory, referenced)
   t.deepEqual(await listMediaFiles(mediaDirectory), onDisk)
+})
+
+test('#localizeSite localizes a relative lightbox href with its image', async (t) => {
+  const mediaDirectory = await createMediaDirectory('feeds-media-relative-')
+  const fetchStub = sinon.stub().resolves(imageResponse())
+  // Real feeds publish relative URLs; the parser and the store only agree
+  // because the link and the image resolve to the same absolute URL.
+  const site = parseRss('Test Feed', {
+    rss: {
+      channel: [
+        {
+          link: ['https://site.example/'],
+          description: ['d'],
+          lastBuildDate: ['2026-01-01T00:00:00Z'],
+          generator: ['t'],
+          item: [
+            {
+              title: ['E'],
+              link: ['https://feed.example/posts/entry-1'],
+              pubDate: ['2026-01-01T00:00:00Z'],
+              description: [
+                '<a href="/images/one.png"><img src="/images/one.png" /></a>'
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  })
+
+  const store = createMediaStore({ mediaDirectory, fetch: fetchStub as any })
+  const localized = await store.localizeSite(site)
+
+  const localPath = `/media/${mediaHash('https://site.example/images/one.png')}.png`
+  t.true(localized.entries[0].content.includes(`href="${localPath}"`))
+  t.true(localized.entries[0].content.includes(`src="${localPath}"`))
+  t.is(fetchStub.callCount, 1)
 })
 
 test('#localizeSite keeps the remote url when the download fails', async (t) => {
@@ -231,14 +273,12 @@ test('#localizeSite leaves data uri images untouched', async (t) => {
 
 test('#localizeSite keeps the remote url for non image responses', async (t) => {
   const mediaDirectory = await createMediaDirectory('feeds-media-html-')
-  const fetchStub = sinon
-    .stub()
-    .resolves(
-      new Response('<html>blocked</html>', {
-        status: 200,
-        headers: { 'content-type': 'text/html' }
-      })
-    )
+  const fetchStub = sinon.stub().resolves(
+    new Response('<html>blocked</html>', {
+      status: 200,
+      headers: { 'content-type': 'text/html' }
+    })
+  )
 
   const store = createMediaStore({ mediaDirectory, fetch: fetchStub as any })
   const localized = await store.localizeSite(
@@ -346,7 +386,9 @@ test('#localizeSite rejects oversized media without a content length', async (t)
 
   t.true(sentChunks <= 22, 'stops reading once the cap is exceeded')
   t.true(
-    localized.entries[0].content.includes('src="https://example.com/stream.png"')
+    localized.entries[0].content.includes(
+      'src="https://example.com/stream.png"'
+    )
   )
   t.deepEqual(await listMediaFiles(mediaDirectory), [])
 })
@@ -419,10 +461,10 @@ test('#collectDownloadableMediaUrls returns absolute image urls only', (t) => {
       '<img src="/media/local.png" /><a href="https://example.com/c.png">link</a>'
   )
 
-  t.deepEqual(
-    [...urls].sort(),
-    ['https://example.com/a.png', 'https://example.com/b.png']
-  )
+  t.deepEqual([...urls].sort(), [
+    'https://example.com/a.png',
+    'https://example.com/b.png'
+  ])
 })
 
 test('#rewriteLocalizedUrls only replaces mapped urls', (t) => {
@@ -469,7 +511,9 @@ test('#collectReferencedMediaFromContents returns every local media reference', 
 })
 
 test('#collectReferencedMediaFromEntryDirectory reads entry files', async (t) => {
-  const rootPath = await fs.mkdtemp(path.join(os.tmpdir(), 'feeds-media-entry-'))
+  const rootPath = await fs.mkdtemp(
+    path.join(os.tmpdir(), 'feeds-media-entry-')
+  )
   const a = `${'a'.repeat(64)}.jpg`
   await fs.writeFile(
     path.join(rootPath, 'one.json'),

--- a/action/feeds/media.test.ts
+++ b/action/feeds/media.test.ts
@@ -7,7 +7,7 @@ import sinon from 'sinon'
 
 import {
   cleanupUnusedMediaFiles,
-  collectImageUrls,
+  collectDownloadableMediaUrls,
   collectReferencedMediaFromContents,
   collectReferencedMediaFromEntryDirectory,
   createMediaStore,
@@ -265,6 +265,16 @@ test('#localizeSite names files from the content type when the url has no extens
   t.true(
     localized.entries[0].content.includes(`src="/media/${mediaHash(url)}.webp"`)
   )
+  // Names built from the content type have to survive the walker too, or
+  // cleanup would delete what this path just downloaded.
+  t.deepEqual(
+    [
+      ...collectReferencedMediaFromContents(
+        localized.entries.map((entry) => entry.content)
+      )
+    ],
+    [`${mediaHash(url)}.webp`]
+  )
 })
 
 test('#localizeSite skips svg images', async (t) => {
@@ -403,8 +413,8 @@ test('#localizeSite stops downloading after the deadline', async (t) => {
   )
 })
 
-test('#collectImageUrls returns absolute image urls only', (t) => {
-  const urls = collectImageUrls(
+test('#collectDownloadableMediaUrls returns absolute image urls only', (t) => {
+  const urls = collectDownloadableMediaUrls(
     '<img src="https://example.com/a.png" srcset="https://example.com/b.png 2x, data:image/gif;base64,AAA 3x" />' +
       '<img src="/media/local.png" /><a href="https://example.com/c.png">link</a>'
   )

--- a/action/feeds/media.test.ts
+++ b/action/feeds/media.test.ts
@@ -84,7 +84,8 @@ test('#localizeSite downloads images and rewrites src and srcset', async (t) => 
     content,
     /srcset="\/media\/[a-f0-9]{64}\.png 1x, \/media\/[a-f0-9]{64}\.webp 2x"/
   )
-  t.true(content.includes('href="https://example.com/images/one.png"'))
+  // A lightbox link to an image we downloaded points at the local copy too.
+  t.regex(content, /href="\/media\/[a-f0-9]{64}\.png"/)
   t.deepEqual(await listMediaFiles(mediaDirectory), [
     `${mediaHash('https://cdn.example.com/two.webp')}.webp`,
     `${mediaHash('https://example.com/images/one.png')}.png`
@@ -105,6 +106,26 @@ test('#localizeSite downloads each url once across entries', async (t) => {
   )
   await store.localizeSite(createSite('<img src="https://example.com/a.png" />'))
 
+  t.is(fetchStub.callCount, 1)
+})
+
+test('#localizeSite localizes a link to an image another entry displays', async (t) => {
+  const mediaDirectory = await createMediaDirectory('feeds-media-crossentry-')
+  const fetchStub = sinon.stub().resolves(imageResponse())
+
+  const store = createMediaStore({ mediaDirectory, fetch: fetchStub as any })
+  const localized = await store.localizeSite(
+    createSite(
+      '<a href="https://example.com/a.png">Full size</a>',
+      '<img src="https://example.com/a.png" />'
+    )
+  )
+
+  // Images are collected across the whole site, so the entry that only links
+  // to one still reaches the local copy.
+  const localPath = `/media/${mediaHash('https://example.com/a.png')}.png`
+  t.true(localized.entries[0].content.includes(`href="${localPath}"`))
+  t.true(localized.entries[1].content.includes(`src="${localPath}"`))
   t.is(fetchStub.callCount, 1)
 })
 
@@ -367,13 +388,28 @@ test('#rewriteImageUrls only replaces mapped urls', (t) => {
   )
 })
 
-test('#collectReferencedMediaFromContents returns local image references', (t) => {
+test('#rewriteImageUrls sends links to a cached image to the local copy', (t) => {
+  const content = rewriteImageUrls(
+    '<a href="https://example.com/a.png"><img src="https://example.com/a.png" /></a>' +
+      '<a href="https://example.com/uncached.png">Full size</a>',
+    new Map([['https://example.com/a.png', '/media/a.png']])
+  )
+
+  t.true(content.includes('href="/media/a.png"'))
+  t.true(content.includes('src="/media/a.png"'))
+  // Nothing was downloaded for this one, so it keeps pointing at the origin.
+  t.true(content.includes('href="https://example.com/uncached.png"'))
+})
+
+test('#collectReferencedMediaFromContents returns every local media reference', (t) => {
   const media = collectReferencedMediaFromContents([
     '<p><img src="/media/a.jpg" srcset="/media/b.webp 1x, /media/c.png 2x" /><a href="/media/d.gif">Download</a></p>',
     '<img src="https://example.com/remote.png" />'
   ])
 
-  t.deepEqual([...media].sort(), ['a.jpg', 'b.webp', 'c.png'])
+  // Links count as well as images: a lightbox href is rewritten to the local
+  // copy too, so cleanup would otherwise delete a file still in use.
+  t.deepEqual([...media].sort(), ['a.jpg', 'b.webp', 'c.png', 'd.gif'])
 })
 
 test('#collectReferencedMediaFromEntryDirectory reads entry files', async (t) => {

--- a/action/feeds/media.test.ts
+++ b/action/feeds/media.test.ts
@@ -173,6 +173,30 @@ test('#localizeSite writes files the reference walker still recognises', async (
   t.deepEqual(await listMediaFiles(mediaDirectory), onDisk)
 })
 
+test('#cleanupUnusedMediaFiles keeps a file only a link still points at', async (t) => {
+  const mediaDirectory = await createMediaDirectory('feeds-media-linkonly-')
+  const fetchStub = sinon.stub().resolves(imageResponse())
+
+  const store = createMediaStore({ mediaDirectory, fetch: fetchStub as any })
+  const localized = await store.localizeSite(
+    createSite(
+      '<img src="https://example.com/a.png" />',
+      '<a href="https://example.com/a.png">Full size</a>'
+    )
+  )
+
+  // The entry that displayed the image is gone, and only the link remains --
+  // which is the case that decides whether counting links actually protects
+  // the file from being deleted.
+  const onDisk = await listMediaFiles(mediaDirectory)
+  t.true(onDisk.length > 0)
+  await cleanupUnusedMediaFiles(
+    mediaDirectory,
+    collectReferencedMediaFromContents([localized.entries[1].content])
+  )
+  t.deepEqual(await listMediaFiles(mediaDirectory), onDisk)
+})
+
 test('#localizeSite localizes a relative lightbox href with its image', async (t) => {
   const mediaDirectory = await createMediaDirectory('feeds-media-relative-')
   const fetchStub = sinon.stub().resolves(imageResponse())

--- a/action/feeds/media.test.ts
+++ b/action/feeds/media.test.ts
@@ -85,7 +85,11 @@ test('#localizeSite downloads images and rewrites src and srcset', async (t) => 
     /srcset="\/media\/[a-f0-9]{64}\.png 1x, \/media\/[a-f0-9]{64}\.webp 2x"/
   )
   // A lightbox link to an image we downloaded points at the local copy too.
-  t.regex(content, /href="\/media\/[a-f0-9]{64}\.png"/)
+  t.true(
+    content.includes(
+      `href="/media/${mediaHash('https://example.com/images/one.png')}.png"`
+    )
+  )
   t.deepEqual(await listMediaFiles(mediaDirectory), [
     `${mediaHash('https://cdn.example.com/two.webp')}.webp`,
     `${mediaHash('https://example.com/images/one.png')}.png`
@@ -117,7 +121,8 @@ test('#localizeSite localizes a link to an image another entry displays', async 
   const localized = await store.localizeSite(
     createSite(
       '<a href="https://example.com/a.png">Full size</a>',
-      '<img src="https://example.com/a.png" />'
+      '<img src="https://example.com/a.png" />',
+      '<a href="https://example.com/link-only.png">Never shown</a>'
     )
   )
 
@@ -126,7 +131,17 @@ test('#localizeSite localizes a link to an image another entry displays', async 
   const localPath = `/media/${mediaHash('https://example.com/a.png')}.png`
   t.true(localized.entries[0].content.includes(`href="${localPath}"`))
   t.true(localized.entries[1].content.includes(`src="${localPath}"`))
+  // An image nothing displays is never downloaded, so the link that is its
+  // only reference keeps pointing at the origin.
+  t.true(
+    localized.entries[2].content.includes(
+      'href="https://example.com/link-only.png"'
+    )
+  )
   t.is(fetchStub.callCount, 1)
+  t.deepEqual(await listMediaFiles(mediaDirectory), [
+    `${mediaHash('https://example.com/a.png')}.png`
+  ])
 })
 
 test('#localizeSite keeps the remote url when the download fails', async (t) => {

--- a/action/feeds/media.test.ts
+++ b/action/feeds/media.test.ts
@@ -12,7 +12,7 @@ import {
   collectReferencedMediaFromEntryDirectory,
   createMediaStore,
   getMediaDirectory,
-  rewriteImageUrls
+  rewriteLocalizedUrls
 } from './media'
 import type { Site } from './parsers'
 
@@ -391,8 +391,8 @@ test('#collectImageUrls returns absolute image urls only', (t) => {
   )
 })
 
-test('#rewriteImageUrls only replaces mapped urls', (t) => {
-  const content = rewriteImageUrls(
+test('#rewriteLocalizedUrls only replaces mapped urls', (t) => {
+  const content = rewriteLocalizedUrls(
     '<img src="https://example.com/a.png" srcset="https://example.com/a.png 1x, https://example.com/b.png 2x" />',
     new Map([['https://example.com/a.png', '/media/a.png']])
   )
@@ -403,8 +403,8 @@ test('#rewriteImageUrls only replaces mapped urls', (t) => {
   )
 })
 
-test('#rewriteImageUrls sends links to a cached image to the local copy', (t) => {
-  const content = rewriteImageUrls(
+test('#rewriteLocalizedUrls sends links to a cached image to the local copy', (t) => {
+  const content = rewriteLocalizedUrls(
     '<a href="https://example.com/a.png"><img src="https://example.com/a.png" /></a>' +
       '<a href="https://example.com/uncached.png">Full size</a>',
     new Map([['https://example.com/a.png', '/media/a.png']])
@@ -417,26 +417,34 @@ test('#rewriteImageUrls sends links to a cached image to the local copy', (t) =>
 })
 
 test('#collectReferencedMediaFromContents returns every local media reference', (t) => {
+  const a = `${'a'.repeat(64)}.jpg`
+  const b = `${'b'.repeat(64)}.webp`
+  const c = `${'c'.repeat(64)}.png`
+  const d = `${'d'.repeat(64)}.gif`
   const media = collectReferencedMediaFromContents([
-    '<p><img src="/media/a.jpg" srcset="/media/b.webp 1x, /media/c.png 2x" /><a href="/media/d.gif">Download</a></p>',
-    '<img src="https://example.com/remote.png" />'
+    `<p><img src="/media/${a}" srcset="/media/${b} 1x, /media/${c} 2x" /><a href="/media/${d}">Download</a></p>`,
+    '<img src="https://example.com/remote.png" />',
+    // A feed's own /media path is not a file we wrote, so it must not be
+    // mistaken for one and keep an unrelated file alive.
+    '<img src="/media/2019/photo.jpg" />'
   ])
 
   // Links count as well as images: a lightbox href is rewritten to the local
   // copy too, so cleanup would otherwise delete a file still in use.
-  t.deepEqual([...media].sort(), ['a.jpg', 'b.webp', 'c.png', 'd.gif'])
+  t.deepEqual([...media].sort(), [a, b, c, d].sort())
 })
 
 test('#collectReferencedMediaFromEntryDirectory reads entry files', async (t) => {
   const rootPath = await fs.mkdtemp(path.join(os.tmpdir(), 'feeds-media-entry-'))
+  const a = `${'a'.repeat(64)}.jpg`
   await fs.writeFile(
     path.join(rootPath, 'one.json'),
-    JSON.stringify({ content: '<img src="/media/a.jpg" />' })
+    JSON.stringify({ content: `<img src="/media/${a}" />` })
   )
   await fs.writeFile(path.join(rootPath, 'broken.json'), 'not json')
 
   const media = await collectReferencedMediaFromEntryDirectory(rootPath)
-  t.deepEqual([...media], ['a.jpg'])
+  t.deepEqual([...media], [a])
 
   const missing = await collectReferencedMediaFromEntryDirectory(
     path.join(rootPath, 'missing')

--- a/action/feeds/media.test.ts
+++ b/action/feeds/media.test.ts
@@ -144,6 +144,30 @@ test('#localizeSite localizes a link to an image another entry displays', async 
   ])
 })
 
+test('#localizeSite writes files the reference walker still recognises', async (t) => {
+  const mediaDirectory = await createMediaDirectory('feeds-media-roundtrip-')
+  const fetchStub = sinon.stub().resolves(imageResponse('x', 'image/jpeg'))
+
+  const store = createMediaStore({ mediaDirectory, fetch: fetchStub as any })
+  const localized = await store.localizeSite(
+    createSite(
+      '<a href="https://example.com/a.jpeg"><img src="https://example.com/a.jpeg" srcset="https://example.com/a.jpeg 1x" /></a>'
+    )
+  )
+
+  // The name the store writes has to be the name cleanup keeps, or a run would
+  // delete the images the previous one downloaded.
+  const onDisk = await listMediaFiles(mediaDirectory)
+  t.true(onDisk.length > 0)
+  const referenced = collectReferencedMediaFromContents(
+    localized.entries.map((entry) => entry.content)
+  )
+  t.deepEqual([...referenced].sort(), onDisk)
+
+  await cleanupUnusedMediaFiles(mediaDirectory, referenced)
+  t.deepEqual(await listMediaFiles(mediaDirectory), onDisk)
+})
+
 test('#localizeSite keeps the remote url when the download fails', async (t) => {
   const mediaDirectory = await createMediaDirectory('feeds-media-failure-')
   const fetchStub = sinon.stub().resolves(new Response('nope', { status: 403 }))

--- a/action/feeds/media.ts
+++ b/action/feeds/media.ts
@@ -22,8 +22,9 @@ const MAX_CONCURRENT_DOWNLOADS_PER_HOST = 2
 const LOCALIZE_DEADLINE_MS = 10 * 60 * 1000
 
 // Which content types name a downloadable image. The extensions themselves
-// live in images.ts, which the link resolver reads too; keep this map a subset
-// of that list. SVG is absent from both, see images.ts for why.
+// live in images.ts, which the link resolver reads too, and every value here
+// goes back through it -- so an entry that is not downloadable simply never
+// resolves. SVG is absent from both, see images.ts for why.
 const CONTENT_TYPE_EXTENSIONS: Record<string, string> = {
   'image/avif': '.avif',
   'image/gif': '.gif',
@@ -59,7 +60,10 @@ function createMediaHash(input: string) {
 export function extensionFromContentType(contentType?: string | null) {
   if (!contentType) return null
   const normalizedType = contentType.split(';')[0].trim().toLowerCase()
-  return CONTENT_TYPE_EXTENSIONS[normalizedType] ?? null
+  // Routed through images.ts rather than returned straight from the map, so an
+  // entry added here that is not downloadable -- svg above all -- becomes a
+  // refused download instead of a file served from our own origin.
+  return normalizeImageExtension(CONTENT_TYPE_EXTENSIONS[normalizedType])
 }
 
 export function extensionFromUrl(url: string) {

--- a/action/feeds/media.ts
+++ b/action/feeds/media.ts
@@ -128,6 +128,10 @@ function extractMediaFileNameFromLocalPath(value: string) {
  * page loads or a link it points at. sanitize-html transforms are synchronous,
  * so downloading happens between a collect pass and a rewrite pass instead of
  * inside the transform itself.
+ *
+ * Expects content that is already sanitized, which is all a feed ever produces
+ * here: the transform runs before tags are discarded, so on raw HTML it would
+ * also visit URLs on tags that never survive to render.
  */
 function walkContentUrls(
   content: string,
@@ -150,9 +154,9 @@ function walkContentUrls(
 export function collectImageUrls(content: string) {
   const urls = new Set<string>()
   if (!content) return urls
-  // Only media the entry actually displays is worth the download. A link to an
-  // image is followed by hand, so it is rewritten when the image happens to be
-  // cached already but never pulls one down on its own.
+  // Only media an entry actually displays is worth the download. A link to an
+  // image is followed by hand, so it is rewritten when some entry of the same
+  // site displays that image, but never pulls one down on its own.
   walkContentUrls(content, (url, target) => {
     if (target === 'media' && isDownloadableUrl(url)) urls.add(url)
   })

--- a/action/feeds/media.ts
+++ b/action/feeds/media.ts
@@ -12,11 +12,8 @@ import {
   type UrlTarget
 } from '../../lib/media'
 import { USER_AGENT } from './http'
-import {
-  ENTRY_CONTENT_SANITIZE_OPTIONS,
-  normalizeImageExtension,
-  type Site
-} from './parsers'
+import { normalizeImageExtension } from './images'
+import { ENTRY_CONTENT_SANITIZE_OPTIONS, type Site } from './parsers'
 
 const MAX_MEDIA_BYTES = 20 * 1024 * 1024
 const DOWNLOAD_TIMEOUT_MS = 15_000
@@ -24,11 +21,9 @@ const MAX_CONCURRENT_DOWNLOADS = 4
 const MAX_CONCURRENT_DOWNLOADS_PER_HOST = 2
 const LOCALIZE_DEADLINE_MS = 10 * 60 * 1000
 
-// Which images may be downloaded and served from our own origin. The list of
-// extensions lives in parsers.ts, where the link resolver reads it too. SVG is
-// deliberately absent from that list and from the map below: a localized file
-// is navigable on the published origin, and a feed could otherwise plant a
-// scripted SVG there.
+// Which content types name a downloadable image. The extensions themselves
+// live in images.ts, which the link resolver reads too; keep this map a subset
+// of that list. SVG is absent from both, see images.ts for why.
 const CONTENT_TYPE_EXTENSIONS: Record<string, string> = {
   'image/avif': '.avif',
   'image/gif': '.gif',
@@ -311,7 +306,9 @@ export function createMediaStore({
   async function localizeSite(site: Site) {
     const urls = new Set<string>()
     for (const entry of site.entries) {
-      for (const url of collectDownloadableMediaUrls(entry.content)) urls.add(url)
+      for (const url of collectDownloadableMediaUrls(entry.content)) {
+        urls.add(url)
+      }
     }
 
     const replacements = new Map<string, string>()

--- a/action/feeds/media.ts
+++ b/action/feeds/media.ts
@@ -7,7 +7,9 @@ import sanitizeHtml from 'sanitize-html'
 
 import {
   LOCAL_MEDIA_PATH,
+  localMediaFileName,
   mapUrlAttributes,
+  normalizeImageExtension,
   type UrlTarget
 } from '../../lib/media'
 import { USER_AGENT } from './http'
@@ -19,25 +21,11 @@ const MAX_CONCURRENT_DOWNLOADS = 4
 const MAX_CONCURRENT_DOWNLOADS_PER_HOST = 2
 const LOCALIZE_DEADLINE_MS = 10 * 60 * 1000
 
-// Which images may be downloaded and served from our own origin. SVG is
-// deliberately absent from both maps: a localized file is navigable on the
-// published origin, and a feed could otherwise plant a scripted SVG there.
-// parsers.ts keeps a wider list to decide how a link resolves; do not merge
-// the two.
-const KNOWN_IMAGE_EXTENSIONS = new Set([
-  '.avif',
-  '.gif',
-  '.heic',
-  '.heif',
-  '.jpeg',
-  '.jpg',
-  '.jxl',
-  '.png',
-  '.tif',
-  '.tiff',
-  '.webp'
-])
-
+// Which images may be downloaded and served from our own origin. The list of
+// extensions lives in lib/media.ts, where the link resolver reads it too. SVG
+// is deliberately absent from that list and from the map below: a localized
+// file is navigable on the published origin, and a feed could otherwise plant
+// a scripted SVG there.
 const CONTENT_TYPE_EXTENSIONS: Record<string, string> = {
   'image/avif': '.avif',
   'image/gif': '.gif',
@@ -68,13 +56,6 @@ export function getMediaDirectory(githubActionPath: string) {
 
 function createMediaHash(input: string) {
   return crypto.createHash('sha256').update(input).digest('hex')
-}
-
-function normalizeImageExtension(extension?: string | null) {
-  if (!extension) return null
-  const normalized = extension.trim().toLowerCase()
-  if (!KNOWN_IMAGE_EXTENSIONS.has(normalized)) return null
-  return normalized
 }
 
 export function extensionFromContentType(contentType?: string | null) {
@@ -108,18 +89,6 @@ function isDownloadableUrl(url: string) {
   } catch {
     return false
   }
-}
-
-function extractMediaFileNameFromLocalPath(value: string) {
-  const prefix = `${LOCAL_MEDIA_PATH}/`
-  const trimmed = value.trim()
-  if (!trimmed.startsWith(prefix)) return null
-  const fileName = trimmed
-    .substring(prefix.length)
-    .split('?')[0]
-    .split('#')[0]
-    .trim()
-  return fileName || null
 }
 
 /**
@@ -168,7 +137,7 @@ export function collectImageUrls(content: string) {
  * images, so a lightbox href to an image the store downloaded stops hotlinking
  * the origin -- the counterpart of collectImageUrls, which is media-only.
  */
-export function rewriteImageUrls(
+export function rewriteLocalizedUrls(
   content: string,
   replacements: Map<string, string>
 ) {
@@ -353,7 +322,7 @@ export function createMediaStore({
       ...site,
       entries: site.entries.map((entry) => ({
         ...entry,
-        content: rewriteImageUrls(entry.content, replacements)
+        content: rewriteLocalizedUrls(entry.content, replacements)
       }))
     }
   }
@@ -363,7 +332,7 @@ export function createMediaStore({
 
 /**
  * Every downloaded file the content still points at, so cleanup keeps it. Links
- * count as well as images: rewriteImageUrls sends a lightbox href to the local
+ * count as well as images: rewriteLocalizedUrls sends a lightbox href to the local
  * copy too, and deleting a file that is still referenced is worse than keeping
  * one that is not.
  */
@@ -371,7 +340,7 @@ export function extractLocalMediaReferences(content: string) {
   const references = new Set<string>()
   if (!content) return references
   walkContentUrls(content, (url) => {
-    const mediaFile = extractMediaFileNameFromLocalPath(url)
+    const mediaFile = localMediaFileName(url)
     if (mediaFile) references.add(mediaFile)
   })
   return references

--- a/action/feeds/media.ts
+++ b/action/feeds/media.ts
@@ -123,7 +123,7 @@ function walkContentUrls(
   })
 }
 
-export function collectImageUrls(content: string) {
+export function collectDownloadableMediaUrls(content: string) {
   const urls = new Set<string>()
   if (!content) return urls
   // Only media an entry actually displays is worth the download. A link to an
@@ -138,7 +138,8 @@ export function collectImageUrls(content: string) {
 /**
  * Swaps every downloaded URL for its local path. This covers links as well as
  * images, so a lightbox href to an image the store downloaded stops hotlinking
- * the origin -- the counterpart of collectImageUrls, which is media-only.
+ * the origin. Deliberately not the mirror of collectDownloadableMediaUrls,
+ * which only ever collects media: a link is rewritten but never downloaded for.
  */
 export function rewriteLocalizedUrls(
   content: string,
@@ -310,7 +311,7 @@ export function createMediaStore({
   async function localizeSite(site: Site) {
     const urls = new Set<string>()
     for (const entry of site.entries) {
-      for (const url of collectImageUrls(entry.content)) urls.add(url)
+      for (const url of collectDownloadableMediaUrls(entry.content)) urls.add(url)
     }
 
     const replacements = new Map<string, string>()

--- a/action/feeds/media.ts
+++ b/action/feeds/media.ts
@@ -3,17 +3,14 @@ import { Dirent } from 'fs'
 import fs from 'fs/promises'
 import path from 'path'
 
-import sanitizeHtml from 'sanitize-html'
-
 import {
   LOCAL_MEDIA_PATH,
   localMediaFileName,
-  mapUrlAttributes,
   type UrlTarget
 } from '../../lib/media'
 import { USER_AGENT } from './http'
 import { normalizeImageExtension } from './images'
-import { ENTRY_CONTENT_SANITIZE_OPTIONS, type Site } from './parsers'
+import { mapContentUrls, type Site } from './parsers'
 
 const MAX_MEDIA_BYTES = 20 * 1024 * 1024
 const DOWNLOAD_TIMEOUT_MS = 15_000
@@ -25,7 +22,7 @@ const LOCALIZE_DEADLINE_MS = 10 * 60 * 1000
 // live in images.ts, which the link resolver reads too, and every value here
 // goes back through it -- so an entry that is not downloadable simply never
 // resolves. SVG is absent from both, see images.ts for why.
-const CONTENT_TYPE_EXTENSIONS: Record<string, string> = {
+export const CONTENT_TYPE_EXTENSIONS: Record<string, string> = {
   'image/avif': '.avif',
   'image/gif': '.gif',
   'image/heic': '.heic',
@@ -94,31 +91,22 @@ function isDownloadableUrl(url: string) {
 }
 
 /**
- * Walks entry content with the same sanitizer configuration used to store it,
- * visiting every URL it carries and reporting whether that URL is media the
- * page loads or a link it points at. sanitize-html transforms are synchronous,
- * so downloading happens between a collect pass and a rewrite pass instead of
- * inside the transform itself.
+ * Visits every URL entry content carries, reporting whether it is media the
+ * page loads or a link it points at, and replaces it with whatever the visitor
+ * returns. sanitize-html transforms are synchronous, so downloading happens
+ * between a collect pass and a rewrite pass instead of inside the transform.
  *
  * Expects content that is already sanitized, which is all a feed ever produces
- * here: the transform runs before tags are discarded, so on raw HTML it would
- * also visit URLs on tags that never survive to render.
+ * here: the walk runs before tags are discarded, so on raw HTML it would also
+ * visit URLs on tags that never survive to render.
  */
 function walkContentUrls(
   content: string,
   visitUrl: (url: string, target: UrlTarget) => string | void
 ) {
-  return sanitizeHtml(content, {
-    ...ENTRY_CONTENT_SANITIZE_OPTIONS,
-    transformTags: {
-      '*': (tagName, attribs) => ({
-        tagName,
-        attribs: mapUrlAttributes(attribs, (url, target) => {
-          const nextUrl = visitUrl(url, target)
-          return typeof nextUrl === 'string' ? nextUrl : url
-        })
-      })
-    }
+  return mapContentUrls(content, (url, target) => {
+    const nextUrl = visitUrl(url, target)
+    return typeof nextUrl === 'string' ? nextUrl : url
   })
 }
 
@@ -171,7 +159,9 @@ async function resolveExistingMediaFile(
 
   try {
     const files = await fs.readdir(mediaDirectory)
-    return files.find((fileName) => fileName.startsWith(`${mediaHash}.`)) || null
+    return (
+      files.find((fileName) => fileName.startsWith(`${mediaHash}.`)) || null
+    )
   } catch {
     return null
   }
@@ -234,7 +224,10 @@ export function createMediaStore({
       return await download()
     } finally {
       activeDownloads--
-      activeDownloadsByHost.set(host, (activeDownloadsByHost.get(host) ?? 1) - 1)
+      activeDownloadsByHost.set(
+        host,
+        (activeDownloadsByHost.get(host) ?? 1) - 1
+      )
       // Every waiter re-checks its own host limit, so waking all of them keeps
       // the queue free of head-of-line blocking on a single busy host.
       waiting.splice(0).forEach((resume) => resume())

--- a/action/feeds/media.ts
+++ b/action/feeds/media.ts
@@ -9,11 +9,14 @@ import {
   LOCAL_MEDIA_PATH,
   localMediaFileName,
   mapUrlAttributes,
-  normalizeImageExtension,
   type UrlTarget
 } from '../../lib/media'
 import { USER_AGENT } from './http'
-import { ENTRY_CONTENT_SANITIZE_OPTIONS, type Site } from './parsers'
+import {
+  ENTRY_CONTENT_SANITIZE_OPTIONS,
+  normalizeImageExtension,
+  type Site
+} from './parsers'
 
 const MAX_MEDIA_BYTES = 20 * 1024 * 1024
 const DOWNLOAD_TIMEOUT_MS = 15_000
@@ -22,10 +25,10 @@ const MAX_CONCURRENT_DOWNLOADS_PER_HOST = 2
 const LOCALIZE_DEADLINE_MS = 10 * 60 * 1000
 
 // Which images may be downloaded and served from our own origin. The list of
-// extensions lives in lib/media.ts, where the link resolver reads it too. SVG
-// is deliberately absent from that list and from the map below: a localized
-// file is navigable on the published origin, and a feed could otherwise plant
-// a scripted SVG there.
+// extensions lives in parsers.ts, where the link resolver reads it too. SVG is
+// deliberately absent from that list and from the map below: a localized file
+// is navigable on the published origin, and a feed could otherwise plant a
+// scripted SVG there.
 const CONTENT_TYPE_EXTENSIONS: Record<string, string> = {
   'image/avif': '.avif',
   'image/gif': '.gif',

--- a/action/feeds/media.ts
+++ b/action/feeds/media.ts
@@ -159,6 +159,11 @@ export function collectImageUrls(content: string) {
   return urls
 }
 
+/**
+ * Swaps every downloaded URL for its local path. This covers links as well as
+ * images, so a lightbox href to an image the store downloaded stops hotlinking
+ * the origin -- the counterpart of collectImageUrls, which is media-only.
+ */
 export function rewriteImageUrls(
   content: string,
   replacements: Map<string, string>

--- a/action/feeds/media.ts
+++ b/action/feeds/media.ts
@@ -5,7 +5,11 @@ import path from 'path'
 
 import sanitizeHtml from 'sanitize-html'
 
-import { LOCAL_MEDIA_PATH, mapSrcSet } from '../../lib/media'
+import {
+  LOCAL_MEDIA_PATH,
+  mapUrlAttributes,
+  type UrlTarget
+} from '../../lib/media'
 import { USER_AGENT } from './http'
 import { ENTRY_CONTENT_SANITIZE_OPTIONS, type Site } from './parsers'
 
@@ -18,7 +22,8 @@ const LOCALIZE_DEADLINE_MS = 10 * 60 * 1000
 // Which images may be downloaded and served from our own origin. SVG is
 // deliberately absent from both maps: a localized file is navigable on the
 // published origin, and a feed could otherwise plant a scripted SVG there.
-// parsers.ts keeps a wider list for URL resolution; do not merge the two.
+// parsers.ts keeps a wider list to decide how a link resolves; do not merge
+// the two.
 const KNOWN_IMAGE_EXTENSIONS = new Set([
   '.avif',
   '.gif',
@@ -119,32 +124,25 @@ function extractMediaFileNameFromLocalPath(value: string) {
 
 /**
  * Walks entry content with the same sanitizer configuration used to store it,
- * visiting every image URL in `src` and `srcset`. sanitize-html transforms are
- * synchronous, so downloading happens between a collect pass and a rewrite pass
- * instead of inside the transform itself.
+ * visiting every URL it carries and reporting whether that URL is media the
+ * page loads or a link it points at. sanitize-html transforms are synchronous,
+ * so downloading happens between a collect pass and a rewrite pass instead of
+ * inside the transform itself.
  */
-function walkImageUrls(
+function walkContentUrls(
   content: string,
-  visitImageUrl: (url: string) => string | void
+  visitUrl: (url: string, target: UrlTarget) => string | void
 ) {
-  const visit = (url: string) => {
-    const nextUrl = visitImageUrl(url)
-    return typeof nextUrl === 'string' ? nextUrl : url
-  }
-
   return sanitizeHtml(content, {
     ...ENTRY_CONTENT_SANITIZE_OPTIONS,
     transformTags: {
-      img: (tagName, attribs) => {
-        const nextAttribs = { ...attribs }
-        if (nextAttribs.src) {
-          nextAttribs.src = visit(nextAttribs.src)
-        }
-        if (nextAttribs.srcset) {
-          nextAttribs.srcset = mapSrcSet(nextAttribs.srcset, visit)
-        }
-        return { tagName, attribs: nextAttribs }
-      }
+      '*': (tagName, attribs) => ({
+        tagName,
+        attribs: mapUrlAttributes(attribs, (url, target) => {
+          const nextUrl = visitUrl(url, target)
+          return typeof nextUrl === 'string' ? nextUrl : url
+        })
+      })
     }
   })
 }
@@ -152,8 +150,11 @@ function walkImageUrls(
 export function collectImageUrls(content: string) {
   const urls = new Set<string>()
   if (!content) return urls
-  walkImageUrls(content, (url) => {
-    if (isDownloadableUrl(url)) urls.add(url)
+  // Only media the entry actually displays is worth the download. A link to an
+  // image is followed by hand, so it is rewritten when the image happens to be
+  // cached already but never pulls one down on its own.
+  walkContentUrls(content, (url, target) => {
+    if (target === 'media' && isDownloadableUrl(url)) urls.add(url)
   })
   return urls
 }
@@ -163,7 +164,7 @@ export function rewriteImageUrls(
   replacements: Map<string, string>
 ) {
   if (!content) return content
-  return walkImageUrls(content, (url) => replacements.get(url))
+  return walkContentUrls(content, (url) => replacements.get(url))
 }
 
 async function fileExists(filePath: string) {
@@ -351,10 +352,16 @@ export function createMediaStore({
   return { localizeSite }
 }
 
+/**
+ * Every downloaded file the content still points at, so cleanup keeps it. Links
+ * count as well as images: rewriteImageUrls sends a lightbox href to the local
+ * copy too, and deleting a file that is still referenced is worse than keeping
+ * one that is not.
+ */
 export function extractLocalMediaReferences(content: string) {
   const references = new Set<string>()
   if (!content) return references
-  walkImageUrls(content, (url) => {
+  walkContentUrls(content, (url) => {
     const mediaFile = extractMediaFileNameFromLocalPath(url)
     if (mediaFile) references.add(mediaFile)
   })

--- a/action/feeds/parsers#media-url-resolution.test.ts
+++ b/action/feeds/parsers#media-url-resolution.test.ts
@@ -90,6 +90,19 @@ test('#parseRss picks the link base on the extension alone', (t) => {
       'href="https://feed.example/images/D.SVG"'
     )
   )
+  // A query parameter that merely ends in an image extension is not an image,
+  // so the link keeps the document base.
+  t.true(
+    contentOf('<a href="/download?file=a.png">d</a>').includes(
+      'href="https://feed.example/download?file=a.png"'
+    )
+  )
+  // A dot in an earlier path segment is not an extension either.
+  t.true(
+    contentOf('<a href="/v1.2/page">v</a>').includes(
+      'href="https://feed.example/v1.2/page"'
+    )
+  )
 })
 
 // Attributes that are allowed through but genuinely carry no URL. Anything not
@@ -254,6 +267,15 @@ test('#parseRss falls back between the entry and site URL', (t) => {
       entry: 'http://feed.example/posts/1'
     }).includes('src="http://cdn.example/x.png"')
   )
+  // A scheme-less link to a downloadable image follows the image instead, so
+  // the two still agree and the link can be swapped for the local copy. Only
+  // this ordering keeps them matching on an http feed.
+  const schemeless = contentOf(
+    '<a href="//cdn.example/x.png">L</a><img src="//cdn.example/x.png" />',
+    { site: 'http://site.example/', entry: 'http://feed.example/posts/1' }
+  )
+  t.true(schemeless.includes('href="http://cdn.example/x.png"'))
+  t.true(schemeless.includes('src="http://cdn.example/x.png"'))
 })
 
 test('#parseRss makes a relative entry link absolute', (t) => {

--- a/action/feeds/parsers#media-url-resolution.test.ts
+++ b/action/feeds/parsers#media-url-resolution.test.ts
@@ -106,7 +106,13 @@ test('#parseRss leaves URLs it must not rewrite alone', (t) => {
   )
   // Resolution runs before sanitize-html filters schemes, so this still goes.
   t.false(contentOf('<a href="javascript:alert(1)">No</a>').includes('href='))
-  t.true(contentOf('<a name="footnote">Anchor</a>').includes('name="footnote"'))
+  // Asserted whole, so an anchor that has no href cannot silently gain one.
+  t.is(
+    contentOf('<a name="footnote">Anchor</a>'),
+    '<a name="footnote">Anchor</a>'
+  )
+  t.is(contentOf('<a href="">Empty</a>'), '<a>Empty</a>')
+  t.is(contentOf('<a href="   ">Blank</a>'), '<a>Blank</a>')
 })
 
 test('#parseRss falls back between the entry and site URL', (t) => {

--- a/action/feeds/parsers#media-url-resolution.test.ts
+++ b/action/feeds/parsers#media-url-resolution.test.ts
@@ -239,12 +239,20 @@ test('#parseRss falls back between the entry and site URL', (t) => {
       entry: ''
     }).includes('href="https://h.example/x"')
   )
-  // A link takes its scheme from the entry, the document base a browser uses.
+  // A scheme-less link is stored as https even when the feed itself is plain
+  // http, since the page it ends up opening from is the reader, not the feed.
   t.true(
     contentOf('<a href="//h.example/x">l</a>', {
-      site: 'https://site.example/',
+      site: 'http://site.example/',
       entry: 'http://feed.example/posts/1'
-    }).includes('href="http://h.example/x"')
+    }).includes('href="https://h.example/x"')
+  )
+  // Media keeps taking the scheme of the site it is loaded alongside.
+  t.true(
+    contentOf('<img src="//cdn.example/x.png" />', {
+      site: 'http://site.example/',
+      entry: 'http://feed.example/posts/1'
+    }).includes('src="http://cdn.example/x.png"')
   )
 })
 
@@ -268,6 +276,52 @@ test('#parseRss makes a relative entry link absolute', (t) => {
   t.true(
     site.entries[0].content.includes(
       'href="https://site.example/2024/01/post/#fn1"'
+    )
+  )
+})
+
+test('#parseRss keeps an absolute entry link byte for byte', (t) => {
+  // The link is half the key an entry is stored under, so normalizing it would
+  // re-create every stored entry on the first run after this ships.
+  for (const link of [
+    'https://feed.example',
+    'https://feed.example/a b',
+    'https://FEED.example/Post'
+  ]) {
+    t.is(
+      parseRss('Test Feed', rssWithContent('<p>x</p>', { entry: link }))
+        .entries[0].link,
+      link
+    )
+  }
+})
+
+test('#parseAtom makes a relative entry link absolute', (t) => {
+  const site = parseAtom('Test Feed', {
+    feed: {
+      title: ['Test'],
+      updated: ['2026-01-01T00:00:00Z'],
+      link: [{ $: { rel: 'alternate', href: 'https://site.example/base/' } }],
+      entry: [
+        {
+          title: ['Entry 1'],
+          link: [{ $: { rel: 'alternate', href: '2024/01/post/' } }],
+          published: ['2026-01-01T00:00:00Z'],
+          content: [{ _: '<a href="foo.html">x</a><a href="#fn1">f</a>' }]
+        }
+      ]
+    }
+  })
+
+  t.is(site.entries[0].link, 'https://site.example/base/2024/01/post/')
+  t.true(
+    site.entries[0].content.includes(
+      'href="https://site.example/base/2024/01/post/foo.html"'
+    )
+  )
+  t.true(
+    site.entries[0].content.includes(
+      'href="https://site.example/base/2024/01/post/#fn1"'
     )
   )
 })

--- a/action/feeds/parsers#media-url-resolution.test.ts
+++ b/action/feeds/parsers#media-url-resolution.test.ts
@@ -71,6 +71,13 @@ test('#parseRss picks the link base on the extension alone', (t) => {
       'href="https://feed.example/images/a"'
     )
   )
+  // The store never downloads svg, so the media base could never pay off and
+  // the link resolves against the document like any other.
+  t.true(
+    contentOf('<a href="diagram.svg">Diagram</a>').includes(
+      'href="https://feed.example/posts/diagram.svg"'
+    )
+  )
 })
 
 test('#parseRss resolves relative links using the entry URL', (t) => {

--- a/action/feeds/parsers#media-url-resolution.test.ts
+++ b/action/feeds/parsers#media-url-resolution.test.ts
@@ -52,6 +52,14 @@ test('#parseRss resolves relative media URLs using site domain', (t) => {
   )
 })
 
+test('#parseRss resolves media against the site even without a downloadable extension', (t) => {
+  // The link rule would send these to the entry base. Media does not follow it:
+  // the media hash is computed from this URL, so the base must not drift.
+  const output = contentOf('<img src="/photo" srcset="/diagram.svg 2x" />')
+  t.true(output.includes('src="https://site.example/photo"'))
+  t.true(output.includes('srcset="https://site.example/diagram.svg 2x"'))
+})
+
 test('#parseRss picks the link base on the extension alone', (t) => {
   // The extension is what decides the base now, so a query or a fragment must
   // not hide it -- these links would otherwise stop matching downloaded media.
@@ -130,7 +138,13 @@ test('#parseRss resolves every allowed attribute that carries a URL', (t) => {
       const output = contentOf(`<${tag} ${attribute}="/rel">x</${tag}>`)
       t.false(
         output.includes(`${attribute}="/rel"`),
-        `${tag}[${attribute}] kept a relative URL -- add it to URL_ATTRIBUTES`
+        `${tag}[${attribute}] kept a relative URL -- add it to URL_ATTRIBUTES in lib/media.ts, or to NON_URL_ATTRIBUTES here if it carries no URL`
+      )
+      // Asserted both ways, or a tag dropped for not being in allowedTags
+      // would look like an attribute that resolved.
+      t.true(
+        output.includes(`${attribute}="https://`),
+        `${tag}[${attribute}] was dropped instead of resolved -- is ${tag} in allowedTags?`
       )
     }
   }
@@ -354,6 +368,21 @@ test('#parseRss keeps an absolute entry link byte for byte', (t) => {
       link
     )
   }
+})
+
+test('#parseRss re-serializes an absolute URL in content', (t) => {
+  // Unlike entry.link, a content URL is not a storage key, so normalizing it is
+  // fine -- but it is a change from leaving non-image hrefs untouched.
+  t.true(
+    contentOf('<a href="HTTPS://Other.Example/Page">x</a>').includes(
+      'href="https://other.example/Page"'
+    )
+  )
+  t.true(
+    contentOf('<a href="https://other.example/a b">x</a>').includes(
+      'href="https://other.example/a%20b"'
+    )
+  )
 })
 
 test('#parseRss gives a scheme-less entry link one', (t) => {

--- a/action/feeds/parsers#media-url-resolution.test.ts
+++ b/action/feeds/parsers#media-url-resolution.test.ts
@@ -1,5 +1,5 @@
 import test from 'ava'
-import { parseAtom, parseRss } from './parsers'
+import { ENTRY_CONTENT_SANITIZE_OPTIONS, parseAtom, parseRss } from './parsers'
 
 const SITE_LINK = 'https://site.example/'
 const ENTRY_LINK = 'https://feed.example/posts/entry-1'
@@ -78,6 +78,49 @@ test('#parseRss picks the link base on the extension alone', (t) => {
       'href="https://feed.example/posts/diagram.svg"'
     )
   )
+  // The extension match is case folded, so a feed shouting its filenames still
+  // lines its links up with the images they point at.
+  t.true(
+    contentOf('<a href="/images/A.PNG">u</a>').includes(
+      'href="https://site.example/images/A.PNG"'
+    )
+  )
+  t.true(
+    contentOf('<a href="/images/D.SVG">s</a>').includes(
+      'href="https://feed.example/images/D.SVG"'
+    )
+  )
+})
+
+// Attributes that are allowed through but genuinely carry no URL. Anything not
+// listed here has to come back resolved, or the sanitizer is allowing an
+// attribute URL_ATTRIBUTES does not know about -- which is the original bug,
+// reintroduced for that one attribute.
+const NON_URL_ATTRIBUTES = new Set([
+  'name',
+  'target',
+  'alt',
+  'title',
+  'width',
+  'height',
+  'loading'
+])
+
+test('#parseRss resolves every allowed attribute that carries a URL', (t) => {
+  const allowed = ENTRY_CONTENT_SANITIZE_OPTIONS.allowedAttributes as Record<
+    string,
+    string[]
+  >
+  for (const [tag, attributes] of Object.entries(allowed)) {
+    for (const attribute of attributes) {
+      if (NON_URL_ATTRIBUTES.has(attribute)) continue
+      const output = contentOf(`<${tag} ${attribute}="/rel">x</${tag}>`)
+      t.false(
+        output.includes(`${attribute}="/rel"`),
+        `${tag}[${attribute}] kept a relative URL -- add it to URL_ATTRIBUTES`
+      )
+    }
+  }
 })
 
 test('#parseRss resolves relative links using the entry URL', (t) => {
@@ -195,6 +238,37 @@ test('#parseRss falls back between the entry and site URL', (t) => {
       site: '',
       entry: ''
     }).includes('href="https://h.example/x"')
+  )
+  // A link takes its scheme from the entry, the document base a browser uses.
+  t.true(
+    contentOf('<a href="//h.example/x">l</a>', {
+      site: 'https://site.example/',
+      entry: 'http://feed.example/posts/1'
+    }).includes('href="http://h.example/x"')
+  )
+})
+
+test('#parseRss makes a relative entry link absolute', (t) => {
+  // Atom allows a relative entry link and RSS feeds publish them too. Left
+  // relative it is useless as a base and lands in storage as the entry URL.
+  const site = parseRss(
+    'Test Feed',
+    rssWithContent('<a href="foo.html">x</a><a href="#fn1">f</a>', {
+      site: 'https://site.example/',
+      entry: '2024/01/post/'
+    })
+  )
+
+  t.is(site.entries[0].link, 'https://site.example/2024/01/post/')
+  t.true(
+    site.entries[0].content.includes(
+      'href="https://site.example/2024/01/post/foo.html"'
+    )
+  )
+  t.true(
+    site.entries[0].content.includes(
+      'href="https://site.example/2024/01/post/#fn1"'
+    )
   )
 })
 

--- a/action/feeds/parsers#media-url-resolution.test.ts
+++ b/action/feeds/parsers#media-url-resolution.test.ts
@@ -114,6 +114,13 @@ test('#parseRss resolves URLs outside of a and img tags', (t) => {
       'cite="https://feed.example/posts/source.html"'
     )
   )
+  // Every link attribute picks its base the same way, so a cite ending in an
+  // image extension takes the media base like a lightbox href would.
+  t.true(
+    contentOf('<q cite="photo.png">Quoted</q>').includes(
+      'cite="https://site.example/photo.png"'
+    )
+  )
 })
 
 test('#parseRss leaves URLs it must not rewrite alone', (t) => {
@@ -141,6 +148,17 @@ test('#parseRss leaves URLs it must not rewrite alone', (t) => {
   )
   t.is(contentOf('<a href="">Empty</a>'), '<a>Empty</a>')
   t.is(contentOf('<a href="   ">Blank</a>'), '<a>Blank</a>')
+  // A citation is a document, so the schemes links and inline images get do
+  // not apply to it.
+  t.is(
+    contentOf('<blockquote cite="mailto:a@b.example">q</blockquote>'),
+    '<blockquote>q</blockquote>'
+  )
+  t.is(
+    contentOf('<blockquote cite="data:text/html,x">q</blockquote>'),
+    '<blockquote>q</blockquote>'
+  )
+  t.is(contentOf('<q cite="javascript:alert(1)">q</q>'), '<q>q</q>')
 })
 
 test('#parseRss falls back between the entry and site URL', (t) => {
@@ -163,6 +181,20 @@ test('#parseRss falls back between the entry and site URL', (t) => {
     contentOf('<a href="/x">l</a>', { site: '', entry: '' }).includes(
       'href="/x"'
     )
+  )
+
+  // A protocol-relative URL takes its scheme from the base it resolves
+  // against, and falls back to https when there is none.
+  t.true(
+    contentOf('<img src="//cdn.example/x.png" />', {
+      site: 'http://site.example/'
+    }).includes('src="http://cdn.example/x.png"')
+  )
+  t.true(
+    contentOf('<a href="//h.example/x">l</a>', {
+      site: '',
+      entry: ''
+    }).includes('href="https://h.example/x"')
   )
 })
 

--- a/action/feeds/parsers#media-url-resolution.test.ts
+++ b/action/feeds/parsers#media-url-resolution.test.ts
@@ -217,6 +217,29 @@ test('#parseRss leaves URLs it must not rewrite alone', (t) => {
   t.is(contentOf('<q cite="javascript:alert(1)">q</q>'), '<q>q</q>')
   // Only an inline image has any use for data:, so a link does not get it.
   t.is(contentOf('<a href="data:text/html,x">d</a>'), '<a>d</a>')
+  // A data: URI is handed back untouched rather than re-serialized, which this
+  // payload can tell apart -- the URL parser would percent-encode both of these.
+  t.true(
+    contentOf('<img src="data:text/plain,café" />').includes(
+      'src="data:text/plain,café"'
+    )
+  )
+  t.true(
+    contentOf('<img src="data:text/plain,a b" />').includes(
+      'src="data:text/plain,a b"'
+    )
+  )
+  // The scheme filter still runs after resolution on media attributes, which
+  // are the ones this change reshapes.
+  t.is(
+    contentOf('<img src="javascript:alert(1)" alt="x" />'),
+    '<img alt="x" />'
+  )
+  t.true(
+    contentOf('<img srcset="javascript:alert(1) 1x, /ok.png 2x" />').includes(
+      'srcset="https://site.example/ok.png 2x"'
+    )
+  )
   t.true(
     contentOf('<img srcset="data:image/gif;base64,AAA 1x" />').includes(
       'srcset="data:image/gif;base64,AAA 1x"'
@@ -331,6 +354,20 @@ test('#parseRss keeps an absolute entry link byte for byte', (t) => {
       link
     )
   }
+})
+
+test('#parseRss gives a scheme-less entry link one', (t) => {
+  const entryLink = (links: { site?: string; entry?: string }) =>
+    parseRss('Test Feed', rssWithContent('<p>x</p>', links)).entries[0].link
+
+  t.is(entryLink({ entry: '//other.example/p' }), 'https://other.example/p')
+  t.is(
+    entryLink({ site: 'http://site.example/', entry: '//other.example/p' }),
+    'http://other.example/p'
+  )
+  // With nothing to resolve against, the link stays as published and the
+  // reader's own resolution degrades to a no-op for that entry.
+  t.is(entryLink({ site: '', entry: '2024/01/post/' }), '2024/01/post/')
 })
 
 test('#parseAtom makes a relative entry link absolute', (t) => {

--- a/action/feeds/parsers#media-url-resolution.test.ts
+++ b/action/feeds/parsers#media-url-resolution.test.ts
@@ -1,44 +1,135 @@
 import test from 'ava'
 import { parseAtom, parseRss } from './parsers'
 
-test('#parseRss resolves relative media URLs using site domain', (t) => {
-  const xml = {
-    rss: {
-      channel: [
-        {
-          link: ['https://site.example/'],
-          description: ['Test feed'],
-          lastBuildDate: ['2026-01-01T00:00:00Z'],
-          generator: ['test'],
-          item: [
-            {
-              title: ['Entry 1'],
-              link: ['https://feed.example/posts/entry-1'],
-              pubDate: ['2026-01-01T00:00:00Z'],
-              description: [
-                '<p><img src="/images/cover.jpg" srcset="/images/cover.jpg 1x, images/cover@2x.jpg 2x" /><a href="/images/download.webp">Download</a><a href="/posts/entry-1">Read more</a></p>'
-              ]
-            }
-          ]
-        }
-      ]
-    }
+const SITE_LINK = 'https://site.example/'
+const ENTRY_LINK = 'https://feed.example/posts/entry-1'
+
+const rssWithContent = (
+  description: string,
+  links: { site?: string; entry?: string } = {}
+) => ({
+  rss: {
+    channel: [
+      {
+        link: [links.site ?? SITE_LINK],
+        description: ['Test feed'],
+        lastBuildDate: ['2026-01-01T00:00:00Z'],
+        generator: ['test'],
+        item: [
+          {
+            title: ['Entry 1'],
+            link: [links.entry ?? ENTRY_LINK],
+            pubDate: ['2026-01-01T00:00:00Z'],
+            description: [description]
+          }
+        ]
+      }
+    ]
   }
+})
 
-  const site = parseRss('Test Feed', xml)
-  t.truthy(site)
+const contentOf = (
+  description: string,
+  links?: { site?: string; entry?: string }
+) =>
+  parseRss('Test Feed', rssWithContent(description, links)).entries[0].content
 
-  const outputContent = site.entries[0].content
+test('#parseRss resolves relative media URLs using site domain', (t) => {
+  const outputContent = contentOf(
+    '<p><img src="/images/cover.jpg" srcset="/images/cover.jpg 1x, images/cover@2x.jpg 2x" /><a href="/images/download.webp">Download</a></p>'
+  )
+
   t.true(outputContent.includes('src="https://site.example/images/cover.jpg"'))
   t.true(
     outputContent.includes(
       'srcset="https://site.example/images/cover.jpg 1x, https://site.example/images/cover@2x.jpg 2x"'
     )
   )
+  // A link to an image shares the media base so it matches the src the media
+  // store downloads and can be swapped for the local copy.
   t.true(
     outputContent.includes('href="https://site.example/images/download.webp"')
   )
-  t.true(outputContent.includes('href="/posts/entry-1"'))
+})
+
+test('#parseRss resolves relative links using the entry URL', (t) => {
+  t.true(
+    contentOf('<a href="/posts/other">Read more</a>').includes(
+      'href="https://feed.example/posts/other"'
+    )
+  )
+  t.true(
+    contentOf('<a href="chapter-two.html">Next</a>').includes(
+      'href="https://feed.example/posts/chapter-two.html"'
+    )
+  )
+  t.true(
+    contentOf('<a href="#footnote">Footnote</a>').includes(
+      'href="https://feed.example/posts/entry-1#footnote"'
+    )
+  )
+  t.true(
+    contentOf('<a href="//en.wikipedia.org/wiki/RSS">RSS</a>').includes(
+      'href="https://en.wikipedia.org/wiki/RSS"'
+    )
+  )
+})
+
+test('#parseRss resolves URLs outside of a and img tags', (t) => {
+  t.true(
+    contentOf('<blockquote cite="/interview">Quoted</blockquote>').includes(
+      'cite="https://feed.example/interview"'
+    )
+  )
+  t.true(
+    contentOf('<q cite="source.html">Quoted</q>').includes(
+      'cite="https://feed.example/posts/source.html"'
+    )
+  )
+})
+
+test('#parseRss leaves URLs it must not rewrite alone', (t) => {
+  t.true(
+    contentOf('<a href="https://other.example/page">Other</a>').includes(
+      'href="https://other.example/page"'
+    )
+  )
+  t.true(
+    contentOf('<a href="mailto:user@example.com">Mail</a>').includes(
+      'href="mailto:user@example.com"'
+    )
+  )
+  t.true(
+    contentOf('<img src="data:image/gif;base64,AAA" />').includes(
+      'src="data:image/gif;base64,AAA"'
+    )
+  )
+  // Resolution runs before sanitize-html filters schemes, so this still goes.
+  t.false(contentOf('<a href="javascript:alert(1)">No</a>').includes('href='))
+  t.true(contentOf('<a name="footnote">Anchor</a>').includes('name="footnote"'))
+})
+
+test('#parseRss falls back between the entry and site URL', (t) => {
+  // No site link, so links and media both resolve against the entry.
+  const withoutSite = contentOf('<a href="/x">l</a><img src="/y.png" />', {
+    site: ''
+  })
+  t.true(withoutSite.includes('href="https://feed.example/x"'))
+  t.true(withoutSite.includes('src="https://feed.example/y.png"'))
+
+  // No entry link, so links fall back to the site.
+  t.true(
+    contentOf('<a href="/x">l</a>', { entry: '' }).includes(
+      'href="https://site.example/x"'
+    )
+  )
+
+  // Nothing to resolve against leaves the URL as it is.
+  t.true(
+    contentOf('<a href="/x">l</a>', { site: '', entry: '' }).includes(
+      'href="/x"'
+    )
+  )
 })
 
 test('#parseAtom resolves relative media URLs using site domain', (t) => {
@@ -52,12 +143,13 @@ test('#parseAtom resolves relative media URLs using site domain', (t) => {
       entry: [
         {
           title: ['Entry 1'],
-          link: [{ $: { rel: 'alternate', href: 'https://feed.example/posts/1' } }],
+          link: [
+            { $: { rel: 'alternate', href: 'https://feed.example/posts/1' } }
+          ],
           published: ['2026-01-01T00:00:00Z'],
           content: [
             {
-              _:
-                '<p><img src="media/photo.png" srcset="media/one.png 1x, /media/two.png 2x" /><a href="media/download.jpg">Download</a></p>'
+              _: '<p><img src="media/photo.png" srcset="media/one.png 1x, /media/two.png 2x" /><a href="media/download.jpg">Download</a><a href="/archive">Archive</a></p>'
             }
           ]
         }
@@ -69,13 +161,18 @@ test('#parseAtom resolves relative media URLs using site domain', (t) => {
   t.truthy(site)
 
   const outputContent = site.entries[0].content
-  t.true(outputContent.includes('src="https://site.example/base/media/photo.png"'))
+  t.true(
+    outputContent.includes('src="https://site.example/base/media/photo.png"')
+  )
   t.true(
     outputContent.includes(
       'srcset="https://site.example/base/media/one.png 1x, https://site.example/media/two.png 2x"'
     )
   )
   t.true(
-    outputContent.includes('href="https://site.example/base/media/download.jpg"')
+    outputContent.includes(
+      'href="https://site.example/base/media/download.jpg"'
+    )
   )
+  t.true(outputContent.includes('href="https://feed.example/archive"'))
 })

--- a/action/feeds/parsers#media-url-resolution.test.ts
+++ b/action/feeds/parsers#media-url-resolution.test.ts
@@ -52,6 +52,27 @@ test('#parseRss resolves relative media URLs using site domain', (t) => {
   )
 })
 
+test('#parseRss picks the link base on the extension alone', (t) => {
+  // The extension is what decides the base now, so a query or a fragment must
+  // not hide it -- these links would otherwise stop matching downloaded media.
+  t.true(
+    contentOf('<a href="/images/a.png?w=100">q</a>').includes(
+      'href="https://site.example/images/a.png?w=100"'
+    )
+  )
+  t.true(
+    contentOf('<a href="/images/a.png#x">f</a>').includes(
+      'href="https://site.example/images/a.png#x"'
+    )
+  )
+  // No extension, so it is an ordinary link and takes the entry base.
+  t.true(
+    contentOf('<a href="/images/a">n</a>').includes(
+      'href="https://feed.example/images/a"'
+    )
+  )
+})
+
 test('#parseRss resolves relative links using the entry URL', (t) => {
   t.true(
     contentOf('<a href="/posts/other">Read more</a>').includes(

--- a/action/feeds/parsers#media-url-resolution.test.ts
+++ b/action/feeds/parsers#media-url-resolution.test.ts
@@ -215,6 +215,13 @@ test('#parseRss leaves URLs it must not rewrite alone', (t) => {
     '<blockquote>q</blockquote>'
   )
   t.is(contentOf('<q cite="javascript:alert(1)">q</q>'), '<q>q</q>')
+  // Only an inline image has any use for data:, so a link does not get it.
+  t.is(contentOf('<a href="data:text/html,x">d</a>'), '<a>d</a>')
+  t.true(
+    contentOf('<img srcset="data:image/gif;base64,AAA 1x" />').includes(
+      'srcset="data:image/gif;base64,AAA 1x"'
+    )
+  )
 })
 
 test('#parseRss falls back between the entry and site URL', (t) => {
@@ -251,6 +258,14 @@ test('#parseRss falls back between the entry and site URL', (t) => {
       site: '',
       entry: ''
     }).includes('href="https://h.example/x"')
+  )
+  // Media is the only caller that reaches resolveUrl's own https default, since
+  // a link is short-circuited by the scheme-less rule before it gets there.
+  t.true(
+    contentOf('<img src="//h.example/x.png" />', {
+      site: '',
+      entry: ''
+    }).includes('src="https://h.example/x.png"')
   )
   // A scheme-less link is stored as https even when the feed itself is plain
   // http, since the page it ends up opening from is the reader, not the feed.

--- a/action/feeds/parsers.ts
+++ b/action/feeds/parsers.ts
@@ -1,7 +1,11 @@
 import { parseString } from 'xml2js'
 import sanitizeHtml from 'sanitize-html'
 
-import { mapUrlAttributes, type UrlTarget } from '../../lib/media'
+import {
+  hasDownloadableImageExtension,
+  mapUrlAttributes,
+  type UrlTarget
+} from '../../lib/media'
 
 export interface Entry {
   title: string
@@ -21,12 +25,6 @@ export interface Site {
 }
 
 type Values = string[] | { _: string; $: { type: 'text' } }[] | null
-// Which links point at an image, so they resolve against the same base as the
-// media they reference. This is deliberately not the list of images media.ts
-// downloads: svg belongs here but must never be served from our own origin.
-// Keep the two lists apart.
-const IMAGE_EXTENSION_REGEX =
-  /\.(avif|gif|heic|heif|jpeg|jpg|jxl|png|svg|tif|tiff|webp)$/i
 
 function joinValuesOrEmptyString(values: Values) {
   if (values && values.length > 0 && typeof values[0] !== 'string') {
@@ -78,11 +76,6 @@ function resolveUrl(
   }
 }
 
-function isImageLikeUrl(url: string) {
-  const pathOnly = url.trim().split('#')[0].split('?')[0]
-  return IMAGE_EXTENSION_REGEX.test(pathOnly)
-}
-
 function resolveContentUrl(
   url: string,
   target: UrlTarget,
@@ -91,14 +84,16 @@ function resolveContentUrl(
 ) {
   const asMedia = resolveUrl(url, siteLink, entryLink)
   if (target === 'media') return asMedia
-  // A link to an image takes the media base so that when some entry of the site
-  // also displays that image, the two agree and the link can be swapped for the
-  // downloaded copy. The trade is that a link to an image nothing displays gets
-  // the site base rather than the document one -- same as the img rule it is
-  // matching, and the reason to keep the two together. Every other link
-  // resolves against the entry, the document base a browser would use and the
-  // only one that gets a bare "foo.html" or a "#footnote" right.
-  return isImageLikeUrl(asMedia)
+  // A link to an image the store can download takes the media base so that when
+  // some entry of the site also displays that image, the two agree and the link
+  // can be swapped for the downloaded copy. The trade is that a link to an
+  // image nothing displays gets the site base rather than the document one --
+  // same as the img rule it is matching, and the reason to keep the two
+  // together. An extension the store will never fetch, svg above all, buys
+  // nothing here and so resolves like any other link. Every other link resolves
+  // against the entry, the document base a browser would use and the only one
+  // that gets a bare "foo.html" or a "#footnote" right.
+  return hasDownloadableImageExtension(asMedia)
     ? asMedia
     : resolveUrl(url, entryLink, siteLink)
 }
@@ -116,7 +111,11 @@ export const ENTRY_CONTENT_SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
   },
   allowedSchemes: ['http', 'https', 'mailto', 'data'],
   allowedSchemesByTag: {
-    img: ['http', 'https', 'data']
+    img: ['http', 'https', 'data'],
+    // A citation is a document, so it has no use for the data: and mailto:
+    // schemes the global list carries for links and inline images.
+    blockquote: ['http', 'https'],
+    q: ['http', 'https']
   },
   disallowedTagsMode: 'discard',
   enforceHtmlBoundary: true

--- a/action/feeds/parsers.ts
+++ b/action/feeds/parsers.ts
@@ -1,7 +1,7 @@
 import { parseString } from 'xml2js'
 import sanitizeHtml from 'sanitize-html'
 
-import { mapSrcSet } from '../../lib/media'
+import { mapUrlAttributes, type UrlTarget } from '../../lib/media'
 
 export interface Entry {
   title: string
@@ -21,9 +21,10 @@ export interface Site {
 }
 
 type Values = string[] | { _: string; $: { type: 'text' } }[] | null
-// Which links look like an image, so their URL is worth resolving. This is
-// deliberately not the list of images media.ts downloads: svg belongs here but
-// must never be served from our own origin. Keep the two lists apart.
+// Which links point at an image, so they resolve against the same base as the
+// media they reference. This is deliberately not the list of images media.ts
+// downloads: svg belongs here but must never be served from our own origin.
+// Keep the two lists apart.
 const IMAGE_EXTENSION_REGEX =
   /\.(avif|gif|heic|heif|jpeg|jpg|jxl|png|svg|tif|tiff|webp)$/i
 
@@ -45,15 +46,19 @@ function parseAbsoluteHttpUrl(input?: string | null) {
   }
 }
 
-function resolveMediaUrl(inputUrl: string, siteLink: string, entryLink: string) {
+function resolveUrl(
+  inputUrl: string,
+  primaryBase: string,
+  fallbackBase: string
+) {
   const trimmed = inputUrl.trim()
   if (!trimmed) return trimmed
   if (trimmed.startsWith('data:')) return trimmed
 
   if (trimmed.startsWith('//')) {
     const protocol =
-      parseAbsoluteHttpUrl(siteLink)?.protocol ||
-      parseAbsoluteHttpUrl(entryLink)?.protocol ||
+      parseAbsoluteHttpUrl(primaryBase)?.protocol ||
+      parseAbsoluteHttpUrl(fallbackBase)?.protocol ||
       'https:'
     return `${protocol}${trimmed}`
   }
@@ -62,8 +67,8 @@ function resolveMediaUrl(inputUrl: string, siteLink: string, entryLink: string) 
   if (absolute) return absolute.toString()
 
   const base =
-    parseAbsoluteHttpUrl(siteLink)?.toString() ||
-    parseAbsoluteHttpUrl(entryLink)?.toString()
+    parseAbsoluteHttpUrl(primaryBase)?.toString() ||
+    parseAbsoluteHttpUrl(fallbackBase)?.toString()
   if (!base) return trimmed
 
   try {
@@ -73,20 +78,37 @@ function resolveMediaUrl(inputUrl: string, siteLink: string, entryLink: string) 
   }
 }
 
-function resolveSrcSet(srcSet: string, siteLink: string, entryLink: string) {
-  return mapSrcSet(srcSet, (url) => resolveMediaUrl(url, siteLink, entryLink))
-}
-
 function isImageLikeUrl(url: string) {
   const pathOnly = url.trim().split('#')[0].split('?')[0]
   return IMAGE_EXTENSION_REGEX.test(pathOnly)
+}
+
+function resolveContentUrl(
+  url: string,
+  target: UrlTarget,
+  siteLink: string,
+  entryLink: string
+) {
+  const asMedia = resolveUrl(url, siteLink, entryLink)
+  if (target === 'media') return asMedia
+  // A link to an image resolves like the media it points at, so it matches the
+  // src the media store downloads and can be swapped for the local copy. The
+  // store collects across the whole site, so this holds whether the link wraps
+  // the image or another entry is the one displaying it. Every other link
+  // resolves against the entry, the document base a browser would use and the
+  // only one that gets a bare "foo.html" or a "#footnote" right.
+  return isImageLikeUrl(asMedia)
+    ? asMedia
+    : resolveUrl(url, entryLink, siteLink)
 }
 
 export const ENTRY_CONTENT_SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
   allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img']),
   allowedAttributes: {
     ...sanitizeHtml.defaults.allowedAttributes,
-    img: ['src', 'alt', 'title', 'width', 'height', 'loading', 'srcset']
+    img: ['src', 'alt', 'title', 'width', 'height', 'loading', 'srcset'],
+    blockquote: ['cite'],
+    q: ['cite']
   },
   allowedSchemes: ['http', 'https', 'mailto', 'data'],
   allowedSchemesByTag: {
@@ -100,33 +122,15 @@ function sanitizeEntryContent(content: string, siteLink: string, entryLink: stri
   return sanitizeHtml(content, {
     ...ENTRY_CONTENT_SANITIZE_OPTIONS,
     transformTags: {
-      img: (tagName, attribs) => {
-        const nextAttribs = { ...attribs }
-        if (nextAttribs.src) {
-          nextAttribs.src = resolveMediaUrl(
-            nextAttribs.src,
-            siteLink,
-            entryLink
-          )
-        }
-        if (nextAttribs.srcset) {
-          nextAttribs.srcset = resolveSrcSet(
-            nextAttribs.srcset,
-            siteLink,
-            entryLink
-          )
-        }
-        return { tagName, attribs: nextAttribs }
-      },
-      a: (tagName, attribs) => {
-        if (!attribs.href) return { tagName, attribs }
-        const nextAttribs = { ...attribs }
-        const resolvedHref = resolveMediaUrl(nextAttribs.href, siteLink, entryLink)
-        if (isImageLikeUrl(resolvedHref)) {
-          nextAttribs.href = resolvedHref
-        }
-        return { tagName, attribs: nextAttribs }
-      }
+      // Every tag rather than img and a alone, so a relative URL is resolved
+      // wherever it hides. Schemes are filtered after this runs, so a
+      // javascript: href is still dropped even though it is resolved here.
+      '*': (tagName, attribs) => ({
+        tagName,
+        attribs: mapUrlAttributes(attribs, (url, target) =>
+          resolveContentUrl(url, target, siteLink, entryLink)
+        )
+      })
     }
   })
 }

--- a/action/feeds/parsers.ts
+++ b/action/feeds/parsers.ts
@@ -29,6 +29,7 @@ function joinValuesOrEmptyString(values: Values) {
   }
   return (values && values.join('').trim()) || ''
 }
+
 function parseAbsoluteHttpUrl(input?: string | null) {
   if (!input) return null
   try {
@@ -95,6 +96,11 @@ function resolveContentUrl(
   siteLink: string,
   entryLink: string
 ) {
+  // Media resolves against the site first. That base is known to be wrong for a
+  // path-relative URL -- a browser uses the document, so "images/x.jpg" in an
+  // entry at /2024/01/post/ belongs under that directory, not at the root. It
+  // is kept because it is what this project has always stored, and changing it
+  // re-hashes and re-downloads every image; see the open follow-up.
   const asMedia = resolveUrl(url, siteLink, entryLink)
   if (target === 'media') return asMedia
   // A link to an image the store can download takes the media base so that when
@@ -123,7 +129,8 @@ export const ENTRY_CONTENT_SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
   allowedAttributes: {
     // An attribute added here that carries a URL has to be listed in
     // URL_ATTRIBUTES in lib/media.ts too, or it keeps whatever relative URL the
-    // feed published and lands on the reader's own domain.
+    // feed published and lands on the reader's own domain -- and its tag needs
+    // an allowedSchemesByTag entry below if http(s) is not the right set.
     ...sanitizeHtml.defaults.allowedAttributes,
     img: ['src', 'alt', 'title', 'width', 'height', 'loading', 'srcset'],
     // Kept so the source of a quotation survives into the stored JSON, and
@@ -131,13 +138,18 @@ export const ENTRY_CONTENT_SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
     blockquote: ['cite'],
     q: ['cite']
   },
-  allowedSchemes: ['http', 'https', 'mailto', 'data'],
+  // Nothing beyond http(s) by default, so an attribute allowed later inherits
+  // the safe set rather than data: or mailto:. Anything that needs more says so
+  // below.
+  allowedSchemes: ['http', 'https'],
   allowedSchemesByTag: {
+    // Only an inline image has any use for data:.
     img: ['http', 'https', 'data'],
-    // Only an inline image has any use for data:, so a link does not get it.
+    // sanitize-html looks srcset up by attribute name rather than by tag, so
+    // this is what covers <img srcset>, not the img entry above.
+    srcset: ['http', 'https', 'data'],
     a: ['http', 'https', 'mailto'],
-    // A citation is a document, so it has no use for the data: and mailto:
-    // schemes the global list carries for links and inline images.
+    // A citation is a document, so it has no use for either.
     blockquote: ['http', 'https'],
     q: ['http', 'https']
   },
@@ -145,7 +157,11 @@ export const ENTRY_CONTENT_SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
   enforceHtmlBoundary: true
 }
 
-function sanitizeEntryContent(content: string, siteLink: string, entryLink: string) {
+function sanitizeEntryContent(
+  content: string,
+  siteLink: string,
+  entryLink: string
+) {
   return sanitizeHtml(content, {
     ...ENTRY_CONTENT_SANITIZE_OPTIONS,
     transformTags: {

--- a/action/feeds/parsers.ts
+++ b/action/feeds/parsers.ts
@@ -113,6 +113,19 @@ function resolveUrl(
   }
 }
 
+/**
+ * The entry's own URL, made absolute against the site. Atom allows a relative
+ * link (RFC 4287) and RSS feeds publish them too, and a relative one is no use
+ * as a base: the entry's links would fall back to the site, and the reader
+ * stores it as the entry URL, so both its resolution and its "View Original"
+ * would point at the reader's own domain. An already absolute link is returned
+ * byte for byte, since it is part of the key an entry is stored under.
+ */
+function resolveEntryLink(rawLink: string, siteLink: string) {
+  if (!rawLink || parseAbsoluteHttpUrl(rawLink)) return rawLink
+  return resolveUrl(rawLink, siteLink, '')
+}
+
 function resolveContentUrl(
   url: string,
   target: UrlTarget,
@@ -223,7 +236,10 @@ export function parseRss(feedTitle: string, xml: any): Site {
             pubDate,
             description: entryDescription
           } = item
-          const entryLink = joinValuesOrEmptyString(entryLinks)
+          const entryLink = resolveEntryLink(
+            joinValuesOrEmptyString(entryLinks),
+            siteLink
+          )
           return {
             title: joinValuesOrEmptyString(title).trim(),
             link: entryLink,
@@ -269,7 +285,10 @@ export function parseAtom(feedTitle: string, xml: any): Site {
             : summary
               ? summary[0]._
               : ''
-          const entryLink = (itemLink && itemLink.$.href) || ''
+          const entryLink = resolveEntryLink(
+            (itemLink && itemLink.$.href) || '',
+            siteUrl
+          )
           return {
             title: joinValuesOrEmptyString(title).trim(),
             link: entryLink,

--- a/action/feeds/parsers.ts
+++ b/action/feeds/parsers.ts
@@ -1,11 +1,7 @@
 import { parseString } from 'xml2js'
 import sanitizeHtml from 'sanitize-html'
 
-import {
-  hasDownloadableImageExtension,
-  mapUrlAttributes,
-  type UrlTarget
-} from '../../lib/media'
+import { mapUrlAttributes, type UrlTarget } from '../../lib/media'
 
 export interface Entry {
   title: string
@@ -25,6 +21,47 @@ export interface Site {
 }
 
 type Values = string[] | { _: string; $: { type: 'text' } }[] | null
+
+/**
+ * Every image extension media.ts may download and serve from our own origin,
+ * and so also every extension whose link resolves against the media base rather
+ * than the document -- the two have to agree or a link stops matching the image
+ * it points at and silently keeps hotlinking. One list, so they cannot drift.
+ *
+ * SVG is deliberately absent: a localized file is navigable on the published
+ * origin, and a feed could otherwise plant a scripted SVG there.
+ */
+const DOWNLOADABLE_IMAGE_EXTENSIONS = new Set([
+  '.avif',
+  '.gif',
+  '.heic',
+  '.heif',
+  '.jpeg',
+  '.jpg',
+  '.jxl',
+  '.png',
+  '.tif',
+  '.tiff',
+  '.webp'
+])
+
+export function normalizeImageExtension(extension?: string | null) {
+  if (!extension) return null
+  const normalized = extension.trim().toLowerCase()
+  if (!DOWNLOADABLE_IMAGE_EXTENSIONS.has(normalized)) return null
+  return normalized
+}
+
+/**
+ * Whether a URL points at an image the action may download, which is what makes
+ * a link to it resolve against the same base as the image itself.
+ */
+function hasDownloadableImageExtension(url: string) {
+  const pathOnly = url.trim().split('#')[0].split('?')[0]
+  const dot = pathOnly.lastIndexOf('.')
+  if (dot < 0) return false
+  return DOWNLOADABLE_IMAGE_EXTENSIONS.has(pathOnly.slice(dot).toLowerCase())
+}
 
 function joinValuesOrEmptyString(values: Values) {
   if (values && values.length > 0 && typeof values[0] !== 'string') {
@@ -106,6 +143,8 @@ export const ENTRY_CONTENT_SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
     // feed published and lands on the reader's own domain.
     ...sanitizeHtml.defaults.allowedAttributes,
     img: ['src', 'alt', 'title', 'width', 'height', 'loading', 'srcset'],
+    // Kept so the source of a quotation survives into the stored JSON, and
+    // resolved like any other URL rather than left pointing at this site.
     blockquote: ['cite'],
     q: ['cite']
   },

--- a/action/feeds/parsers.ts
+++ b/action/feeds/parsers.ts
@@ -97,23 +97,25 @@ function resolveContentUrl(
 ) {
   const asMedia = resolveUrl(url, siteLink, entryLink)
   if (target === 'media') return asMedia
-  // A scheme-less link says "whatever this page is served over", and the page it
-  // ends up on is the reader, not the feed. Baking in the entry's scheme would
-  // pin every such link on an http feed to plaintext, where before this change
-  // the browser resolved it against the reader's own https.
-  if (url.trim().startsWith('//')) return `https:${url.trim()}`
   // A link to an image the store can download takes the media base so that when
   // some entry of the site also displays that image, the two agree and the link
-  // can be swapped for the downloaded copy. The trade is that a link to an
-  // image nothing displays gets the site base rather than the document one --
-  // same as the img rule it is matching, and the reason to keep the two
-  // together. An extension the store will never fetch, svg above all, buys
-  // nothing here and so resolves like any other link. Every other link resolves
-  // against the entry, the document base a browser would use and the only one
-  // that gets a bare "foo.html" or a "#footnote" right.
-  return hasDownloadableImageExtension(asMedia)
-    ? asMedia
-    : resolveUrl(url, entryLink, siteLink)
+  // can be swapped for the downloaded copy. This is checked first, before the
+  // scheme-less rule below, because agreeing with the image matters more than
+  // the scheme: disagree and the link is left hotlinking the origin. The trade
+  // is that a link to an image nothing displays gets the site base rather than
+  // the document one -- same as the img rule it is matching, and the reason to
+  // keep the two together. An extension the store will never fetch, svg above
+  // all, buys nothing here and so resolves like any other link.
+  if (hasDownloadableImageExtension(asMedia)) return asMedia
+  // A scheme-less link says "whatever this page is served over", and the page it
+  // ends up on is the reader, not the feed. Baking in the entry's scheme would
+  // pin every such link on an http feed to plaintext, where the browser would
+  // otherwise resolve it against the reader's own https.
+  if (url.trim().startsWith('//')) return `https:${url.trim()}`
+  // Every other link resolves against the entry, the document base a browser
+  // would use and the only one that gets a bare "foo.html" or a "#footnote"
+  // right.
+  return resolveUrl(url, entryLink, siteLink)
 }
 
 export const ENTRY_CONTENT_SANITIZE_OPTIONS: sanitizeHtml.IOptions = {

--- a/action/feeds/parsers.ts
+++ b/action/feeds/parsers.ts
@@ -91,10 +91,11 @@ function resolveContentUrl(
 ) {
   const asMedia = resolveUrl(url, siteLink, entryLink)
   if (target === 'media') return asMedia
-  // A link to an image resolves like the media it points at, so it matches the
-  // src the media store downloads and can be swapped for the local copy. The
-  // store collects across the whole site, so this holds whether the link wraps
-  // the image or another entry is the one displaying it. Every other link
+  // A link to an image takes the media base so that when some entry of the site
+  // also displays that image, the two agree and the link can be swapped for the
+  // downloaded copy. The trade is that a link to an image nothing displays gets
+  // the site base rather than the document one -- same as the img rule it is
+  // matching, and the reason to keep the two together. Every other link
   // resolves against the entry, the document base a browser would use and the
   // only one that gets a bare "foo.html" or a "#footnote" right.
   return isImageLikeUrl(asMedia)

--- a/action/feeds/parsers.ts
+++ b/action/feeds/parsers.ts
@@ -106,6 +106,9 @@ function resolveContentUrl(
 export const ENTRY_CONTENT_SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
   allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img']),
   allowedAttributes: {
+    // An attribute added here that carries a URL has to be listed in
+    // URL_ATTRIBUTES in lib/media.ts too, or it keeps whatever relative URL the
+    // feed published and lands on the reader's own domain.
     ...sanitizeHtml.defaults.allowedAttributes,
     img: ['src', 'alt', 'title', 'width', 'height', 'loading', 'srcset'],
     blockquote: ['cite'],

--- a/action/feeds/parsers.ts
+++ b/action/feeds/parsers.ts
@@ -99,8 +99,10 @@ function resolveContentUrl(
   // Media resolves against the site first. That base is known to be wrong for a
   // path-relative URL -- a browser uses the document, so "images/x.jpg" in an
   // entry at /2024/01/post/ belongs under that directory, not at the root. It
-  // is kept because it is what this project has always stored, and changing it
-  // re-hashes and re-downloads every image; see the open follow-up.
+  // is kept because it is what this project has always stored: every image is
+  // hashed under the URL this produces, so switching to the entry base re-keys
+  // and re-downloads all of them, and that is worth doing on its own with
+  // before-and-after numbers from real feeds rather than as part of a link fix.
   const asMedia = resolveUrl(url, siteLink, entryLink)
   if (target === 'media') return asMedia
   // A link to an image the store can download takes the media base so that when
@@ -157,25 +159,39 @@ export const ENTRY_CONTENT_SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
   enforceHtmlBoundary: true
 }
 
+/**
+ * Rewrites every URL in entry content through `mapUrl`, under the sanitizer
+ * configuration the content is stored with. Both passes over entry content go
+ * through here -- this one and the media store's -- so neither can end up
+ * walking the content under different rules than the other.
+ *
+ * Every tag is visited rather than img and a alone, so a relative URL is
+ * resolved wherever it hides. Schemes are filtered after this runs, so a
+ * javascript: href is still dropped even though it is resolved here.
+ */
+export function mapContentUrls(
+  content: string,
+  mapUrl: (url: string, target: UrlTarget) => string
+) {
+  return sanitizeHtml(content, {
+    ...ENTRY_CONTENT_SANITIZE_OPTIONS,
+    transformTags: {
+      '*': (tagName, attribs) => ({
+        tagName,
+        attribs: mapUrlAttributes(attribs, mapUrl)
+      })
+    }
+  })
+}
+
 function sanitizeEntryContent(
   content: string,
   siteLink: string,
   entryLink: string
 ) {
-  return sanitizeHtml(content, {
-    ...ENTRY_CONTENT_SANITIZE_OPTIONS,
-    transformTags: {
-      // Every tag rather than img and a alone, so a relative URL is resolved
-      // wherever it hides. Schemes are filtered after this runs, so a
-      // javascript: href is still dropped even though it is resolved here.
-      '*': (tagName, attribs) => ({
-        tagName,
-        attribs: mapUrlAttributes(attribs, (url, target) =>
-          resolveContentUrl(url, target, siteLink, entryLink)
-        )
-      })
-    }
-  })
+  return mapContentUrls(content, (url, target) =>
+    resolveContentUrl(url, target, siteLink, entryLink)
+  )
 }
 
 function parseDate(dateString: string): number {

--- a/action/feeds/parsers.ts
+++ b/action/feeds/parsers.ts
@@ -2,6 +2,7 @@ import { parseString } from 'xml2js'
 import sanitizeHtml from 'sanitize-html'
 
 import { mapUrlAttributes, type UrlTarget } from '../../lib/media'
+import { hasDownloadableImageExtension } from './images'
 
 export interface Entry {
   title: string
@@ -22,54 +23,12 @@ export interface Site {
 
 type Values = string[] | { _: string; $: { type: 'text' } }[] | null
 
-/**
- * Every image extension media.ts may download and serve from our own origin,
- * and so also every extension whose link resolves against the media base rather
- * than the document -- the two have to agree or a link stops matching the image
- * it points at and silently keeps hotlinking. One list, so they cannot drift.
- *
- * SVG is deliberately absent: a localized file is navigable on the published
- * origin, and a feed could otherwise plant a scripted SVG there.
- */
-const DOWNLOADABLE_IMAGE_EXTENSIONS = new Set([
-  '.avif',
-  '.gif',
-  '.heic',
-  '.heif',
-  '.jpeg',
-  '.jpg',
-  '.jxl',
-  '.png',
-  '.tif',
-  '.tiff',
-  '.webp'
-])
-
-export function normalizeImageExtension(extension?: string | null) {
-  if (!extension) return null
-  const normalized = extension.trim().toLowerCase()
-  if (!DOWNLOADABLE_IMAGE_EXTENSIONS.has(normalized)) return null
-  return normalized
-}
-
-/**
- * Whether a URL points at an image the action may download, which is what makes
- * a link to it resolve against the same base as the image itself.
- */
-function hasDownloadableImageExtension(url: string) {
-  const pathOnly = url.trim().split('#')[0].split('?')[0]
-  const dot = pathOnly.lastIndexOf('.')
-  if (dot < 0) return false
-  return DOWNLOADABLE_IMAGE_EXTENSIONS.has(pathOnly.slice(dot).toLowerCase())
-}
-
 function joinValuesOrEmptyString(values: Values) {
   if (values && values.length > 0 && typeof values[0] !== 'string') {
     return values[0]._
   }
   return (values && values.join('').trim()) || ''
 }
-
 function parseAbsoluteHttpUrl(input?: string | null) {
   if (!input) return null
   try {
@@ -120,8 +79,12 @@ function resolveUrl(
  * stores it as the entry URL, so both its resolution and its "View Original"
  * would point at the reader's own domain. An already absolute link is returned
  * byte for byte, since it is part of the key an entry is stored under.
+ *
+ * A feed that does publish relative links is therefore re-keyed once, the first
+ * run after this ships: its stored entries reappear under new keys and the old
+ * ones are cleaned up. That is the cost of the fix, not a bug to undo.
  */
-function resolveEntryLink(rawLink: string, siteLink: string) {
+function absoluteEntryLink(rawLink: string, siteLink: string) {
   if (!rawLink || parseAbsoluteHttpUrl(rawLink)) return rawLink
   return resolveUrl(rawLink, siteLink, '')
 }
@@ -134,6 +97,11 @@ function resolveContentUrl(
 ) {
   const asMedia = resolveUrl(url, siteLink, entryLink)
   if (target === 'media') return asMedia
+  // A scheme-less link says "whatever this page is served over", and the page it
+  // ends up on is the reader, not the feed. Baking in the entry's scheme would
+  // pin every such link on an http feed to plaintext, where before this change
+  // the browser resolved it against the reader's own https.
+  if (url.trim().startsWith('//')) return `https:${url.trim()}`
   // A link to an image the store can download takes the media base so that when
   // some entry of the site also displays that image, the two agree and the link
   // can be swapped for the downloaded copy. The trade is that a link to an
@@ -164,6 +132,8 @@ export const ENTRY_CONTENT_SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
   allowedSchemes: ['http', 'https', 'mailto', 'data'],
   allowedSchemesByTag: {
     img: ['http', 'https', 'data'],
+    // Only an inline image has any use for data:, so a link does not get it.
+    a: ['http', 'https', 'mailto'],
     // A citation is a document, so it has no use for the data: and mailto:
     // schemes the global list carries for links and inline images.
     blockquote: ['http', 'https'],
@@ -236,7 +206,7 @@ export function parseRss(feedTitle: string, xml: any): Site {
             pubDate,
             description: entryDescription
           } = item
-          const entryLink = resolveEntryLink(
+          const entryLink = absoluteEntryLink(
             joinValuesOrEmptyString(entryLinks),
             siteLink
           )
@@ -285,7 +255,7 @@ export function parseAtom(feedTitle: string, xml: any): Site {
             : summary
               ? summary[0]._
               : ''
-          const entryLink = resolveEntryLink(
+          const entryLink = absoluteEntryLink(
             (itemLink && itemLink.$.href) || '',
             siteUrl
           )

--- a/lib/components/ItemContent.test.tsx
+++ b/lib/components/ItemContent.test.tsx
@@ -54,7 +54,9 @@ test('#ItemContent resolves URLs outside of a and img tags', (t) => {
   )
 })
 
-test('#ItemContent serves downloaded media from this site', (t) => {
+// Serial because it swaps NEXT_PUBLIC_BASE_PATH, which the component reads as
+// it renders, and ava runs a file's tests concurrently.
+test.serial('#ItemContent serves downloaded media from this site', (t) => {
   process.env.NEXT_PUBLIC_BASE_PATH = '/feeds'
   try {
     const output = render(
@@ -80,10 +82,27 @@ test('#ItemContent opens content links in a new tab', (t) => {
   t.true(output.includes('rel="noopener noreferrer"'))
 })
 
+test('#ItemContent hardens remote images', (t) => {
+  const output = render('<img src="https://example.com/a.png" />')
+  // An image that could not be downloaded still points at its origin, where a
+  // referrer often triggers hotlink protection.
+  t.true(output.includes('referrerPolicy="no-referrer"'))
+  t.true(output.includes('loading="lazy"'))
+  t.true(
+    render('<img src="https://example.com/a.png" loading="eager" />').includes(
+      'loading="eager"'
+    )
+  )
+})
+
 test('#ItemContent leaves data uri images alone', (t) => {
-  const output = render('<img src="data:image/gif;base64,AAA" />')
+  const output = render(
+    '<img src="data:image/gif;base64,AAA" /><img src="https://example.com/a.png" />'
+  )
   t.true(output.includes('src="data:image/gif;base64,AAA"'))
-  t.false(output.includes('referrerPolicy'))
+  // Only the remote image is hardened, so this stays a real assertion even if
+  // the hardening itself is removed.
+  t.is(output.match(/referrerPolicy/g)?.length, 1)
 })
 
 test('#ItemContent keeps relative URLs when the entry URL is unusable', (t) => {

--- a/lib/components/ItemContent.test.tsx
+++ b/lib/components/ItemContent.test.tsx
@@ -111,9 +111,14 @@ test('#ItemContent resolves a feed path that only looks like local media', (t) =
 })
 
 test('#ItemContent opens content links in a new tab', (t) => {
-  const output = render('<a href="https://example.com/page">Link</a>')
-  t.true(output.includes('target="_blank"'))
-  t.true(output.includes('rel="noopener noreferrer"'))
+  // Asserted on the anchor itself: the header's own "View Original" link
+  // carries these attributes on every render, so a looser check would pass
+  // against content containing no links at all.
+  t.true(
+    render('<a href="https://example.com/page">Link</a>').includes(
+      '<a href="https://example.com/page" target="_blank" rel="noopener noreferrer">Link</a>'
+    )
+  )
 })
 
 test('#ItemContent hardens remote images', (t) => {

--- a/lib/components/ItemContent.test.tsx
+++ b/lib/components/ItemContent.test.tsx
@@ -1,0 +1,100 @@
+import test from 'ava'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+import { ItemContent } from './ItemContent'
+import { Content } from '../storage/types'
+
+const ENTRY_URL = 'https://feed.example/posts/entry-1'
+
+const render = (content: string, url: string = ENTRY_URL) =>
+  renderToStaticMarkup(
+    <ItemContent
+      content={
+        {
+          title: 'Entry',
+          content,
+          url,
+          siteKey: 'site',
+          siteTitle: 'Site',
+          timestamp: 1700000000
+        } as Content
+      }
+    />
+  )
+
+test('#ItemContent resolves relative URLs against the entry', (t) => {
+  t.true(
+    render('<a href="/posts/other">Read more</a>').includes(
+      'href="https://feed.example/posts/other"'
+    )
+  )
+  t.true(
+    render('<a href="#footnote">Footnote</a>').includes(
+      'href="https://feed.example/posts/entry-1#footnote"'
+    )
+  )
+  // Entries stored before the action resolved URLs still hold relative ones.
+  const legacy = render(
+    '<img src="cover.jpg" srcset="cover.jpg 1x, /w.png 2x" />'
+  )
+  t.true(legacy.includes('src="https://feed.example/posts/cover.jpg"'))
+  t.true(
+    legacy.includes(
+      'srcSet="https://feed.example/posts/cover.jpg 1x, https://feed.example/w.png 2x"'
+    )
+  )
+})
+
+test('#ItemContent resolves URLs outside of a and img tags', (t) => {
+  t.true(
+    render('<blockquote cite="/interview">Quoted</blockquote>').includes(
+      'cite="https://feed.example/interview"'
+    )
+  )
+})
+
+test('#ItemContent serves downloaded media from this site', (t) => {
+  process.env.NEXT_PUBLIC_BASE_PATH = '/feeds'
+  try {
+    const output = render(
+      '<a href="/media/a.png"><img src="/media/a.png" srcset="/media/a.png 1x, https://example.com/b.png 2x" /></a>'
+    )
+    // The link to a downloaded image needs the base path too, not the entry.
+    t.true(output.includes('href="/feeds/media/a.png"'))
+    t.true(output.includes('src="/feeds/media/a.png"'))
+    // An image that failed to download keeps its remote candidate.
+    t.true(
+      output.includes(
+        'srcSet="/feeds/media/a.png 1x, https://example.com/b.png 2x"'
+      )
+    )
+  } finally {
+    delete process.env.NEXT_PUBLIC_BASE_PATH
+  }
+})
+
+test('#ItemContent opens content links in a new tab', (t) => {
+  const output = render('<a href="https://example.com/page">Link</a>')
+  t.true(output.includes('target="_blank"'))
+  t.true(output.includes('rel="noopener noreferrer"'))
+})
+
+test('#ItemContent leaves data uri images alone', (t) => {
+  const output = render('<img src="data:image/gif;base64,AAA" />')
+  t.true(output.includes('src="data:image/gif;base64,AAA"'))
+  t.false(output.includes('referrerPolicy'))
+})
+
+test('#ItemContent keeps relative URLs when the entry URL is unusable', (t) => {
+  // A malformed feed can leave the entry link empty or non-http, and resolving
+  // against it would point the reader at itself, or at a script URL.
+  t.true(
+    render('<a href="/posts/other">x</a>', '').includes('href="/posts/other"')
+  )
+  t.true(
+    render('<a href="#fn1">x</a>', 'javascript:alert(1)').includes(
+      'href="#fn1"'
+    )
+  )
+})

--- a/lib/components/ItemContent.test.tsx
+++ b/lib/components/ItemContent.test.tsx
@@ -73,6 +73,13 @@ test.serial('#ItemContent serves downloaded media from this site', (t) => {
         `srcSet="/feeds${DOWNLOADED} 1x, https://example.com/b.png 2x"`
       )
     )
+    // A legacy entry whose images only partly downloaded mixes the two
+    // branches within one srcset.
+    t.true(
+      render(`<img srcset="${DOWNLOADED} 1x, legacy.png 2x" />`).includes(
+        `srcSet="/feeds${DOWNLOADED} 1x, https://feed.example/posts/legacy.png 2x"`
+      )
+    )
   } finally {
     delete process.env.NEXT_PUBLIC_BASE_PATH
   }

--- a/lib/components/ItemContent.test.tsx
+++ b/lib/components/ItemContent.test.tsx
@@ -54,26 +54,53 @@ test('#ItemContent resolves URLs outside of a and img tags', (t) => {
   )
 })
 
+// The media store names every file it writes after the sha256 of its URL.
+const DOWNLOADED = `/media/${'a'.repeat(64)}.png`
+const downloadedMedia = `<a href="${DOWNLOADED}"><img src="${DOWNLOADED}" srcset="${DOWNLOADED} 1x, https://example.com/b.png 2x" /></a>`
+
 // Serial because it swaps NEXT_PUBLIC_BASE_PATH, which the component reads as
 // it renders, and ava runs a file's tests concurrently.
 test.serial('#ItemContent serves downloaded media from this site', (t) => {
   process.env.NEXT_PUBLIC_BASE_PATH = '/feeds'
   try {
-    const output = render(
-      '<a href="/media/a.png"><img src="/media/a.png" srcset="/media/a.png 1x, https://example.com/b.png 2x" /></a>'
-    )
+    const output = render(downloadedMedia)
     // The link to a downloaded image needs the base path too, not the entry.
-    t.true(output.includes('href="/feeds/media/a.png"'))
-    t.true(output.includes('src="/feeds/media/a.png"'))
+    t.true(output.includes(`href="/feeds${DOWNLOADED}"`))
+    t.true(output.includes(`src="/feeds${DOWNLOADED}"`))
     // An image that failed to download keeps its remote candidate.
     t.true(
       output.includes(
-        'srcSet="/feeds/media/a.png 1x, https://example.com/b.png 2x"'
+        `srcSet="/feeds${DOWNLOADED} 1x, https://example.com/b.png 2x"`
       )
     )
   } finally {
     delete process.env.NEXT_PUBLIC_BASE_PATH
   }
+})
+
+test.serial(
+  '#ItemContent leaves downloaded media alone without a base path',
+  (t) => {
+    delete process.env.NEXT_PUBLIC_BASE_PATH
+    const output = render(downloadedMedia)
+    // Downloaded media is served from this site at any base path, so it must
+    // never be resolved against the entry.
+    t.true(output.includes(`href="${DOWNLOADED}"`))
+    t.true(output.includes(`src="${DOWNLOADED}"`))
+    t.true(
+      output.includes(`srcSet="${DOWNLOADED} 1x, https://example.com/b.png 2x"`)
+    )
+  }
+)
+
+test('#ItemContent resolves a feed path that only looks like local media', (t) => {
+  // Plenty of sites lay their own uploads out under /media, and those are not
+  // files we downloaded -- they belong to the entry.
+  t.true(
+    render('<img src="/media/2019/photo.jpg" />').includes(
+      'src="https://feed.example/media/2019/photo.jpg"'
+    )
+  )
 })
 
 test('#ItemContent opens content links in a new tab', (t) => {

--- a/lib/components/ItemContent.tsx
+++ b/lib/components/ItemContent.tsx
@@ -5,7 +5,7 @@ import { ExternalLink } from 'lucide-react'
 import { BackButton } from './BackButton'
 import parse from 'html-react-parser'
 import { isLocalMediaPath, mapUrlAttributes, withBasePath } from '../media'
-import { resolveEntryLink } from '../utils'
+import { resolveEntryUrl } from '../utils'
 
 interface ReactParserNode {
   name: string
@@ -82,15 +82,15 @@ export const ItemContent = ({ content, selectBack }: ItemContentProps) => {
               if (!node.attribs) return domNode
 
               // Downloaded media is served from this site, so it only needs the
-              // base path. Everything else resolves against the entry, which
-              // keeps a relative URL stored before the action resolved them
-              // from pointing at the reader's own domain. Links and media both
-              // take the entry as their base here: the site link the action
-              // prefers for media is not part of the stored entry.
+              // base path. Everything else resolves against the entry, which is
+              // what stops a URL stored before the action resolved them from
+              // pointing at the reader's own domain. Links and media both take
+              // the entry as their base here: the site link the action prefers
+              // for media is not part of the stored entry.
               node.attribs = mapUrlAttributes(node.attribs, (url) =>
                 isLocalMediaPath(url)
                   ? withBasePath(url, basePath)
-                  : resolveEntryLink(url, content.url)
+                  : resolveEntryUrl(url, content.url)
               )
 
               if (node.name === 'a') {

--- a/lib/components/ItemContent.tsx
+++ b/lib/components/ItemContent.tsx
@@ -4,7 +4,8 @@ import { formatDistance } from 'date-fns'
 import { ExternalLink } from 'lucide-react'
 import { BackButton } from './BackButton'
 import parse from 'html-react-parser'
-import { isLocalMediaPath, rewriteLocalSrcSet, withBasePath } from '../media'
+import { isLocalMediaPath, mapUrlAttributes, withBasePath } from '../media'
+import { resolveEntryLink } from '../utils'
 
 interface ReactParserNode {
   name: string
@@ -78,27 +79,32 @@ export const ItemContent = ({ content, selectBack }: ItemContentProps) => {
           {parse(content.content, {
             replace: (domNode) => {
               const node = domNode as ReactParserNode
-              if (node.attribs && node.name === 'a') {
+              if (!node.attribs) return domNode
+
+              // Downloaded media is served from this site, so it only needs the
+              // base path. Everything else resolves against the entry, which
+              // keeps a relative URL stored before the action resolved them
+              // from pointing at the reader's own domain.
+              node.attribs = mapUrlAttributes(node.attribs, (url) =>
+                isLocalMediaPath(url)
+                  ? withBasePath(url, basePath)
+                  : resolveEntryLink(url, content.url)
+              )
+
+              if (node.name === 'a') {
                 node.attribs.target = '_blank'
                 node.attribs.rel = 'noopener noreferrer'
-                return node
               }
-              if (node.attribs && node.name === 'img') {
-                const { src, srcset } = node.attribs
-                if (src?.startsWith('data:')) return node
+              if (
+                node.name === 'img' &&
+                !node.attribs.src?.startsWith('data:')
+              ) {
                 // Images that could not be downloaded still point at their
                 // origin, where a referrer often triggers hotlink protection.
                 node.attribs.referrerpolicy = 'no-referrer'
                 node.attribs.loading = node.attribs.loading || 'lazy'
-                if (isLocalMediaPath(src)) {
-                  node.attribs.src = withBasePath(src, basePath)
-                }
-                if (srcset) {
-                  node.attribs.srcset = rewriteLocalSrcSet(srcset, basePath)
-                }
-                return node
               }
-              return domNode
+              return node
             }
           })}
         </div>

--- a/lib/components/ItemContent.tsx
+++ b/lib/components/ItemContent.tsx
@@ -84,7 +84,9 @@ export const ItemContent = ({ content, selectBack }: ItemContentProps) => {
               // Downloaded media is served from this site, so it only needs the
               // base path. Everything else resolves against the entry, which
               // keeps a relative URL stored before the action resolved them
-              // from pointing at the reader's own domain.
+              // from pointing at the reader's own domain. Links and media both
+              // take the entry as their base here: the site link the action
+              // prefers for media is not part of the stored entry.
               node.attribs = mapUrlAttributes(node.attribs, (url) =>
                 isLocalMediaPath(url)
                   ? withBasePath(url, basePath)

--- a/lib/media.test.ts
+++ b/lib/media.test.ts
@@ -2,22 +2,33 @@ import test from 'ava'
 
 import { isLocalMediaPath, mapUrlAttributes, withBasePath } from './media'
 
+// The media store names every file it writes after the sha256 of its URL.
+const DOWNLOADED = `/media/${'a'.repeat(64)}.png`
+
 test('#isLocalMediaPath matches downloaded media paths only', (t) => {
-  t.true(isLocalMediaPath('/media/a.png'))
+  t.true(isLocalMediaPath(DOWNLOADED))
+  t.true(isLocalMediaPath(`${DOWNLOADED}?v=2`))
   t.false(isLocalMediaPath('/media/'))
   t.false(isLocalMediaPath('https://example.com/media/a.png'))
   t.false(isLocalMediaPath('data:image/gif;base64,AAA'))
   t.false(isLocalMediaPath(''))
   t.false(isLocalMediaPath(undefined))
+  // A feed's own /media path is not something we downloaded, so it has to keep
+  // resolving against the entry rather than being served from this site.
+  t.false(isLocalMediaPath('/media/2019/photo.jpg'))
+  t.false(isLocalMediaPath('/media/a.png'))
+  t.false(isLocalMediaPath(`/media/${'a'.repeat(63)}.png`))
+  t.false(isLocalMediaPath(`/media/${'z'.repeat(64)}.png`))
 })
 
 test('#withBasePath prefixes local media only', (t) => {
-  t.is(withBasePath('/media/a.png', '/feeds'), '/feeds/media/a.png')
-  t.is(withBasePath('/media/a.png', ''), '/media/a.png')
+  t.is(withBasePath(DOWNLOADED, '/feeds'), `/feeds${DOWNLOADED}`)
+  t.is(withBasePath(DOWNLOADED, ''), DOWNLOADED)
   t.is(
     withBasePath('https://example.com/a.png', '/feeds'),
     'https://example.com/a.png'
   )
+  t.is(withBasePath('/media/2019/photo.jpg', '/feeds'), '/media/2019/photo.jpg')
 })
 
 test('#mapUrlAttributes maps every url and reports what it points at', (t) => {
@@ -114,6 +125,30 @@ test('#mapUrlAttributes keeps commas that belong to a srcset URL', (t) => {
     'data:image/gif;base64,R0lGODlhAQ 1x, /real.png 2x'
   )
   t.deepEqual(seen, ['data:image/gif;base64,R0lGODlhAQ', '/real.png'])
+})
+
+test('#mapUrlAttributes reads srcset candidates the way HTML does', (t) => {
+  const seen: string[] = []
+  const collect = (url: string) => {
+    seen.push(url)
+    return `M(${url})`
+  }
+
+  // No space after the comma is the common compact form.
+  t.is(
+    mapUrlAttributes({ srcset: 'a.png 1x,b.png 2x' }, collect).srcset,
+    'M(a.png) 1x, M(b.png) 2x'
+  )
+  t.deepEqual(seen, ['a.png', 'b.png'])
+
+  // A comma inside a descriptor-less URL belongs to the URL, so splitting on
+  // commas would wrongly make this two candidates.
+  seen.length = 0
+  t.is(
+    mapUrlAttributes({ srcset: 'a.png,b.png' }, collect).srcset,
+    'M(a.png,b.png)'
+  )
+  t.deepEqual(seen, ['a.png,b.png'])
 })
 
 test('#mapUrlAttributes ignores attributes inherited from Object', (t) => {

--- a/lib/media.test.ts
+++ b/lib/media.test.ts
@@ -61,3 +61,52 @@ test('#mapUrlAttributes leaves the original attributes alone', (t) => {
   t.is(attribs.href, 'page.html')
   t.is(mapped.href, 'changed')
 })
+
+test('#mapUrlAttributes keeps srcset candidates a mapper skipped', (t) => {
+  // A candidate can carry no descriptor, and one that maps to itself has to
+  // survive untouched -- images that fail to download keep their remote URL.
+  t.is(
+    mapUrlAttributes(
+      { srcset: '/media/a.png 1x, https://example.com/b.png 2x, /media/c.png' },
+      (url) => (url.startsWith('/media/') ? `/feeds${url}` : url)
+    ).srcset,
+    '/feeds/media/a.png 1x, https://example.com/b.png 2x, /feeds/media/c.png'
+  )
+})
+
+test('#mapUrlAttributes keeps commas that belong to a srcset URL', (t) => {
+  const seen: string[] = []
+  const collect = (url: string) => {
+    seen.push(url)
+    return url
+  }
+
+  // Image CDNs put commas in the path, and every data: URI carries one.
+  t.is(
+    mapUrlAttributes(
+      { srcset: 'https://cdn.example/upload/w_300,h_200/x.jpg 1x' },
+      collect
+    ).srcset,
+    'https://cdn.example/upload/w_300,h_200/x.jpg 1x'
+  )
+  t.deepEqual(seen, ['https://cdn.example/upload/w_300,h_200/x.jpg'])
+
+  seen.length = 0
+  t.is(
+    mapUrlAttributes(
+      { srcset: 'data:image/gif;base64,R0lGODlhAQ 1x, /real.png 2x' },
+      collect
+    ).srcset,
+    'data:image/gif;base64,R0lGODlhAQ 1x, /real.png 2x'
+  )
+  t.deepEqual(seen, ['data:image/gif;base64,R0lGODlhAQ', '/real.png'])
+})
+
+test('#mapUrlAttributes ignores attributes inherited from Object', (t) => {
+  // Attribute names come straight from feed HTML.
+  const attribs = { constructor: 'evil.html', toString: 'evil.html' }
+  t.deepEqual(
+    mapUrlAttributes(attribs, () => 'mapped'),
+    attribs
+  )
+})

--- a/lib/media.test.ts
+++ b/lib/media.test.ts
@@ -74,6 +74,20 @@ test('#mapUrlAttributes keeps srcset candidates a mapper skipped', (t) => {
   )
 })
 
+test('#mapUrlAttributes maps a candidate whose descriptor is omitted', (t) => {
+  // A candidate can end at a comma rather than a descriptor, which is the only
+  // thing separating its URL from the one that follows.
+  const seen: string[] = []
+  t.is(
+    mapUrlAttributes({ srcset: '/media/a.png, /media/b.png 2x' }, (url) => {
+      seen.push(url)
+      return `/feeds${url}`
+    }).srcset,
+    '/feeds/media/a.png, /feeds/media/b.png 2x'
+  )
+  t.deepEqual(seen, ['/media/a.png', '/media/b.png'])
+})
+
 test('#mapUrlAttributes keeps commas that belong to a srcset URL', (t) => {
   const seen: string[] = []
   const collect = (url: string) => {

--- a/lib/media.test.ts
+++ b/lib/media.test.ts
@@ -151,6 +151,22 @@ test('#mapUrlAttributes reads srcset candidates the way HTML does', (t) => {
   t.deepEqual(seen, ['a.png,b.png'])
 })
 
+test('#mapUrlAttributes scans a long comma run in linear time', (t) => {
+  // A feed publishes the srcset, so scanning it must not be quadratic. This
+  // input takes milliseconds linearly and about sixteen seconds otherwise.
+  t.timeout(5000)
+  const seen: string[] = []
+  const srcset = `a${','.repeat(200_000)}x`
+  t.is(
+    mapUrlAttributes({ srcset }, (url) => {
+      seen.push(url)
+      return url
+    }).srcset,
+    srcset
+  )
+  t.deepEqual(seen, [srcset])
+})
+
 test('#mapUrlAttributes ignores attributes inherited from Object', (t) => {
   // Attribute names come straight from feed HTML.
   const attribs = { constructor: 'evil.html', toString: 'evil.html' }

--- a/lib/media.test.ts
+++ b/lib/media.test.ts
@@ -65,6 +65,20 @@ test('#mapUrlAttributes maps every url and reports what it points at', (t) => {
   ])
 })
 
+test('#mapUrlAttributes skips a URL attribute holding nothing', (t) => {
+  // The guard has to be on the value, not just on the attribute name, or an
+  // empty href is handed to the mapper and comes back as a resolved URL.
+  const seen: string[] = []
+  t.deepEqual(
+    mapUrlAttributes({ href: '', src: 'a.png' }, (url) => {
+      seen.push(url)
+      return `resolved:${url}`
+    }),
+    { href: '', src: 'resolved:a.png' }
+  )
+  t.deepEqual(seen, ['a.png'])
+})
+
 test('#mapUrlAttributes leaves the original attributes alone', (t) => {
   const attribs = { href: 'page.html' }
   const mapped = mapUrlAttributes(attribs, () => 'changed')

--- a/lib/media.test.ts
+++ b/lib/media.test.ts
@@ -1,6 +1,6 @@
 import test from 'ava'
 
-import { isLocalMediaPath, rewriteLocalSrcSet, withBasePath } from './media'
+import { isLocalMediaPath, mapUrlAttributes, withBasePath } from './media'
 
 test('#isLocalMediaPath matches downloaded media paths only', (t) => {
   t.true(isLocalMediaPath('/media/a.png'))
@@ -20,16 +20,44 @@ test('#withBasePath prefixes local media only', (t) => {
   )
 })
 
-test('#rewriteLocalSrcSet keeps remote candidates and descriptors', (t) => {
-  t.is(
-    rewriteLocalSrcSet(
-      '/media/a.png 1x, https://example.com/b.png 2x, /media/c.png',
-      '/feeds'
-    ),
-    '/feeds/media/a.png 1x, https://example.com/b.png 2x, /feeds/media/c.png'
+test('#mapUrlAttributes maps every url and reports what it points at', (t) => {
+  const seen: [string, string][] = []
+  const attribs = mapUrlAttributes(
+    {
+      href: 'page.html',
+      cite: 'quote.html',
+      src: 'a.png',
+      srcset: 'a.png 1x, b.png 2x',
+      alt: 'not a url',
+      title: ''
+    },
+    (url, target) => {
+      seen.push([url, target])
+      return `resolved:${url}`
+    }
   )
-  t.is(
-    rewriteLocalSrcSet('/media/a.png 1x', ''),
-    '/media/a.png 1x'
-  )
+
+  t.deepEqual(attribs, {
+    href: 'resolved:page.html',
+    cite: 'resolved:quote.html',
+    src: 'resolved:a.png',
+    srcset: 'resolved:a.png 1x, resolved:b.png 2x',
+    alt: 'not a url',
+    title: ''
+  })
+  t.deepEqual(seen, [
+    ['page.html', 'link'],
+    ['quote.html', 'link'],
+    ['a.png', 'media'],
+    ['a.png', 'media'],
+    ['b.png', 'media']
+  ])
+})
+
+test('#mapUrlAttributes leaves the original attributes alone', (t) => {
+  const attribs = { href: 'page.html' }
+  const mapped = mapUrlAttributes(attribs, () => 'changed')
+
+  t.is(attribs.href, 'page.html')
+  t.is(mapped.href, 'changed')
 })

--- a/lib/media.ts
+++ b/lib/media.ts
@@ -98,8 +98,10 @@ export type UrlTarget = 'link' | 'media'
 
 interface UrlAttribute {
   target: UrlTarget
-  /** Comma separated candidate list rather than a single URL, as in srcset. */
-  list: boolean
+  /** Holds a srcset candidate list rather than a single URL, and is parsed by
+   * srcset's grammar specifically -- a space separated list such as <a ping>
+   * would need its own format rather than this flag. */
+  srcset: boolean
 }
 
 /**
@@ -108,10 +110,10 @@ interface UrlAttribute {
  * covers a newly allowed tag as soon as its attribute is listed here.
  */
 const URL_ATTRIBUTES: Record<string, UrlAttribute> = {
-  href: { target: 'link', list: false },
-  cite: { target: 'link', list: false },
-  src: { target: 'media', list: false },
-  srcset: { target: 'media', list: true }
+  href: { target: 'link', srcset: false },
+  cite: { target: 'link', srcset: false },
+  src: { target: 'media', srcset: false },
+  srcset: { target: 'media', srcset: true }
 }
 
 /**
@@ -130,7 +132,7 @@ export function mapUrlAttributes(
     if (!Object.hasOwn(URL_ATTRIBUTES, name) || !value) continue
     const attribute = URL_ATTRIBUTES[name]
     const map = (url: string) => mapUrl(url, attribute.target)
-    nextAttribs[name] = attribute.list ? mapSrcSet(value, map) : map(value)
+    nextAttribs[name] = attribute.srcset ? mapSrcSet(value, map) : map(value)
   }
   return nextAttribs
 }

--- a/lib/media.ts
+++ b/lib/media.ts
@@ -6,21 +6,52 @@ export const LOCAL_MEDIA_PATH = '/media'
 
 const LOCAL_MEDIA_PREFIX = `${LOCAL_MEDIA_PATH}/`
 
+const WHITESPACE = /\s/
+
 /**
  * Rewrites every candidate URL of a srcset, keeping its descriptor.
+ *
+ * Splitting on commas alone would tear apart a URL that contains one, which
+ * image CDNs emit routinely (`/upload/w_300,h_200/x.jpg`) and every `data:` URI
+ * does. So candidates are read the way HTML defines them: the URL runs to the
+ * next whitespace, and a comma only ends a candidate when it trails the URL or
+ * follows the descriptor.
  */
-export function mapSrcSet(srcSet: string, mapUrl: (url: string) => string) {
-  return srcSet
-    .split(',')
-    .map((candidate) => candidate.trim())
-    .filter((candidate) => candidate.length > 0)
-    .map((candidate) => {
-      const [urlPart, ...descriptorParts] = candidate.split(/\s+/)
-      const url = mapUrl(urlPart)
-      const descriptor = descriptorParts.join(' ').trim()
-      return descriptor ? `${url} ${descriptor}` : url
-    })
-    .join(', ')
+function mapSrcSet(srcSet: string, mapUrl: (url: string) => string) {
+  const candidates: string[] = []
+  let index = 0
+
+  while (index < srcSet.length) {
+    while (
+      index < srcSet.length &&
+      (WHITESPACE.test(srcSet[index]) || srcSet[index] === ',')
+    ) {
+      index++
+    }
+    if (index >= srcSet.length) break
+
+    const urlStart = index
+    while (index < srcSet.length && !WHITESPACE.test(srcSet[index])) index++
+    let url = srcSet.slice(urlStart, index)
+    let descriptor = ''
+
+    const trailingCommas = url.match(/,+$/)
+    if (trailingCommas) {
+      url = url.slice(0, -trailingCommas[0].length)
+    } else {
+      while (index < srcSet.length && WHITESPACE.test(srcSet[index])) index++
+      const descriptorStart = index
+      while (index < srcSet.length && srcSet[index] !== ',') index++
+      descriptor = srcSet.slice(descriptorStart, index).trim()
+      index++
+    }
+
+    if (!url) continue
+    const mapped = mapUrl(url)
+    candidates.push(descriptor ? `${mapped} ${descriptor}` : mapped)
+  }
+
+  return candidates.join(', ')
 }
 
 export function isLocalMediaPath(url?: string) {
@@ -53,13 +84,12 @@ interface UrlAttribute {
 /**
  * Every attribute that carries a URL in entry content. Walking this map instead
  * of naming tags keeps the action and the reader resolving the same set, and
- * covers new tags as soon as the sanitizer allows their attributes.
+ * covers a newly allowed tag as soon as its attribute is listed here.
  */
-export const URL_ATTRIBUTES: Record<string, UrlAttribute> = {
+const URL_ATTRIBUTES: Record<string, UrlAttribute> = {
   href: { target: 'link', list: false },
   cite: { target: 'link', list: false },
   src: { target: 'media', list: false },
-  poster: { target: 'media', list: false },
   srcset: { target: 'media', list: true }
 }
 
@@ -74,8 +104,10 @@ export function mapUrlAttributes(
 ) {
   const nextAttribs = { ...attribs }
   for (const [name, value] of Object.entries(nextAttribs)) {
+    // Attribute names come from feed HTML, so an own-property check keeps one
+    // called "constructor" from matching Object.prototype.
+    if (!Object.hasOwn(URL_ATTRIBUTES, name) || !value) continue
     const attribute = URL_ATTRIBUTES[name]
-    if (!attribute || !value) continue
     const map = (url: string) => mapUrl(url, attribute.target)
     nextAttribs[name] = attribute.list ? mapSrcSet(value, map) : map(value)
   }

--- a/lib/media.ts
+++ b/lib/media.ts
@@ -2,41 +2,12 @@
  * Shared between the action that downloads feed images and the reader that
  * renders them, so both sides always agree on where media lives -- and, through
  * URL_ATTRIBUTES below, on which attributes of entry content carry a URL at all
- * and whether each points at a document or at media.
+ * and whether each points at a document or at media. What the action may
+ * download is its own policy and lives with the parser.
  */
 export const LOCAL_MEDIA_PATH = '/media'
 
 const LOCAL_MEDIA_PREFIX = `${LOCAL_MEDIA_PATH}/`
-
-/**
- * Every image extension the action may download and serve from our own origin,
- * and so also every extension whose link resolves against the media base rather
- * than the document -- the two have to agree or a link stops matching the image
- * it points at and silently keeps hotlinking. One list, so they cannot drift.
- *
- * SVG is deliberately absent: a localized file is navigable on the published
- * origin, and a feed could otherwise plant a scripted SVG there.
- */
-const DOWNLOADABLE_IMAGE_EXTENSIONS = new Set([
-  '.avif',
-  '.gif',
-  '.heic',
-  '.heif',
-  '.jpeg',
-  '.jpg',
-  '.jxl',
-  '.png',
-  '.tif',
-  '.tiff',
-  '.webp'
-])
-
-export function normalizeImageExtension(extension?: string | null) {
-  if (!extension) return null
-  const normalized = extension.trim().toLowerCase()
-  if (!DOWNLOADABLE_IMAGE_EXTENSIONS.has(normalized)) return null
-  return normalized
-}
 
 /** The media store names every file it writes after the hash of its URL. */
 const LOCAL_MEDIA_FILE = /^[0-9a-f]{64}\.[a-z0-9]+$/
@@ -45,7 +16,7 @@ const LOCAL_MEDIA_FILE = /^[0-9a-f]{64}\.[a-z0-9]+$/
  * The part of a local media URL that names the file on disk, or null when the
  * URL is not one we wrote. Matching the hashed shape rather than the `/media`
  * prefix alone keeps a feed's own `/media/...` path from being mistaken for a
- * downloaded copy -- serving plenty of sites lay their uploads out that way.
+ * downloaded copy -- plenty of sites lay their own uploads out that way.
  */
 export function localMediaFileName(url?: string) {
   if (!url) return null
@@ -56,17 +27,6 @@ export function localMediaFileName(url?: string) {
     .split('?')[0]
     .split('#')[0]
   return LOCAL_MEDIA_FILE.test(fileName) ? fileName : null
-}
-
-/**
- * Whether a URL points at an image the action may download, which is what makes
- * a link to it resolve against the same base as the image itself.
- */
-export function hasDownloadableImageExtension(url: string) {
-  const pathOnly = url.trim().split('#')[0].split('?')[0]
-  const dot = pathOnly.lastIndexOf('.')
-  if (dot < 0) return false
-  return DOWNLOADABLE_IMAGE_EXTENSIONS.has(pathOnly.slice(dot).toLowerCase())
 }
 
 const WHITESPACE = /\s/
@@ -98,9 +58,12 @@ function mapSrcSet(srcSet: string, mapUrl: (url: string) => string) {
     let url = srcSet.slice(urlStart, index)
     let descriptor = ''
 
-    const trailingCommas = url.match(/,+$/)
-    if (trailingCommas) {
-      url = url.slice(0, -trailingCommas[0].length)
+    // Scanned rather than matched with /,+$/, which backtracks quadratically
+    // over a long run of commas that a feed is free to publish.
+    let end = url.length
+    while (end > 0 && url[end - 1] === ',') end--
+    if (end < url.length) {
+      url = url.slice(0, end)
     } else {
       while (index < srcSet.length && WHITESPACE.test(srcSet[index])) index++
       const descriptorStart = index

--- a/lib/media.ts
+++ b/lib/media.ts
@@ -1,6 +1,8 @@
 /**
  * Shared between the action that downloads feed images and the reader that
- * renders them, so both sides always agree on where media lives.
+ * renders them, so both sides always agree on where media lives -- and, through
+ * URL_ATTRIBUTES below, on which attributes of entry content carry a URL at all
+ * and whether each points at a document or at media.
  */
 export const LOCAL_MEDIA_PATH = '/media'
 

--- a/lib/media.ts
+++ b/lib/media.ts
@@ -3,7 +3,7 @@
  * renders them, so both sides always agree on where media lives -- and, through
  * URL_ATTRIBUTES below, on which attributes of entry content carry a URL at all
  * and whether each points at a document or at media. What the action may
- * download is its own policy and lives with the parser.
+ * download is its own policy and lives in action/feeds/images.ts.
  */
 export const LOCAL_MEDIA_PATH = '/media'
 

--- a/lib/media.ts
+++ b/lib/media.ts
@@ -8,6 +8,67 @@ export const LOCAL_MEDIA_PATH = '/media'
 
 const LOCAL_MEDIA_PREFIX = `${LOCAL_MEDIA_PATH}/`
 
+/**
+ * Every image extension the action may download and serve from our own origin,
+ * and so also every extension whose link resolves against the media base rather
+ * than the document -- the two have to agree or a link stops matching the image
+ * it points at and silently keeps hotlinking. One list, so they cannot drift.
+ *
+ * SVG is deliberately absent: a localized file is navigable on the published
+ * origin, and a feed could otherwise plant a scripted SVG there.
+ */
+const DOWNLOADABLE_IMAGE_EXTENSIONS = new Set([
+  '.avif',
+  '.gif',
+  '.heic',
+  '.heif',
+  '.jpeg',
+  '.jpg',
+  '.jxl',
+  '.png',
+  '.tif',
+  '.tiff',
+  '.webp'
+])
+
+export function normalizeImageExtension(extension?: string | null) {
+  if (!extension) return null
+  const normalized = extension.trim().toLowerCase()
+  if (!DOWNLOADABLE_IMAGE_EXTENSIONS.has(normalized)) return null
+  return normalized
+}
+
+/** The media store names every file it writes after the hash of its URL. */
+const LOCAL_MEDIA_FILE = /^[0-9a-f]{64}\.[a-z0-9]+$/
+
+/**
+ * The part of a local media URL that names the file on disk, or null when the
+ * URL is not one we wrote. Matching the hashed shape rather than the `/media`
+ * prefix alone keeps a feed's own `/media/...` path from being mistaken for a
+ * downloaded copy -- serving plenty of sites lay their uploads out that way.
+ */
+export function localMediaFileName(url?: string) {
+  if (!url) return null
+  const trimmed = url.trim()
+  if (!trimmed.startsWith(LOCAL_MEDIA_PREFIX)) return null
+  const fileName = trimmed
+    .slice(LOCAL_MEDIA_PREFIX.length)
+    .split('?')[0]
+    .split('#')[0]
+  return LOCAL_MEDIA_FILE.test(fileName) ? fileName : null
+}
+
+/**
+ * Whether a URL points at an image the action may download, which is what makes
+ * a link to it resolve against the same base as the image itself.
+ */
+export function hasDownloadableImageExtension(url: string) {
+  const pathOnly = url.trim().split('#')[0].split('?')[0]
+  const dot = pathOnly.lastIndexOf('.')
+  if (dot < 0) return false
+  return DOWNLOADABLE_IMAGE_EXTENSIONS.has(pathOnly.slice(dot).toLowerCase())
+}
+
 const WHITESPACE = /\s/
 
 /**
@@ -57,12 +118,7 @@ function mapSrcSet(srcSet: string, mapUrl: (url: string) => string) {
 }
 
 export function isLocalMediaPath(url?: string) {
-  if (!url) return false
-  const trimmed = url.trim()
-  return (
-    trimmed.startsWith(LOCAL_MEDIA_PREFIX) &&
-    trimmed.length > LOCAL_MEDIA_PREFIX.length
-  )
+  return localMediaFileName(url) !== null
 }
 
 export function withBasePath(url: string, basePath: string) {

--- a/lib/media.ts
+++ b/lib/media.ts
@@ -38,9 +38,46 @@ export function withBasePath(url: string, basePath: string) {
 }
 
 /**
- * Images that fail to download keep their remote URL, so a srcset can mix local
- * and remote candidates. Only the local ones get the base path.
+ * Where a URL attribute points: `link` at another document, `media` at a
+ * subresource the page loads. Relative URLs of the two resolve against
+ * different bases, see resolveContentUrl in action/feeds/parsers.ts.
  */
-export function rewriteLocalSrcSet(srcSet: string, basePath: string) {
-  return mapSrcSet(srcSet, (url) => withBasePath(url, basePath))
+export type UrlTarget = 'link' | 'media'
+
+interface UrlAttribute {
+  target: UrlTarget
+  /** Comma separated candidate list rather than a single URL, as in srcset. */
+  list: boolean
+}
+
+/**
+ * Every attribute that carries a URL in entry content. Walking this map instead
+ * of naming tags keeps the action and the reader resolving the same set, and
+ * covers new tags as soon as the sanitizer allows their attributes.
+ */
+export const URL_ATTRIBUTES: Record<string, UrlAttribute> = {
+  href: { target: 'link', list: false },
+  cite: { target: 'link', list: false },
+  src: { target: 'media', list: false },
+  poster: { target: 'media', list: false },
+  srcset: { target: 'media', list: true }
+}
+
+/**
+ * Copies `attribs` with every URL it carries passed through `mapUrl`. srcset
+ * candidates are visited one at a time, so a mixed local and remote list stays
+ * intact. Attributes holding no URL, and empty values, are left untouched.
+ */
+export function mapUrlAttributes(
+  attribs: Record<string, string>,
+  mapUrl: (url: string, target: UrlTarget) => string
+) {
+  const nextAttribs = { ...attribs }
+  for (const [name, value] of Object.entries(nextAttribs)) {
+    const attribute = URL_ATTRIBUTES[name]
+    if (!attribute || !value) continue
+    const map = (url: string) => mapUrl(url, attribute.target)
+    nextAttribs[name] = attribute.list ? mapSrcSet(value, map) : map(value)
+  }
+  return nextAttribs
 }

--- a/lib/utils.test.ts
+++ b/lib/utils.test.ts
@@ -45,6 +45,19 @@ test('#resolveEntryLink returns the url unchanged without a usable entry', (t) =
   t.is(resolveEntryLink('   ', ENTRY_URL), '   ')
 })
 
+test('#resolveEntryLink refuses a base that is not http', (t) => {
+  // The entry link is whatever the feed published. Resolving against a
+  // javascript: base would turn every footnote anchor into a script URL.
+  t.is(resolveEntryLink('#fn1', 'javascript:alert(1)'), '#fn1')
+  t.is(resolveEntryLink('#fn1', 'file:///etc/passwd'), '#fn1')
+  t.is(resolveEntryLink('#fn1', 'data:text/html,<script></script>'), '#fn1')
+  t.is(resolveEntryLink('/posts/other', 'ftp://feed.example/x'), '/posts/other')
+  t.is(
+    resolveEntryLink('/posts/other', 'http://feed.example/posts/1'),
+    'http://feed.example/posts/other'
+  )
+})
+
 test('#parseLocation returns category type', (t) => {
   t.deepEqual(parseLocation('/categories/Apple'), {
     type: 'category',

--- a/lib/utils.test.ts
+++ b/lib/utils.test.ts
@@ -38,9 +38,11 @@ test('#resolveEntryUrl keeps urls it must not rewrite', (t) => {
     resolveEntryUrl('mailto:user@example.com', ENTRY_URL),
     'mailto:user@example.com'
   )
+  // A payload the URL parser would rewrite, so the assertion can tell being
+  // handed back untouched apart from being round-tripped through it.
   t.is(
-    resolveEntryUrl('data:image/gif;base64,AAA', ENTRY_URL),
-    'data:image/gif;base64,AAA'
+    resolveEntryUrl('data:image/svg+xml,<svg>café</svg>', ENTRY_URL),
+    'data:image/svg+xml,<svg>café</svg>'
   )
   // Signed CDN URLs carry characters a stricter normalizer would escape.
   t.is(

--- a/lib/utils.test.ts
+++ b/lib/utils.test.ts
@@ -20,6 +20,13 @@ test('#resolveEntryUrl resolves relative urls against the entry', (t) => {
     resolveEntryUrl('//en.wikipedia.org/wiki/RSS', ENTRY_URL),
     'https://en.wikipedia.org/wiki/RSS'
   )
+  // A scheme-less URL takes the scheme of the page it ends up on, which is the
+  // reader, so an http entry does not drag it down to plaintext -- the same
+  // rule the action applies when it resolves content.
+  t.is(
+    resolveEntryUrl('//x.example/y', 'http://feed.example/p'),
+    'https://x.example/y'
+  )
 })
 
 test('#resolveEntryUrl keeps urls it must not rewrite', (t) => {

--- a/lib/utils.test.ts
+++ b/lib/utils.test.ts
@@ -1,5 +1,49 @@
 import test from 'ava'
-import { parseLocation } from './utils'
+import { parseLocation, resolveEntryLink } from './utils'
+
+const ENTRY_URL = 'https://feed.example/posts/entry-1'
+
+test('#resolveEntryLink resolves relative urls against the entry', (t) => {
+  t.is(
+    resolveEntryLink('/posts/other', ENTRY_URL),
+    'https://feed.example/posts/other'
+  )
+  t.is(
+    resolveEntryLink('chapter-two.html', ENTRY_URL),
+    'https://feed.example/posts/chapter-two.html'
+  )
+  t.is(
+    resolveEntryLink('#footnote', ENTRY_URL),
+    'https://feed.example/posts/entry-1#footnote'
+  )
+  t.is(
+    resolveEntryLink('//en.wikipedia.org/wiki/RSS', ENTRY_URL),
+    'https://en.wikipedia.org/wiki/RSS'
+  )
+})
+
+test('#resolveEntryLink keeps urls it must not rewrite', (t) => {
+  t.is(
+    resolveEntryLink('https://other.example/page', ENTRY_URL),
+    'https://other.example/page'
+  )
+  t.is(
+    resolveEntryLink('mailto:user@example.com', ENTRY_URL),
+    'mailto:user@example.com'
+  )
+  t.is(
+    resolveEntryLink('data:image/gif;base64,AAA', ENTRY_URL),
+    'data:image/gif;base64,AAA'
+  )
+})
+
+test('#resolveEntryLink returns the url unchanged without a usable entry', (t) => {
+  t.is(resolveEntryLink('/posts/other'), '/posts/other')
+  t.is(resolveEntryLink('/posts/other', ''), '/posts/other')
+  t.is(resolveEntryLink('/posts/other', 'not a url'), '/posts/other')
+  t.is(resolveEntryLink('', ENTRY_URL), '')
+  t.is(resolveEntryLink('   ', ENTRY_URL), '   ')
+})
 
 test('#parseLocation returns category type', (t) => {
   t.deepEqual(parseLocation('/categories/Apple'), {

--- a/lib/utils.test.ts
+++ b/lib/utils.test.ts
@@ -1,59 +1,77 @@
 import test from 'ava'
-import { parseLocation, resolveEntryLink } from './utils'
+import { parseLocation, resolveEntryUrl } from './utils'
 
 const ENTRY_URL = 'https://feed.example/posts/entry-1'
 
-test('#resolveEntryLink resolves relative urls against the entry', (t) => {
+test('#resolveEntryUrl resolves relative urls against the entry', (t) => {
   t.is(
-    resolveEntryLink('/posts/other', ENTRY_URL),
+    resolveEntryUrl('/posts/other', ENTRY_URL),
     'https://feed.example/posts/other'
   )
   t.is(
-    resolveEntryLink('chapter-two.html', ENTRY_URL),
+    resolveEntryUrl('chapter-two.html', ENTRY_URL),
     'https://feed.example/posts/chapter-two.html'
   )
   t.is(
-    resolveEntryLink('#footnote', ENTRY_URL),
+    resolveEntryUrl('#footnote', ENTRY_URL),
     'https://feed.example/posts/entry-1#footnote'
   )
   t.is(
-    resolveEntryLink('//en.wikipedia.org/wiki/RSS', ENTRY_URL),
+    resolveEntryUrl('//en.wikipedia.org/wiki/RSS', ENTRY_URL),
     'https://en.wikipedia.org/wiki/RSS'
   )
 })
 
-test('#resolveEntryLink keeps urls it must not rewrite', (t) => {
+test('#resolveEntryUrl keeps urls it must not rewrite', (t) => {
   t.is(
-    resolveEntryLink('https://other.example/page', ENTRY_URL),
+    resolveEntryUrl('https://other.example/page', ENTRY_URL),
     'https://other.example/page'
   )
   t.is(
-    resolveEntryLink('mailto:user@example.com', ENTRY_URL),
+    resolveEntryUrl('mailto:user@example.com', ENTRY_URL),
     'mailto:user@example.com'
   )
   t.is(
-    resolveEntryLink('data:image/gif;base64,AAA', ENTRY_URL),
+    resolveEntryUrl('data:image/gif;base64,AAA', ENTRY_URL),
     'data:image/gif;base64,AAA'
+  )
+  // Signed CDN URLs carry characters a stricter normalizer would escape.
+  t.is(
+    resolveEntryUrl('https://cdn.example/x?sig=a|b^c', ENTRY_URL),
+    'https://cdn.example/x?sig=a|b^c'
   )
 })
 
-test('#resolveEntryLink returns the url unchanged without a usable entry', (t) => {
-  t.is(resolveEntryLink('/posts/other'), '/posts/other')
-  t.is(resolveEntryLink('/posts/other', ''), '/posts/other')
-  t.is(resolveEntryLink('/posts/other', 'not a url'), '/posts/other')
-  t.is(resolveEntryLink('', ENTRY_URL), '')
-  t.is(resolveEntryLink('   ', ENTRY_URL), '   ')
+test('#resolveEntryUrl re-serializes an absolute url', (t) => {
+  // Every URL in stored content goes through here now, so the normalizing is
+  // worth pinning: it keeps the target but not necessarily the exact bytes.
+  t.is(
+    resolveEntryUrl('https://other.example', ENTRY_URL),
+    'https://other.example/'
+  )
+  t.is(
+    resolveEntryUrl('HTTPS://Other.Example/Page', ENTRY_URL),
+    'https://other.example/Page'
+  )
 })
 
-test('#resolveEntryLink refuses a base that is not http', (t) => {
+test('#resolveEntryUrl returns the url unchanged without a usable entry', (t) => {
+  t.is(resolveEntryUrl('/posts/other'), '/posts/other')
+  t.is(resolveEntryUrl('/posts/other', ''), '/posts/other')
+  t.is(resolveEntryUrl('/posts/other', 'not a url'), '/posts/other')
+  t.is(resolveEntryUrl('', ENTRY_URL), '')
+  t.is(resolveEntryUrl('   ', ENTRY_URL), '   ')
+})
+
+test('#resolveEntryUrl refuses a base that is not http', (t) => {
   // The entry link is whatever the feed published. Resolving against a
   // javascript: base would turn every footnote anchor into a script URL.
-  t.is(resolveEntryLink('#fn1', 'javascript:alert(1)'), '#fn1')
-  t.is(resolveEntryLink('#fn1', 'file:///etc/passwd'), '#fn1')
-  t.is(resolveEntryLink('#fn1', 'data:text/html,<script></script>'), '#fn1')
-  t.is(resolveEntryLink('/posts/other', 'ftp://feed.example/x'), '/posts/other')
+  t.is(resolveEntryUrl('#fn1', 'javascript:alert(1)'), '#fn1')
+  t.is(resolveEntryUrl('#fn1', 'file:///etc/passwd'), '#fn1')
+  t.is(resolveEntryUrl('#fn1', 'data:text/html,<script></script>'), '#fn1')
+  t.is(resolveEntryUrl('/posts/other', 'ftp://feed.example/x'), '/posts/other')
   t.is(
-    resolveEntryLink('/posts/other', 'http://feed.example/posts/1'),
+    resolveEntryUrl('/posts/other', 'http://feed.example/posts/1'),
     'http://feed.example/posts/other'
   )
 })

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -39,13 +39,19 @@ export const categoriesClassName = (pageState: PageState): string => {
  * stored before the action started resolving URLs still hold relative ones,
  * which would otherwise point at the reader's own domain. Anything already
  * absolute is returned as it is.
+ *
+ * The base has to be http(s), the same gate the action applies. An entry link
+ * is whatever the feed put in it, and resolving against a `javascript:` base
+ * would turn every "#footnote" in the entry into a script URL.
  */
 export const resolveEntryLink = (url: string, entryUrl?: string): string => {
   const trimmed = url.trim()
   if (!trimmed || !entryUrl) return url
   if (trimmed.startsWith('data:')) return url
   try {
-    return new URL(trimmed, entryUrl).toString()
+    const base = new URL(entryUrl)
+    if (base.protocol !== 'http:' && base.protocol !== 'https:') return url
+    return new URL(trimmed, base).toString()
   } catch {
     return url
   }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -37,8 +37,9 @@ export const categoriesClassName = (pageState: PageState): string => {
 /**
  * Resolves a URL from entry content against the entry it came from. Entries
  * stored before the action started resolving URLs still hold relative ones,
- * which would otherwise point at the reader's own domain. Anything already
- * absolute is returned as it is.
+ * which would otherwise point at the reader's own domain. An absolute URL
+ * keeps its target but comes back re-serialized by the URL parser, so it can
+ * differ from the input by a trailing slash or percent-encoding.
  *
  * The base has to be http(s), the same gate the action applies. An entry link
  * is whatever the feed put in it, and resolving against a `javascript:` base

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -34,6 +34,23 @@ export const categoriesClassName = (pageState: PageState): string => {
   }
 }
 
+/**
+ * Resolves a URL from entry content against the entry it came from. Entries
+ * stored before the action started resolving URLs still hold relative ones,
+ * which would otherwise point at the reader's own domain. Anything already
+ * absolute is returned as it is.
+ */
+export const resolveEntryLink = (url: string, entryUrl?: string): string => {
+  const trimmed = url.trim()
+  if (!trimmed || !entryUrl) return url
+  if (trimmed.startsWith('data:')) return url
+  try {
+    return new URL(trimmed, entryUrl).toString()
+  } catch {
+    return url
+  }
+}
+
 export type LocationState =
   | {
       type: 'category'

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -50,6 +50,11 @@ export const resolveEntryUrl = (url: string, entryUrl?: string): string => {
   const trimmed = url.trim()
   if (!trimmed || !entryUrl) return url
   if (trimmed.startsWith('data:')) return url
+  // Same rule the action applies: a scheme-less URL takes the scheme of the
+  // page it ends up on, which is this one, not the feed's. Inheriting the
+  // entry's would render a legacy //host URL from an http feed as plaintext,
+  // and an image that way is blocked outright as mixed content.
+  if (trimmed.startsWith('//')) return `https:${trimmed}`
   try {
     const base = new URL(entryUrl)
     if (base.protocol !== 'http:' && base.protocol !== 'https:') return url

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -35,7 +35,8 @@ export const categoriesClassName = (pageState: PageState): string => {
 }
 
 /**
- * Resolves a URL from entry content against the entry it came from. Entries
+ * Resolves any URL from entry content against the entry it came from -- media
+ * as well as links, since the reader has no site link to fall back on. Entries
  * stored before the action started resolving URLs still hold relative ones,
  * which would otherwise point at the reader's own domain. An absolute URL
  * keeps its target but comes back re-serialized by the URL parser, so it can
@@ -45,7 +46,7 @@ export const categoriesClassName = (pageState: PageState): string => {
  * is whatever the feed put in it, and resolving against a `javascript:` base
  * would turn every "#footnote" in the entry into a script URL.
  */
-export const resolveEntryLink = (url: string, entryUrl?: string): string => {
+export const resolveEntryUrl = (url: string, entryUrl?: string): string => {
   const trimmed = url.trim()
   if (!trimmed || !entryUrl) return url
   if (trimmed.startsWith('data:')) return url

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feeds-fetcher",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "description": "Websites feed fetcher and static feeds aggregator",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
## Problem

Clicking a link inside a post could navigate to the reader's own domain instead of the article's site. Feeds publish relative URLs (`/posts/x`, `foo.html`, `#fn1`, `//host/...`), and those were stored as-is.

The sanitizer already resolved anchor hrefs, but only wrote the result back when the URL looked like an image — so ordinary links stayed relative:

```ts
const resolvedHref = resolveMediaUrl(nextAttribs.href, siteLink, entryLink)
if (isImageLikeUrl(resolvedHref)) {   // ← everything else fell through
  nextAttribs.href = resolvedHref
}
```

Against the `neizod.rss` fixture, **54 of 79 URLs were unresolved**. After this change, **0**.

## What changed

**Resolution is attribute-driven, not tag-driven.** A shared `URL_ATTRIBUTES` map names every attribute that carries a URL (`href`, `cite`, `src`, `srcset`) and whether it points at a document or at media; both the action and the reader walk it, and both passes over entry content go through a single `mapContentUrls`. A test walks the sanitizer's own allowed-attribute map and fails if any URL-bearing attribute is allowed without being resolved.

**Links resolve against the entry URL** — the document base a browser would use, and the only one that gets a bare `foo.html` or a `#footnote` right. The entry link is itself made absolute against the site first: Atom permits a relative one, and left relative it is useless as a base *and* becomes a broken "View Original".

**A link to a downloadable image stays on the media base**, so it still matches the `src` the store downloads and can be swapped for the local `/media/<hash>` copy — which is what stops a lightbox link hotlinking the origin. Collection stays media-only, so a link never triggers a download, and reference-scanning counts links so cleanup can't delete a file a rewritten href still points at.

**The reader resolves at render time too**, so entries already published are repaired without waiting to be re-fetched. Its base is gated to http(s), matching the action — an entry link is whatever the feed published, and a `javascript:` base would turn every footnote anchor into a script URL.

**`srcset` is parsed per the HTML grammar** rather than split on commas, so a comma inside a URL (image CDNs, `data:` URIs) no longer tears a candidate in half. The scan is linear.

**The sanitizer defaults to http(s) only.** Exceptions are named per tag: inline images keep `data:`, links keep `mailto:`, citations get neither. An attribute allowed later inherits the safe set instead of `data:`.

## Review

Ten rounds of sub-agent review (correctness, security, tests, design) filed **103 findings**, every one addressed, replied to and resolved inline. The substantive ones:

- a **quadratic `srcset` scan** on feed-controlled input — 200k commas took 16s, now 2ms
- the reader's resolver accepting a **non-http base**, so a `javascript:` entry link poisoned every fragment anchor
- **relative entry links** breaking both halves of the fix
- a **scheme downgrade**, then the ordering fix it needed so image links still match their images
- **six tests that passed against deleted implementation code**, including one guarding the branch the whole fix turns on
- two image-extension lists that had to agree but were documented as "keep apart" — now one list in `action/feeds/images.ts`

Correctness and security both returned clean in the final two rounds.

## Verification

- `yarn test` — 115 pass. The one local failure, `action/repository`, is pre-existing and unrelated: it asserts the checkout directory is named `feeds`, which fails in any worktree. It passes in CI here.
- `yarn build` — TypeScript clean; all CI checks green.
- Parsed `stubs/neizod.rss` end to end: 79 URLs checked, 0 unresolved (54 before).
- Re-ran all 79 build-time URLs through the reader's own resolution: none changed, so the two layers compose rather than fight.
- Entry links byte-identical across all 4 real fixtures, so no stored entry is re-keyed.
- Narrowing the scheme list changed nothing on real feeds: 795 entries byte-identical.
- The sanitizer-walk refactor changed nothing across parse, collect, rewrite and reference passes: 1,563 rows byte-identical.
- Scaling sweep at 250k and 1M chars over srcset, media-path and resolver inputs: all linear.
- Mutation-checked every new guard — deleting the media branch, either `data:` guard, the empty-value guard, the img hardening, the case folding, the local-media check, or the link/media collection split each fails at least one test.

## Follow-ups (not in this PR)

- Whether relative **media** should resolve against the entry rather than the site. It is the one wrong-base case left, and the comment now says so outright — changing it re-keys and re-downloads every image, so it deserves before/after numbers on real feeds.
- `downloadMedia` accepting a body whose declared content type is not an image.
- Collapsing the action's and reader's resolvers into one shared core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)