### PR TITLE
Resolve relative media URLs against the entry, not the site

### DIFF
--- a/action/feeds/images.test.ts
+++ b/action/feeds/images.test.ts
@@ -1,12 +1,9 @@
 import test from 'ava'
 
-import {
-  hasDownloadableImageExtension,
-  normalizeImageExtension
-} from './images'
+import { normalizeImageExtension } from './images'
 import { CONTENT_TYPE_EXTENSIONS, extensionFromContentType } from './media'
 
-test('every content type the store writes also picks the media base for links', (t) => {
+test('every content type the store writes names a downloadable extension', (t) => {
   // Driven off the map itself rather than a copy of it, so adding a content
   // type without adding its extension to images.ts fails here instead of
   // silently refusing every download of that format.
@@ -14,25 +11,23 @@ test('every content type the store writes also picks the media base for links', 
     CONTENT_TYPE_EXTENSIONS
   )) {
     t.is(extensionFromContentType(contentType), extension, contentType)
-    t.true(
-      hasDownloadableImageExtension(`https://e.example/x${extension}`),
-      `${contentType} writes ${extension}, which links do not resolve as media`
+    t.is(
+      normalizeImageExtension(extension),
+      extension,
+      `${contentType} writes ${extension}, which is not downloadable`
     )
   }
 })
 
 test('svg is downloadable by neither, which keeps it off our origin', (t) => {
-  t.false(hasDownloadableImageExtension('https://e.example/x.svg'))
   t.is(normalizeImageExtension('.svg'), null)
   t.is(extensionFromContentType('image/svg+xml'), null)
 })
 
-test('#hasDownloadableImageExtension reads the path, not the whole URL', (t) => {
-  t.true(hasDownloadableImageExtension('https://e.example/x.PNG'))
-  t.true(hasDownloadableImageExtension('https://e.example/x.png?v=2#f'))
-  t.false(
-    hasDownloadableImageExtension('https://e.example/download?file=x.png')
-  )
-  t.false(hasDownloadableImageExtension('https://e.example/v1.2/page'))
-  t.false(hasDownloadableImageExtension('https://e.example/noextension'))
+test('#normalizeImageExtension accepts any casing and padding', (t) => {
+  t.is(normalizeImageExtension('.PNG'), '.png')
+  t.is(normalizeImageExtension('  .webp  '), '.webp')
+  t.is(normalizeImageExtension('.noextension'), null)
+  t.is(normalizeImageExtension(''), null)
+  t.is(normalizeImageExtension(null), null)
 })

--- a/action/feeds/images.ts
+++ b/action/feeds/images.ts
@@ -1,11 +1,12 @@
 /**
- * Which images the action may download and serve from our own origin.
+ * Which images the action may download and serve from our own origin. Read by
+ * media.ts, both to pick an extension from a content type and to keep one from
+ * a URL.
  *
- * Two modules need this and neither can own it: media.ts downloads by it, and
- * parsers.ts picks a link's base by it -- a link to a downloadable image has to
- * resolve exactly like the image itself or it stops matching the copy on disk
- * and silently keeps hotlinking. media.ts already imports parsers.ts, so the
- * list lives here rather than in either of them, and there is only ever one.
+ * The list sat here rather than in media.ts because parsers.ts also picked a
+ * link's base by it, so that a link to a downloadable image resolved exactly
+ * like the image itself. Links and media now share one base outright, so that
+ * caller is gone; the list stays here so media.ts keeps a single source for it.
  *
  * SVG is deliberately absent: a localized file is navigable on the published
  * origin, and a feed could otherwise plant a scripted SVG there.
@@ -29,21 +30,4 @@ export function normalizeImageExtension(extension?: string | null) {
   const normalized = extension.trim().toLowerCase()
   if (!DOWNLOADABLE_IMAGE_EXTENSIONS.has(normalized)) return null
   return normalized
-}
-
-/**
- * Whether a URL's extension names an image the action may download, which is
- * what makes a link to it resolve against the same base as the image itself.
- *
- * Extension-less URLs the store fetches by content type are not covered here,
- * so a link to one aligns with its image only when both already resolve to the
- * same absolute URL -- which they do when the URL is absolute or root-relative.
- * A path-relative one takes the entry base while the image takes the site base,
- * and that pair never localizes.
- */
-export function hasDownloadableImageExtension(url: string) {
-  const pathOnly = url.trim().split('#')[0].split('?')[0]
-  const dot = pathOnly.lastIndexOf('.')
-  if (dot < 0) return false
-  return DOWNLOADABLE_IMAGE_EXTENSIONS.has(pathOnly.slice(dot).toLowerCase())
 }

--- a/action/feeds/media.test.ts
+++ b/action/feeds/media.test.ts
@@ -201,7 +201,8 @@ test('#localizeSite localizes a relative lightbox href with its image', async (t
   const mediaDirectory = await createMediaDirectory('feeds-media-relative-')
   const fetchStub = sinon.stub().resolves(imageResponse())
   // Real feeds publish relative URLs; the parser and the store only agree
-  // because the link and the image resolve to the same absolute URL.
+  // because the link and the image resolve to the same absolute URL, which they
+  // do for every relative shape now that both take the entry as their base.
   const site = parseRss('Test Feed', {
     rss: {
       channel: [
@@ -228,7 +229,7 @@ test('#localizeSite localizes a relative lightbox href with its image', async (t
   const store = createMediaStore({ mediaDirectory, fetch: fetchStub as any })
   const localized = await store.localizeSite(site)
 
-  const localPath = `/media/${mediaHash('https://site.example/images/one.png')}.png`
+  const localPath = `/media/${mediaHash('https://feed.example/images/one.png')}.png`
   t.true(localized.entries[0].content.includes(`href="${localPath}"`))
   t.true(localized.entries[0].content.includes(`src="${localPath}"`))
   t.is(fetchStub.callCount, 1)

--- a/action/feeds/media.ts
+++ b/action/feeds/media.ts
@@ -19,9 +19,9 @@ const MAX_CONCURRENT_DOWNLOADS_PER_HOST = 2
 const LOCALIZE_DEADLINE_MS = 10 * 60 * 1000
 
 // Which content types name a downloadable image. The extensions themselves
-// live in images.ts, which the link resolver reads too, and every value here
-// goes back through it -- so an entry that is not downloadable simply never
-// resolves. SVG is absent from both, see images.ts for why.
+// live in images.ts, and every value here goes back through it -- so an entry
+// that is not downloadable simply never resolves. SVG is absent from both, see
+// images.ts for why.
 export const CONTENT_TYPE_EXTENSIONS: Record<string, string> = {
   'image/avif': '.avif',
   'image/gif': '.gif',

--- a/action/feeds/parsers#media-url-resolution.test.ts
+++ b/action/feeds/parsers#media-url-resolution.test.ts
@@ -1,5 +1,6 @@
 import test from 'ava'
 import { ENTRY_CONTENT_SANITIZE_OPTIONS, parseAtom, parseRss } from './parsers'
+import { resolveEntryUrl } from '../../lib/utils'
 
 const SITE_LINK = 'https://site.example/'
 const ENTRY_LINK = 'https://feed.example/posts/entry-1'
@@ -34,83 +35,78 @@ const contentOf = (
 ) =>
   parseRss('Test Feed', rssWithContent(description, links)).entries[0].content
 
-test('#parseRss resolves relative media URLs using site domain', (t) => {
+test('#parseRss resolves relative media URLs using the entry URL', (t) => {
   const outputContent = contentOf(
     '<p><img src="/images/cover.jpg" srcset="/images/cover.jpg 1x, images/cover@2x.jpg 2x" /><a href="/images/download.webp">Download</a></p>'
   )
 
-  t.true(outputContent.includes('src="https://site.example/images/cover.jpg"'))
+  t.true(outputContent.includes('src="https://feed.example/images/cover.jpg"'))
   t.true(
     outputContent.includes(
-      'srcset="https://site.example/images/cover.jpg 1x, https://site.example/images/cover@2x.jpg 2x"'
+      'srcset="https://feed.example/images/cover.jpg 1x, https://feed.example/posts/images/cover@2x.jpg 2x"'
     )
   )
-  // A link to an image shares the media base so it matches the src the media
-  // store downloads and can be swapped for the local copy.
+  // A link to an image is resolved like any other link. Media takes the same
+  // base, so the two still agree and the media store can swap either for the
+  // downloaded copy.
   t.true(
-    outputContent.includes('href="https://site.example/images/download.webp"')
+    outputContent.includes('href="https://feed.example/images/download.webp"')
   )
 })
 
-test('#parseRss resolves media against the site even without a downloadable extension', (t) => {
-  // The link rule would send these to the entry base. Media does not follow it:
-  // the media hash is computed from this URL, so the base must not drift.
+test('#parseRss resolves a document-relative image against the entry directory', (t) => {
+  // The shape that made this the entry base: a feed whose channel link is the
+  // homepage and whose items sit deeper, carrying a bare filename beside the
+  // post. Resolving against the site gives /photo.jpg, which 404s.
+  t.true(
+    contentOf('<img src="photo.jpg" />', {
+      site: 'https://blog.example/',
+      entry: 'https://blog.example/2024/01/post/'
+    }).includes('src="https://blog.example/2024/01/post/photo.jpg"')
+  )
+  t.true(
+    contentOf('<img src="../assets/photo.jpg" />', {
+      site: 'https://blog.example/',
+      entry: 'https://blog.example/2024/01/post/'
+    }).includes('src="https://blog.example/2024/01/assets/photo.jpg"')
+  )
+})
+
+test('#parseRss resolves media against the entry whatever its extension', (t) => {
+  // Media used to take the site base, and an extension-less URL was the case
+  // that made the split visible. One base means the extension decides nothing.
   const output = contentOf('<img src="/photo" srcset="/diagram.svg 2x" />')
-  t.true(output.includes('src="https://site.example/photo"'))
-  t.true(output.includes('srcset="https://site.example/diagram.svg 2x"'))
+  t.true(output.includes('src="https://feed.example/photo"'))
+  t.true(output.includes('srcset="https://feed.example/diagram.svg 2x"'))
 })
 
-test('#parseRss picks the link base on the extension alone', (t) => {
-  // The extension is what decides the base now, so a query or a fragment must
-  // not hide it -- these links would otherwise stop matching downloaded media.
-  t.true(
-    contentOf('<a href="/images/a.png?w=100">q</a>').includes(
-      'href="https://site.example/images/a.png?w=100"'
+test('#parseRss picks the same base whatever the extension looks like', (t) => {
+  // A link to a downloadable image used to be pulled onto the media base so it
+  // would match the image the store downloaded. Links and media now share a
+  // base outright, so nothing inspects the extension -- and these cases, which
+  // existed to pin down where that inspection started and stopped, are here to
+  // catch the exception coming back.
+  for (const [url, expected] of [
+    ['/images/a.png?w=100', 'https://feed.example/images/a.png?w=100'],
+    ['/images/a.png#x', 'https://feed.example/images/a.png#x'],
+    ['/images/a', 'https://feed.example/images/a'],
+    ['diagram.svg', 'https://feed.example/posts/diagram.svg'],
+    ['/images/A.PNG', 'https://feed.example/images/A.PNG'],
+    ['/images/D.SVG', 'https://feed.example/images/D.SVG'],
+    ['/download?file=a.png', 'https://feed.example/download?file=a.png'],
+    ['/v1.2/page', 'https://feed.example/v1.2/page']
+  ]) {
+    t.true(
+      contentOf(`<a href="${url}">x</a>`).includes(`href="${expected}"`),
+      `${url} should resolve to ${expected}`
     )
-  )
-  t.true(
-    contentOf('<a href="/images/a.png#x">f</a>').includes(
-      'href="https://site.example/images/a.png#x"'
+    // And the image itself lands on the same URL, which is what lets the media
+    // store swap a link for the copy it downloaded.
+    t.true(
+      contentOf(`<img src="${url}" />`).includes(`src="${expected}"`),
+      `${url} as media should resolve to ${expected}`
     )
-  )
-  // No extension, so it is an ordinary link and takes the entry base.
-  t.true(
-    contentOf('<a href="/images/a">n</a>').includes(
-      'href="https://feed.example/images/a"'
-    )
-  )
-  // The store never downloads svg, so the media base could never pay off and
-  // the link resolves against the document like any other.
-  t.true(
-    contentOf('<a href="diagram.svg">Diagram</a>').includes(
-      'href="https://feed.example/posts/diagram.svg"'
-    )
-  )
-  // The extension match is case folded, so a feed shouting its filenames still
-  // lines its links up with the images they point at.
-  t.true(
-    contentOf('<a href="/images/A.PNG">u</a>').includes(
-      'href="https://site.example/images/A.PNG"'
-    )
-  )
-  t.true(
-    contentOf('<a href="/images/D.SVG">s</a>').includes(
-      'href="https://feed.example/images/D.SVG"'
-    )
-  )
-  // A query parameter that merely ends in an image extension is not an image,
-  // so the link keeps the document base.
-  t.true(
-    contentOf('<a href="/download?file=a.png">d</a>').includes(
-      'href="https://feed.example/download?file=a.png"'
-    )
-  )
-  // A dot in an earlier path segment is not an extension either.
-  t.true(
-    contentOf('<a href="/v1.2/page">v</a>').includes(
-      'href="https://feed.example/v1.2/page"'
-    )
-  )
+  }
 })
 
 // Attributes that are allowed through but genuinely carry no URL. Anything not
@@ -184,11 +180,11 @@ test('#parseRss resolves URLs outside of a and img tags', (t) => {
       'cite="https://feed.example/posts/source.html"'
     )
   )
-  // Every link attribute picks its base the same way, so a cite ending in an
-  // image extension takes the media base like a lightbox href would.
+  // Every attribute picks its base the same way, so a cite ending in an image
+  // extension resolves against the entry like any other URL.
   t.true(
     contentOf('<q cite="photo.png">Quoted</q>').includes(
-      'cite="https://site.example/photo.png"'
+      'cite="https://feed.example/posts/photo.png"'
     )
   )
 })
@@ -251,7 +247,7 @@ test('#parseRss leaves URLs it must not rewrite alone', (t) => {
   )
   t.true(
     contentOf('<img srcset="javascript:alert(1) 1x, /ok.png 2x" />').includes(
-      'srcset="https://site.example/ok.png 2x"'
+      'srcset="https://feed.example/ok.png 2x"'
     )
   )
   t.true(
@@ -269,12 +265,12 @@ test('#parseRss falls back between the entry and site URL', (t) => {
   t.true(withoutSite.includes('href="https://feed.example/x"'))
   t.true(withoutSite.includes('src="https://feed.example/y.png"'))
 
-  // No entry link, so links fall back to the site.
-  t.true(
-    contentOf('<a href="/x">l</a>', { entry: '' }).includes(
-      'href="https://site.example/x"'
-    )
-  )
+  // No entry link, so links and media both fall back to the site.
+  const withoutEntry = contentOf('<a href="/x">l</a><img src="/y.png" />', {
+    entry: ''
+  })
+  t.true(withoutEntry.includes('href="https://site.example/x"'))
+  t.true(withoutEntry.includes('src="https://site.example/y.png"'))
 
   // Nothing to resolve against leaves the URL as it is.
   t.true(
@@ -283,11 +279,13 @@ test('#parseRss falls back between the entry and site URL', (t) => {
     )
   )
 
-  // A protocol-relative URL takes its scheme from the base it resolves
-  // against, and falls back to https when there is none.
+  // A protocol-relative image takes its scheme from the base it resolves
+  // against -- now the entry, like everything else -- and falls back to https
+  // when there is none.
   t.true(
     contentOf('<img src="//cdn.example/x.png" />', {
-      site: 'http://site.example/'
+      site: 'https://site.example/',
+      entry: 'http://feed.example/posts/1'
     }).includes('src="http://cdn.example/x.png"')
   )
   t.true(
@@ -312,21 +310,25 @@ test('#parseRss falls back between the entry and site URL', (t) => {
       entry: 'http://feed.example/posts/1'
     }).includes('href="https://h.example/x"')
   )
-  // Media keeps taking the scheme of the site it is loaded alongside.
+  // Media keeps the feed's own scheme, because the action fetches it server
+  // side rather than from the reader's page.
   t.true(
     contentOf('<img src="//cdn.example/x.png" />', {
       site: 'http://site.example/',
       entry: 'http://feed.example/posts/1'
     }).includes('src="http://cdn.example/x.png"')
   )
-  // A scheme-less link to a downloadable image follows the image instead, so
-  // the two still agree and the link can be swapped for the local copy. Only
-  // this ordering keeps them matching on an http feed.
+  // Scheme-less is the one shape where a link and an image on the same URL
+  // still part ways, and only on an http feed: the link is pinned to https and
+  // the image keeps http, so the media store cannot swap that link for the copy
+  // it downloaded. The extension test that used to hold them together is gone
+  // with the split base it existed to bridge, and it bought nothing anywhere
+  // else -- every URL that takes a base now resolves identically for both.
   const schemeless = contentOf(
     '<a href="//cdn.example/x.png">L</a><img src="//cdn.example/x.png" />',
     { site: 'http://site.example/', entry: 'http://feed.example/posts/1' }
   )
-  t.true(schemeless.includes('href="http://cdn.example/x.png"'))
+  t.true(schemeless.includes('href="https://cdn.example/x.png"'))
   t.true(schemeless.includes('src="http://cdn.example/x.png"'))
 })
 
@@ -429,7 +431,47 @@ test('#parseAtom makes a relative entry link absolute', (t) => {
   )
 })
 
-test('#parseAtom resolves relative media URLs using site domain', (t) => {
+test('#parseRss agrees with the reader on every relative URL', (t) => {
+  // The action resolves when it stores an entry, the reader when it renders one
+  // stored before the action did that. A URL that resolved differently in the
+  // two halves would render one way or the other depending only on when the
+  // entry was fetched, so they have to agree by construction.
+  //
+  // Every URL that takes a base is covered here. A scheme-less one is not: it
+  // takes no base, and the action deliberately pins a scheme-less link to https
+  // rather than to the feed's own scheme, which the reader has no reason to do.
+  const site = 'https://blog.example/'
+  const entry = 'https://blog.example/2024/01/post/'
+  const relativeUrls = [
+    'photo.jpg',
+    '/images/cover.png',
+    '../assets/diagram.svg',
+    'gallery/full.webp',
+    'chapter-two.html',
+    '#footnote',
+    '?page=2'
+  ]
+
+  for (const url of relativeUrls) {
+    const stored = contentOf(`<img src="${url}" /><a href="${url}">l</a>`, {
+      site,
+      entry
+    })
+    const storedUrls = [...stored.matchAll(/(?:src|href)="([^"]*)"/g)].map(
+      (match) => match[1]
+    )
+    t.is(storedUrls.length, 2)
+    for (const storedUrl of storedUrls) {
+      t.is(
+        storedUrl,
+        resolveEntryUrl(url, entry),
+        `action and reader disagree on ${url}`
+      )
+    }
+  }
+})
+
+test('#parseAtom resolves relative media URLs using the entry URL', (t) => {
   const xml = {
     feed: {
       title: ['Test Feed'],
@@ -459,16 +501,16 @@ test('#parseAtom resolves relative media URLs using site domain', (t) => {
 
   const outputContent = site.entries[0].content
   t.true(
-    outputContent.includes('src="https://site.example/base/media/photo.png"')
+    outputContent.includes('src="https://feed.example/posts/media/photo.png"')
   )
   t.true(
     outputContent.includes(
-      'srcset="https://site.example/base/media/one.png 1x, https://site.example/media/two.png 2x"'
+      'srcset="https://feed.example/posts/media/one.png 1x, https://feed.example/media/two.png 2x"'
     )
   )
   t.true(
     outputContent.includes(
-      'href="https://site.example/base/media/download.jpg"'
+      'href="https://feed.example/posts/media/download.jpg"'
     )
   )
   t.true(outputContent.includes('href="https://feed.example/archive"'))

--- a/action/feeds/parsers.ts
+++ b/action/feeds/parsers.ts
@@ -2,7 +2,6 @@ import { parseString } from 'xml2js'
 import sanitizeHtml from 'sanitize-html'
 
 import { mapUrlAttributes, type UrlTarget } from '../../lib/media'
-import { hasDownloadableImageExtension } from './images'
 
 export interface Entry {
   title: string
@@ -90,39 +89,46 @@ function absoluteEntryLink(rawLink: string, siteLink: string) {
   return resolveUrl(rawLink, siteLink, '')
 }
 
+/**
+ * Resolves a URL from entry content against the entry link -- the document base
+ * a browser would use -- falling back to the site link when the feed gives no
+ * usable entry link.
+ *
+ * Links and media share that base deliberately. Media resolved against the site
+ * until this base was measured, which turns a path-relative "images/x.jpg" in
+ * an entry at /2024/01/post/ into /images/x.jpg. Both rules were run over 167
+ * live feeds (77k URLs) and every disagreement was fetched from its origin:
+ * they differed on 20 URLs, the entry base was right on 16 of them (the site
+ * base returned 404) and tied on the other 4, and no feed was found where the
+ * site base won. Images are hashed under the URL this produces, so those 20
+ * re-key and re-download once; the rest of the corpus is absolute or
+ * root-relative and resolves the same either way.
+ *
+ * One base also means a link to an image and the image itself resolve alike
+ * wherever a base is involved, so a link the media store downloaded is still
+ * swapped for the local copy without the extension test that used to drag it
+ * onto the media base. The exception is a scheme-less URL, which takes no base:
+ * the rule below pins a link to https while the image keeps the feed's scheme,
+ * so that one pair stops matching on an http feed.
+ *
+ * Sharing a base also keeps the action in step with the reader, which can only
+ * resolve against the entry link because stored Content carries no site link.
+ */
 function resolveContentUrl(
   url: string,
   target: UrlTarget,
   siteLink: string,
   entryLink: string
 ) {
-  // Media resolves against the site first. That base is known to be wrong for a
-  // path-relative URL -- a browser uses the document, so "images/x.jpg" in an
-  // entry at /2024/01/post/ belongs under that directory, not at the root. It
-  // is kept because it is what this project has always stored: every image is
-  // hashed under the URL this produces, so switching to the entry base re-keys
-  // and re-downloads all of them, and that is worth doing on its own with
-  // before-and-after numbers from real feeds rather than as part of a link fix.
-  const asMedia = resolveUrl(url, siteLink, entryLink)
-  if (target === 'media') return asMedia
-  // A link to an image the store can download takes the media base so that when
-  // some entry of the site also displays that image, the two agree and the link
-  // can be swapped for the downloaded copy. This is checked first, before the
-  // scheme-less rule below, because agreeing with the image matters more than
-  // the scheme: disagree and the link is left hotlinking the origin. The trade
-  // is that a link to an image nothing displays gets the site base rather than
-  // the document one -- same as the img rule it is matching, and the reason to
-  // keep the two together. An extension the store will never fetch, svg above
-  // all, buys nothing here and so resolves like any other link.
-  if (hasDownloadableImageExtension(asMedia)) return asMedia
   // A scheme-less link says "whatever this page is served over", and the page it
   // ends up on is the reader, not the feed. Baking in the entry's scheme would
   // pin every such link on an http feed to plaintext, where the browser would
-  // otherwise resolve it against the reader's own https.
-  if (url.trim().startsWith('//')) return `https:${url.trim()}`
-  // Every other link resolves against the entry, the document base a browser
-  // would use and the only one that gets a bare "foo.html" or a "#footnote"
-  // right.
+  // otherwise resolve it against the reader's own https. Media keeps the feed's
+  // scheme instead: the action fetches it server side, where there is no
+  // reader origin to inherit.
+  if (target === 'link' && url.trim().startsWith('//')) {
+    return `https:${url.trim()}`
+  }
   return resolveUrl(url, entryLink, siteLink)
 }
 

--- a/lib/components/ItemContent.tsx
+++ b/lib/components/ItemContent.tsx
@@ -85,8 +85,9 @@ export const ItemContent = ({ content, selectBack }: ItemContentProps) => {
               // base path. Everything else resolves against the entry, which is
               // what stops a URL stored before the action resolved them from
               // pointing at the reader's own domain. Links and media both take
-              // the entry as their base here: the site link the action prefers
-              // for media is not part of the stored entry.
+              // the entry as their base here, and so does the action, so a
+              // given relative URL lands on the same absolute one whichever
+              // half of the pipeline handles it.
               node.attribs = mapUrlAttributes(node.attribs, (url) =>
                 isLocalMediaPath(url)
                   ? withBasePath(url, basePath)

--- a/lib/media.ts
+++ b/lib/media.ts
@@ -91,8 +91,9 @@ export function withBasePath(url: string, basePath: string) {
 
 /**
  * Where a URL attribute points: `link` at another document, `media` at a
- * subresource the page loads. Relative URLs of the two resolve against
- * different bases, see resolveContentUrl in action/feeds/parsers.ts.
+ * subresource the page loads. Both resolve against the same base; the
+ * distinction is what the media store downloads, see collectImageUrls in
+ * action/feeds/media.ts.
  */
 export type UrlTarget = 'link' | 'media'
 


### PR DESCRIPTION
Follow-up to the base-choice question deferred in #912, which kept the site base on purpose and asked for before-and-after numbers from real feeds first. Rebased onto main now that #912 has merged.

## Problem

`resolveContentUrl` resolved `media` — and, via an extension test, links to downloadable images — with `siteLink` as the primary base. HTML resolves a relative URL against the *document* base, which for a feed entry is the entry URL. For the ordinary feed shape (channel link = homepage, item link deeper), a path-relative `images/x.jpg` in a post at `https://blog.example/2024/01/post/` became `https://blog.example/images/x.jpg`.

It also split the pipeline in two. `resolveEntryUrl` in the reader can only resolve against the entry URL, because `Content` carries no site link — so the same relative `src` resolved one way when the action stored it and another when the reader repaired a legacy entry.

## Deciding the base empirically

Both rules were run over the same feeds through the real pipeline (the site-first side is main's own `parsers.ts`, so the two differed only in the base), then **every disagreement was fetched from its origin**.

`feeds.opml` alone decides nothing: 2 feeds, 686 URLs, **0 disagreements** — both publish fully absolute URLs. The repo's fixture feeds add ~108 URLs and 0 disagreements; `neizod.rss`'s relative URLs are all root-relative, which both rules resolve identically. So the corpus was widened to 209 real feeds — personal blogs, project/vendor blogs, planet aggregators, FeedBurner-proxied feeds, WordPress and static-site generators.

**167 feeds parsed, 77,276 URLs, 20 disagreements (0.03%).**

| Origin says | Count |
|---|---|
| Entry base 200s, site base **404s** | **16** |
| Both work | 4 |
| Site base works, entry base fails | **0** |

All 16 entry-base wins return real image content types (`image/png`, `image/webp`, `image/jpeg`, `image/svg+xml`); all 16 site-base counterparts are hard 404s. The 4 ties differ only by a redundant slash the server normalizes (kubevirt's feed declares its own site link as `https://kubevirt.io//`).

| Feed | URLs | Entry base wins | Tie |
|---|---|---|---|
| `mkennedy.codes` | 10 | 10 | 0 |
| `kubernetes.io` | 3 | 3 | 0 |
| `blog.rust-lang.org/inside-rust` | 3 | 3 | 0 |
| `kubevirt.io` | 4 | 0 | 4 |

Every case is the same shape: a Hugo/Jekyll page bundle referencing an image by bare filename beside the post.

The counter-argument for site-first — feeds whose item links point at a tracker or an aggregated member blog, where the entry host is not the content host — did not materialize. The four FeedBurner feeds and eight planet aggregators in the corpus produced **0 disagreements**: they publish absolute URLs, so the base never comes up.

## Before / after

```
entry: https://kubernetes.io/blog/2026/07/13/kubernetes-dashboard-to-headlamp/
  before: https://kubernetes.io/workloads.png                                        -> 404
  after : https://kubernetes.io/blog/2026/07/13/.../workloads.png                    -> 200 image/png

entry: https://kubernetes.io/blog/2026/02/03/introducing-node-readiness-controller/
  before: https://kubernetes.io/node-readiness-controller-logo.svg                   -> 404
  after : https://kubernetes.io/blog/2026/02/03/.../node-readiness-controller-logo.svg -> 200 image/svg+xml
```

This changes how media resolves for every feed, but in practice it changes **20 URLs in 77,276** — the rest are absolute or root-relative, which both rules resolve identically. Every URL it does change goes from a 404 to a served image.

**Re-keying:** #912 noted that images are hashed under the resolved URL, so moving the base re-keys and re-downloads them. That is true of exactly the 20 URLs that change; everything else hashes the same as before, so the one-off cost is 20 downloads and 20 stale files cleaned up, not the whole store.

## What changed

**Media resolves entry-first**, matching links and matching the reader.

**The downloadable-extension test is gone.** It existed so a link to an image would share the media base and could be swapped for the downloaded copy. Links and media now share a base by construction, so `hasDownloadableImageExtension` is deleted; `DOWNLOADABLE_IMAGE_EXTENSIONS` and `normalizeImageExtension` stay in `images.ts` for the media store, which is now their only caller. `collectImageUrls` is still media-only and `rewriteImageUrls` still covers links, so lightbox hrefs are localized exactly as before.

**One case regresses, and it is the only thing the extension test bought.** A *scheme-less* URL takes no base, so the shared base does not reach it: #912's rule pins a scheme-less link to `https:` while an image keeps the feed's scheme. On an **http** feed, `<a href="//cdn/x.png">` around `<img src="//cdn/x.png">` no longer matches, so that href stays hotlinking instead of being localized. Everywhere a base is actually involved, the two now agree. This is asserted and explained in the test rather than left to be rediscovered.

For the same reason the agreement test covers every URL shape that takes a base but excludes scheme-less ones — the action deliberately pins those to https and the reader has no reason to.

## Verification

- `yarn test` — 117 pass. The one failure, `action/repository`, is pre-existing and unrelated: it asserts the checkout directory is named `feeds`, which fails in any worktree. Confirmed identical on the unmodified tree.
- `yarn build` — TypeScript clean. `prettier --check` clean on every touched file.
- Test expectations were flipped to entry-first *first* and confirmed failing against the old code before it changed. Main's `resolves media against the site even without a downloadable extension` and `picks the link base on the extension alone` tests are rewritten to assert the opposite — that the extension changes nothing — so the exception cannot come back unnoticed.
- A test asserts the action and the reader resolve the same relative URL identically, across bare, root-relative, `../`, fragment and query forms. Confirmed it fails against the old code with `action and reader disagree on photo.jpg`.
- All measurements above were re-run after the rebase, against main's current pipeline (which now makes relative entry links absolute first): same 20 disagreements, same 16/4/0 split.
- Cross-half agreement re-checked on live data: 79,259 stored URLs pushed through the reader's own resolution, 3 changed — all pre-existing percent-encoding quirks in the feeds themselves (literal spaces, a malformed `//Users/...` path), byte-identical before and after this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)