### PR TITLE
Reject downloads whose declared content type is not an image

### DIFF
--- a/action/feeds/images.test.ts
+++ b/action/feeds/images.test.ts
@@ -24,37 +24,12 @@ test('svg is downloadable by neither, which keeps it off our origin', (t) => {
   t.is(extensionFromContentType('image/svg+xml'), null)
 })
 
-test('#extensionFromContentType reads the last type a repeated header declares', (t) => {
-  // headers.get joins repeated Content-Type headers, and the fetch spec
-  // resolves them to the last one it can parse.
-  t.is(extensionFromContentType('image/png, image/png'), '.png')
-  t.is(extensionFromContentType('image/png; charset=binary, text/html'), null)
-  t.is(extensionFromContentType('text/html, image/png'), '.png')
-  // A value the spec would skip must not become the answer, whether it is
-  // empty, a wildcard, or not a media type at all.
-  t.is(extensionFromContentType('image/png,'), '.png')
-  t.is(extensionFromContentType('image/png, '), '.png')
-  t.is(extensionFromContentType('image/png, */*'), '.png')
-  t.is(extensionFromContentType('image/png, nonsense'), '.png')
-})
-
-test('#extensionFromContentType ignores a comma inside a quoted parameter', (t) => {
-  // A bare split would read the last comma segment, so an unterminated quote
-  // could hide a type the browser never sees.
-  t.is(extensionFromContentType('text/html;x="a,image/png'), null)
+test('svg stays excluded however the header dresses it up', (t) => {
+  // The exclusion is what keeps a scripted svg off our own origin, so it has
+  // to survive a header built to slip one past the parser. The rest of that
+  // parsing lives in media#extensionFromContentType.test.ts.
   t.is(extensionFromContentType('image/svg+xml;x="a,image/png'), null)
-  // And the legal shape has to keep working: RFC 2045 name= is legacy but live.
-  t.is(extensionFromContentType('image/png; name="a,b"'), '.png')
-  t.is(extensionFromContentType('image/jpeg; name="photo,1.jpg"'), '.jpg')
-})
-
-test('#extensionFromContentType refuses a type naming an object property', (t) => {
-  // The type is feed-controlled, and `constructor` survives lowercasing where
-  // toString and valueOf do not.
-  t.is(extensionFromContentType('constructor'), null)
-  t.is(extensionFromContentType('__proto__'), null)
-  // Slash-shaped, so it reaches the lookup where the bare keys never do.
-  t.is(extensionFromContentType('image/constructor'), null)
+  t.is(extensionFromContentType('image/png, image/svg+xml'), null)
 })
 
 test('#normalizeImageExtension accepts any casing and padding', (t) => {

--- a/action/feeds/images.test.ts
+++ b/action/feeds/images.test.ts
@@ -24,6 +24,39 @@ test('svg is downloadable by neither, which keeps it off our origin', (t) => {
   t.is(extensionFromContentType('image/svg+xml'), null)
 })
 
+test('#extensionFromContentType reads the last type a repeated header declares', (t) => {
+  // headers.get joins repeated Content-Type headers, and the fetch spec
+  // resolves them to the last one it can parse.
+  t.is(extensionFromContentType('image/png, image/png'), '.png')
+  t.is(extensionFromContentType('image/png; charset=binary, text/html'), null)
+  t.is(extensionFromContentType('text/html, image/png'), '.png')
+  // A value the spec would skip must not become the answer, whether it is
+  // empty, a wildcard, or not a media type at all.
+  t.is(extensionFromContentType('image/png,'), '.png')
+  t.is(extensionFromContentType('image/png, '), '.png')
+  t.is(extensionFromContentType('image/png, */*'), '.png')
+  t.is(extensionFromContentType('image/png, nonsense'), '.png')
+})
+
+test('#extensionFromContentType ignores a comma inside a quoted parameter', (t) => {
+  // A bare split would read the last comma segment, so an unterminated quote
+  // could hide a type the browser never sees.
+  t.is(extensionFromContentType('text/html;x="a,image/png'), null)
+  t.is(extensionFromContentType('image/svg+xml;x="a,image/png'), null)
+  // And the legal shape has to keep working: RFC 2045 name= is legacy but live.
+  t.is(extensionFromContentType('image/png; name="a,b"'), '.png')
+  t.is(extensionFromContentType('image/jpeg; name="photo,1.jpg"'), '.jpg')
+})
+
+test('#extensionFromContentType refuses a type naming an object property', (t) => {
+  // The type is feed-controlled, and `constructor` survives lowercasing where
+  // toString and valueOf do not.
+  t.is(extensionFromContentType('constructor'), null)
+  t.is(extensionFromContentType('__proto__'), null)
+  // Slash-shaped, so it reaches the lookup where the bare keys never do.
+  t.is(extensionFromContentType('image/constructor'), null)
+})
+
 test('#normalizeImageExtension accepts any casing and padding', (t) => {
   t.is(normalizeImageExtension('.PNG'), '.png')
   t.is(normalizeImageExtension('  .webp  '), '.webp')

--- a/action/feeds/media#extensionFromContentType.test.ts
+++ b/action/feeds/media#extensionFromContentType.test.ts
@@ -42,6 +42,17 @@ test('#extensionFromContentType reads the last type a repeated header declares',
     ),
     null
   )
+  // And again on the other side of the slash. The class is applied twice, and
+  // a subtype-only value pins only one of them: every other type half in the
+  // suite is image, text, application, a or *, so narrowing the left class
+  // alone passed everything while turning `image/png, x-image/x-png` into a
+  // download.
+  t.is(
+    extensionFromContentType(
+      "image/png, !#$%&'*+-.^_`|~0123456789abcdefghijklmnopqrstuvwxyz/png"
+    ),
+    null
+  )
 })
 
 test('#extensionFromContentType passes over a value it cannot use', (t) => {

--- a/action/feeds/media#extensionFromContentType.test.ts
+++ b/action/feeds/media#extensionFromContentType.test.ts
@@ -4,10 +4,10 @@ import { extensionFromContentType } from './media'
 
 /**
  * Measured against a real socket rather than the Response constructor, which
- * normalizes where the wire does not: headers.get strips leading SP and HTAB
- * and nothing else, so a trailing SP or HTAB, and U+00A0 on either side, all
- * arrive verbatim. Those cases are reachable by any feed whose image host is
- * hostile or merely broken.
+ * normalizes where the wire does not: the wire delivers leading SP and HTAB
+ * already stripped and nothing else, so a trailing SP or HTAB, and U+00A0 on
+ * either side, all arrive verbatim. Those cases are reachable by any feed
+ * whose image host is hostile or merely broken.
  *
  * A value carrying CR, LF, \v or \f never arrives at all -- undici rejects the
  * response before headers.get sees it -- so those assertions pin the whitespace
@@ -26,13 +26,21 @@ test('#extensionFromContentType reads the last type a repeated header declares',
   // A last type that parses but names something we do not serve still wins.
   // These need the full token class to parse at all, so a narrower one would
   // skip them and let the earlier image/png through -- the fail-open
-  // direction, since a skipped value does not overwrite the answer. Between
-  // them they carry every character of the class except `+`, which
-  // `image/png, image/svg+xml` pins over in images.test.ts.
+  // direction, since a skipped value does not overwrite the answer.
   t.is(extensionFromContentType('image/png, image/x-icon'), null)
   t.is(extensionFromContentType('image/png, application/vnd.ms-excel'), null)
-  t.is(extensionFromContentType("image/png, image/!#$%&'*^_`|~"), null)
   t.is(extensionFromContentType('image/png, image/h265'), null)
+  // Carrying the whole class covers the 44 characters image/png does not use:
+  // drop any of them and this last value stops parsing, so image/png wins and
+  // the answer flips. The seven that image/png does use need no assertion here
+  // -- dropping one of those fails every test in the suite that expects an
+  // image at all.
+  t.is(
+    extensionFromContentType(
+      "image/png, image/!#$%&'*+-.^_`|~0123456789abcdefghijklmnopqrstuvwxyz"
+    ),
+    null
+  )
 })
 
 test('#extensionFromContentType skips a value the spec cannot use', (t) => {
@@ -47,10 +55,15 @@ test('#extensionFromContentType skips a value the spec cannot use', (t) => {
   t.is(extensionFromContentType('image/png, /png'), '.png')
   t.is(extensionFromContentType('image/png, a/b/c'), '.png')
   t.is(extensionFromContentType('image/png, image /png'), '.png')
-  // Quotes are not token characters. Led by text/html rather than image/png,
-  // or accepting the quoted value would give the same answer as skipping it
-  // and the assertion would pass either way.
-  t.is(extensionFromContentType('text/html, "image/png"'), null)
+  // splitHeaderValue keeps the quote characters, so a quoted value fails
+  // MEDIA_TYPE and is skipped. A closed quote cannot show that on its own --
+  // a quoted candidate never resolves to an extension, so skipping it and
+  // accepting it both answer null whatever leads. Only a quote that opens a
+  // value separates them: skipping preserves the type before it, accepting
+  // erases it.
+  t.is(extensionFromContentType('image/png, "text/html'), '.png')
+  t.is(extensionFromContentType('text/html, "image/png'), null)
+  t.is(extensionFromContentType('image/png, "text/html"'), '.png')
   // A parameter is not a value: the segment after the ; can never become the
   // essence, however much it looks like one.
   t.is(extensionFromContentType('text/html; image/png'), null)

--- a/action/feeds/media#extensionFromContentType.test.ts
+++ b/action/feeds/media#extensionFromContentType.test.ts
@@ -1,0 +1,77 @@
+import test from 'ava'
+
+import { extensionFromContentType } from './media'
+
+/**
+ * The response names the type, so these cases are all reachable by any feed
+ * whose image host is hostile or merely broken. The oracle throughout is what
+ * a browser fetching the same URL would conclude, which is the fetch spec's
+ * "extract a MIME type".
+ */
+
+test('#extensionFromContentType reads the last type a repeated header declares', (t) => {
+  // headers.get joins repeated Content-Type headers, and the spec resolves
+  // them to the last one it can parse.
+  t.is(extensionFromContentType('image/png, image/png'), '.png')
+  t.is(extensionFromContentType('image/png; charset=binary, text/html'), null)
+  t.is(extensionFromContentType('text/html, image/png'), '.png')
+})
+
+test('#extensionFromContentType skips a value the spec cannot use', (t) => {
+  // Empty, wildcard, or unparseable values are passed over rather than
+  // becoming the answer, so junk appended by a proxy cannot erase a real type.
+  t.is(extensionFromContentType('image/png,'), '.png')
+  t.is(extensionFromContentType('image/png, '), '.png')
+  t.is(extensionFromContentType('image/png, */*'), '.png')
+  t.is(extensionFromContentType('image/png, nonsense'), '.png')
+  // Slash-shaped is not the same as parseable: both halves have to be tokens.
+  t.is(extensionFromContentType('image/png, image/'), '.png')
+  t.is(extensionFromContentType('image/png, /png'), '.png')
+  t.is(extensionFromContentType('image/png, a/b/c'), '.png')
+  t.is(extensionFromContentType('image/png, image /png'), '.png')
+  t.is(extensionFromContentType('image/png, "image/png"'), '.png')
+})
+
+test('#extensionFromContentType ignores a comma inside a quoted parameter', (t) => {
+  // A bare split would read the last comma segment, so an unterminated quote
+  // could hide a type the browser never sees.
+  t.is(extensionFromContentType('text/html;x="a,image/png'), null)
+  t.is(extensionFromContentType('image/svg+xml;x="a,image/png'), null)
+  // A quote that closes gives the comma after it back, so the real last value
+  // still decides. Missing this is the failure that lets html through.
+  t.is(extensionFromContentType('image/png; name="a,b", text/html'), null)
+  // And an escaped quote does not close the run, or the comma after it splits
+  // a value the spec keeps whole.
+  t.is(extensionFromContentType('image/png; name="a\\", text/html'), '.png')
+  // The legal shape has to keep working: a quoted name= is deprecated but
+  // still live in the wild.
+  t.is(extensionFromContentType('image/png; name="a,b"'), '.png')
+  t.is(extensionFromContentType('image/jpeg; name="photo,1.jpg"'), '.jpg')
+})
+
+test('#extensionFromContentType strips only the whitespace the spec strips', (t) => {
+  t.is(extensionFromContentType('  image/png  '), '.png')
+  t.is(extensionFromContentType('\timage/png\t'), '.png')
+  // JS trim() also strips U+00A0, which the spec does not -- and a value the
+  // browser refuses must not become an image here.
+  t.is(extensionFromContentType('image/png '), null)
+  t.is(extensionFromContentType(' image/png'), null)
+  t.is(extensionFromContentType('text/html, image/png'), null)
+})
+
+test('#extensionFromContentType refuses a type naming an object property', (t) => {
+  // The type comes from the response, and `constructor` survives lowercasing
+  // where toString and valueOf do not.
+  t.is(extensionFromContentType('constructor'), null)
+  t.is(extensionFromContentType('__proto__'), null)
+  // Slash-shaped, so it reaches the lookup where the bare keys never do.
+  t.is(extensionFromContentType('image/constructor'), null)
+})
+
+test('#extensionFromContentType treats a header naming nothing as naming nothing', (t) => {
+  // Distinct from an absent header, which downloadMedia handles separately:
+  // these all arrive as a value, and none of them names a type.
+  t.is(extensionFromContentType(''), null)
+  t.is(extensionFromContentType('   '), null)
+  t.is(extensionFromContentType('; charset=utf-8'), null)
+})

--- a/action/feeds/media#extensionFromContentType.test.ts
+++ b/action/feeds/media#extensionFromContentType.test.ts
@@ -47,9 +47,10 @@ test('#extensionFromContentType reads the last type a repeated header declares',
 test('#extensionFromContentType passes over a value it cannot use', (t) => {
   // Skipping is not stopping, and every case below puts the unusable value
   // last, where passing over it and abandoning the scan at it agree. These
-  // four put it in the middle, which is the only position that tells the two
-  // apart -- and stopping there is the fail-open direction, since it leaves an
-  // earlier image/png standing as the answer.
+  // four put a usable value after it, which is what tells the two apart. The
+  // three that lead with image/png show stopping in its fail-open direction --
+  // it leaves that earlier image/png standing as the answer -- and the first
+  // shows the same mutant from the other side, refusing a real image.
   t.is(extensionFromContentType('nonsense, image/png'), '.png')
   t.is(extensionFromContentType('image/png, nonsense, text/html'), null)
   t.is(extensionFromContentType('image/png, */*, text/html'), null)
@@ -115,7 +116,7 @@ test('#extensionFromContentType strips only the whitespace the spec strips', (t)
   t.is(extensionFromContentType('text/html,\u00a0image/png'), null)
 })
 
-test('#extensionFromContentType strips a long whitespace run in linear time', (t) => {
+test('#extensionFromContentType refuses a long whitespace run in linear time', (t) => {
   // Scanned rather than matched with /[\t\n\r ]+$/, which is quadratic on an
   // interior run. A feed's image host picks this header, and 16 KiB is about
   // the most Node's default maxHeaderSize will carry.
@@ -130,6 +131,26 @@ test('#extensionFromContentType strips a long whitespace run in linear time', (t
   // walking 16 KiB, not the strip -- so these 40 run in about 5ms. A one
   // second bound leaves room for a slow machine without letting the
   // regression back.
+  t.true(elapsedMs < 1000, `40 refusals took ${elapsedMs.toFixed(0)}ms`)
+})
+
+test('#extensionFromContentType refuses a long token run in linear time', (t) => {
+  // A separate axis from the whitespace run above, which MEDIA_TYPE rejects at
+  // its second character and so never exercises. A slash-free token run is the
+  // input that makes the regex do work, and it is the shape the parse test is
+  // built to reject -- so it is exactly what a hostile host would send if the
+  // class ever grew a nested quantifier.
+  //
+  // Short on purpose: the cost of a backtracking form doubles per character,
+  // so at 16 KiB it would never return and at 30 it outruns ava's timeout.
+  // 26 keeps the failure a reported one rather than a hang -- 40 refusals in
+  // about 6s against this bound, where HEAD needs under a millisecond.
+  const hostile = 'a'.repeat(26)
+  const started = process.hrtime.bigint()
+  for (let attempt = 0; attempt < 40; attempt++) {
+    t.is(extensionFromContentType(hostile), null)
+  }
+  const elapsedMs = Number(process.hrtime.bigint() - started) / 1e6
   t.true(elapsedMs < 1000, `40 refusals took ${elapsedMs.toFixed(0)}ms`)
 })
 

--- a/action/feeds/media#extensionFromContentType.test.ts
+++ b/action/feeds/media#extensionFromContentType.test.ts
@@ -3,11 +3,15 @@ import test from 'ava'
 import { extensionFromContentType } from './media'
 
 /**
- * The response names the type, so these cases are reachable by any feed whose
- * image host is hostile or merely broken. Measured against a real socket rather
- * than the Response constructor, which normalizes where the wire does not:
- * headers.get strips leading HTTP whitespace and nothing else, so trailing
- * whitespace and U+00A0 on either side arrive verbatim.
+ * Measured against a real socket rather than the Response constructor, which
+ * normalizes where the wire does not: headers.get strips leading SP and HTAB
+ * and nothing else, so a trailing SP or HTAB, and U+00A0 on either side, all
+ * arrive verbatim. Those cases are reachable by any feed whose image host is
+ * hostile or merely broken.
+ *
+ * A value carrying CR, LF, \v or \f never arrives at all -- undici rejects the
+ * response before headers.get sees it -- so those assertions pin the whitespace
+ * set's definition rather than a shape off the wire.
  *
  * The oracle throughout is what a browser fetching the same URL would conclude,
  * which is the fetch spec's "extract a MIME type".
@@ -22,11 +26,13 @@ test('#extensionFromContentType reads the last type a repeated header declares',
   // A last type that parses but names something we do not serve still wins.
   // These need the full token class to parse at all, so a narrower one would
   // skip them and let the earlier image/png through -- the fail-open
-  // direction, since a skipped value does not overwrite the answer. The third
-  // carries every token character the other two do not.
+  // direction, since a skipped value does not overwrite the answer. Between
+  // them they carry every character of the class except `+`, which
+  // `image/png, image/svg+xml` pins over in images.test.ts.
   t.is(extensionFromContentType('image/png, image/x-icon'), null)
   t.is(extensionFromContentType('image/png, application/vnd.ms-excel'), null)
   t.is(extensionFromContentType("image/png, image/!#$%&'*^_`|~"), null)
+  t.is(extensionFromContentType('image/png, image/h265'), null)
 })
 
 test('#extensionFromContentType skips a value the spec cannot use', (t) => {
@@ -41,7 +47,13 @@ test('#extensionFromContentType skips a value the spec cannot use', (t) => {
   t.is(extensionFromContentType('image/png, /png'), '.png')
   t.is(extensionFromContentType('image/png, a/b/c'), '.png')
   t.is(extensionFromContentType('image/png, image /png'), '.png')
-  t.is(extensionFromContentType('image/png, "image/png"'), '.png')
+  // Quotes are not token characters. Led by text/html rather than image/png,
+  // or accepting the quoted value would give the same answer as skipping it
+  // and the assertion would pass either way.
+  t.is(extensionFromContentType('text/html, "image/png"'), null)
+  // A parameter is not a value: the segment after the ; can never become the
+  // essence, however much it looks like one.
+  t.is(extensionFromContentType('text/html; image/png'), null)
 })
 
 test('#extensionFromContentType ignores a comma inside a quoted parameter', (t) => {

--- a/action/feeds/media#extensionFromContentType.test.ts
+++ b/action/feeds/media#extensionFromContentType.test.ts
@@ -4,10 +4,13 @@ import { extensionFromContentType } from './media'
 
 /**
  * The response names the type, so these cases are reachable by any feed whose
- * image host is hostile or merely broken -- except the padded values below,
- * which headers.get would have stripped, and which pin this parser's own
- * stripping instead. The oracle throughout is what a browser fetching the same
- * URL would conclude, which is the fetch spec's "extract a MIME type".
+ * image host is hostile or merely broken. Measured against a real socket rather
+ * than the Response constructor, which normalizes where the wire does not:
+ * headers.get strips leading HTTP whitespace and nothing else, so trailing
+ * whitespace and U+00A0 on either side arrive verbatim.
+ *
+ * The oracle throughout is what a browser fetching the same URL would conclude,
+ * which is the fetch spec's "extract a MIME type".
  */
 
 test('#extensionFromContentType reads the last type a repeated header declares', (t) => {
@@ -17,10 +20,13 @@ test('#extensionFromContentType reads the last type a repeated header declares',
   t.is(extensionFromContentType('image/png; charset=binary, text/html'), null)
   t.is(extensionFromContentType('text/html, image/png'), '.png')
   // A last type that parses but names something we do not serve still wins.
-  // Both of these need the full token class to parse at all, so a narrower
-  // one would skip them and let the earlier image/png through.
+  // These need the full token class to parse at all, so a narrower one would
+  // skip them and let the earlier image/png through -- the fail-open
+  // direction, since a skipped value does not overwrite the answer. The third
+  // carries every token character the other two do not.
   t.is(extensionFromContentType('image/png, image/x-icon'), null)
   t.is(extensionFromContentType('image/png, application/vnd.ms-excel'), null)
+  t.is(extensionFromContentType("image/png, image/!#$%&'*^_`|~"), null)
 })
 
 test('#extensionFromContentType skips a value the spec cannot use', (t) => {
@@ -58,6 +64,13 @@ test('#extensionFromContentType ignores a comma inside a quoted parameter', (t) 
 test('#extensionFromContentType strips only the whitespace the spec strips', (t) => {
   t.is(extensionFromContentType('  image/png  '), '.png')
   t.is(extensionFromContentType('\timage/png\t'), '.png')
+  // All four members of the set, or half of it can be dropped silently.
+  t.is(extensionFromContentType('\nimage/png\r'), '.png')
+  t.is(extensionFromContentType('\rimage/png\n'), '.png')
+  // And only those four: \v and \f are whitespace to JS but not to the spec,
+  // so admitting them would launder a value the browser refuses.
+  t.is(extensionFromContentType('image/png\f'), null)
+  t.is(extensionFromContentType('\vimage/png'), null)
   // Escaped rather than literal: U+00A0 renders as a space, so these would
   // otherwise read identically to the U+0020 assertions above while expecting
   // the opposite. JS trim() takes U+00A0 and the spec does not, so a value the
@@ -69,8 +82,8 @@ test('#extensionFromContentType strips only the whitespace the spec strips', (t)
 
 test('#extensionFromContentType strips a long whitespace run in linear time', (t) => {
   // Scanned rather than matched with /[\t\n\r ]+$/, which is quadratic on an
-  // interior run. A feed's image host picks this header, and 16 KiB sits well
-  // inside Node's default maxHeaderSize.
+  // interior run. A feed's image host picks this header, and 16 KiB is about
+  // the most Node's default maxHeaderSize will carry.
   const hostile = `a${' '.repeat(16198)}b`
   const started = process.hrtime.bigint()
   for (let attempt = 0; attempt < 40; attempt++) {

--- a/action/feeds/media#extensionFromContentType.test.ts
+++ b/action/feeds/media#extensionFromContentType.test.ts
@@ -32,9 +32,10 @@ test('#extensionFromContentType reads the last type a repeated header declares',
   t.is(extensionFromContentType('image/png, image/h265'), null)
   // Carrying the whole class covers the 44 characters image/png does not use:
   // drop any of them and this last value stops parsing, so image/png wins and
-  // the answer flips. The seven that image/png does use need no assertion here
-  // -- dropping one of those fails every test in the suite that expects an
-  // image at all.
+  // the answer flips. The seven that image/png does use cannot be covered this
+  // way -- dropping one of those stops the leading value parsing too, and the
+  // answer stays null. They need no assertion here regardless: image/png
+  // itself becomes unparseable, which fails four tests in this file alone.
   t.is(
     extensionFromContentType(
       "image/png, image/!#$%&'*+-.^_`|~0123456789abcdefghijklmnopqrstuvwxyz"
@@ -43,7 +44,16 @@ test('#extensionFromContentType reads the last type a repeated header declares',
   )
 })
 
-test('#extensionFromContentType skips a value the spec cannot use', (t) => {
+test('#extensionFromContentType passes over a value it cannot use', (t) => {
+  // Skipping is not stopping, and every case below puts the unusable value
+  // last, where passing over it and abandoning the scan at it agree. These
+  // four put it in the middle, which is the only position that tells the two
+  // apart -- and stopping there is the fail-open direction, since it leaves an
+  // earlier image/png standing as the answer.
+  t.is(extensionFromContentType('nonsense, image/png'), '.png')
+  t.is(extensionFromContentType('image/png, nonsense, text/html'), null)
+  t.is(extensionFromContentType('image/png, */*, text/html'), null)
+  t.is(extensionFromContentType('image/png,, text/html'), null)
   // Empty, wildcard, or unparseable values are passed over rather than
   // becoming the answer, so junk appended by a proxy cannot erase a real type.
   t.is(extensionFromContentType('image/png,'), '.png')
@@ -56,11 +66,11 @@ test('#extensionFromContentType skips a value the spec cannot use', (t) => {
   t.is(extensionFromContentType('image/png, a/b/c'), '.png')
   t.is(extensionFromContentType('image/png, image /png'), '.png')
   // splitHeaderValue keeps the quote characters, so a quoted value fails
-  // MEDIA_TYPE and is skipped. A closed quote cannot show that on its own --
-  // a quoted candidate never resolves to an extension, so skipping it and
-  // accepting it both answer null whatever leads. Only a quote that opens a
-  // value separates them: skipping preserves the type before it, accepting
-  // erases it.
+  // MEDIA_TYPE and is skipped. A closed quote cannot show that on its own: its
+  // closing quote survives any mutation of the opening one, so the candidate
+  // stays unparseable and the answer is the same either way. Only a quote that
+  // opens a value separates them, and it is the pair below that does the work
+  // -- skipping preserves the type before it, accepting erases it.
   t.is(extensionFromContentType('image/png, "text/html'), '.png')
   t.is(extensionFromContentType('text/html, "image/png'), null)
   t.is(extensionFromContentType('image/png, "text/html"'), '.png')
@@ -116,17 +126,22 @@ test('#extensionFromContentType strips a long whitespace run in linear time', (t
   }
   const elapsedMs = Number(process.hrtime.bigint() - started) / 1e6
   // The regex form took ~137ms per call, so 40 of them took 5.5 seconds. The
-  // scan is under 0.01ms; a one second bound leaves room for a slow machine
-  // without admitting the regression back.
+  // scan costs ~0.14ms per call here -- almost all of it splitHeaderValue
+  // walking 16 KiB, not the strip -- so these 40 run in about 5ms. A one
+  // second bound leaves room for a slow machine without letting the
+  // regression back.
   t.true(elapsedMs < 1000, `40 refusals took ${elapsedMs.toFixed(0)}ms`)
 })
 
 test('#extensionFromContentType refuses a type naming an object property', (t) => {
   // The type comes from the response, and `constructor` survives lowercasing
   // where toString and valueOf do not.
+  // These two are what pin the guard: without the media-type test they reach
+  // the lookup, hit Object.prototype, and throw rather than refuse.
   t.is(extensionFromContentType('constructor'), null)
   t.is(extensionFromContentType('__proto__'), null)
-  // Slash-shaped, so it reaches the lookup where the bare keys never do.
+  // Slash-shaped, so it does reach the lookup -- and misses it like any other
+  // unserved type. Here to mark that boundary, not to pin it.
   t.is(extensionFromContentType('image/constructor'), null)
 })
 

--- a/action/feeds/media#extensionFromContentType.test.ts
+++ b/action/feeds/media#extensionFromContentType.test.ts
@@ -3,10 +3,11 @@ import test from 'ava'
 import { extensionFromContentType } from './media'
 
 /**
- * The response names the type, so these cases are all reachable by any feed
- * whose image host is hostile or merely broken. The oracle throughout is what
- * a browser fetching the same URL would conclude, which is the fetch spec's
- * "extract a MIME type".
+ * The response names the type, so these cases are reachable by any feed whose
+ * image host is hostile or merely broken -- except the padded values below,
+ * which headers.get would have stripped, and which pin this parser's own
+ * stripping instead. The oracle throughout is what a browser fetching the same
+ * URL would conclude, which is the fetch spec's "extract a MIME type".
  */
 
 test('#extensionFromContentType reads the last type a repeated header declares', (t) => {
@@ -15,6 +16,11 @@ test('#extensionFromContentType reads the last type a repeated header declares',
   t.is(extensionFromContentType('image/png, image/png'), '.png')
   t.is(extensionFromContentType('image/png; charset=binary, text/html'), null)
   t.is(extensionFromContentType('text/html, image/png'), '.png')
+  // A last type that parses but names something we do not serve still wins.
+  // Both of these need the full token class to parse at all, so a narrower
+  // one would skip them and let the earlier image/png through.
+  t.is(extensionFromContentType('image/png, image/x-icon'), null)
+  t.is(extensionFromContentType('image/png, application/vnd.ms-excel'), null)
 })
 
 test('#extensionFromContentType skips a value the spec cannot use', (t) => {
@@ -52,11 +58,29 @@ test('#extensionFromContentType ignores a comma inside a quoted parameter', (t) 
 test('#extensionFromContentType strips only the whitespace the spec strips', (t) => {
   t.is(extensionFromContentType('  image/png  '), '.png')
   t.is(extensionFromContentType('\timage/png\t'), '.png')
-  // JS trim() also strips U+00A0, which the spec does not -- and a value the
+  // Escaped rather than literal: U+00A0 renders as a space, so these would
+  // otherwise read identically to the U+0020 assertions above while expecting
+  // the opposite. JS trim() takes U+00A0 and the spec does not, so a value the
   // browser refuses must not become an image here.
-  t.is(extensionFromContentType('image/png '), null)
-  t.is(extensionFromContentType(' image/png'), null)
-  t.is(extensionFromContentType('text/html, image/png'), null)
+  t.is(extensionFromContentType('image/png\u00a0'), null)
+  t.is(extensionFromContentType('\u00a0image/png'), null)
+  t.is(extensionFromContentType('text/html,\u00a0image/png'), null)
+})
+
+test('#extensionFromContentType strips a long whitespace run in linear time', (t) => {
+  // Scanned rather than matched with /[\t\n\r ]+$/, which is quadratic on an
+  // interior run. A feed's image host picks this header, and 16 KiB sits well
+  // inside Node's default maxHeaderSize.
+  const hostile = `a${' '.repeat(16198)}b`
+  const started = process.hrtime.bigint()
+  for (let attempt = 0; attempt < 40; attempt++) {
+    t.is(extensionFromContentType(hostile), null)
+  }
+  const elapsedMs = Number(process.hrtime.bigint() - started) / 1e6
+  // The regex form took ~137ms per call, so 40 of them took 5.5 seconds. The
+  // scan is under 0.01ms; a one second bound leaves room for a slow machine
+  // without admitting the regression back.
+  t.true(elapsedMs < 1000, `40 refusals took ${elapsedMs.toFixed(0)}ms`)
 })
 
 test('#extensionFromContentType refuses a type naming an object property', (t) => {

--- a/action/feeds/media.test.ts
+++ b/action/feeds/media.test.ts
@@ -414,9 +414,12 @@ test('#localizeSite keeps the remote url for an empty content type header', asyn
   const url = 'https://example.com/photo.png'
   // Sending the header and naming nothing is still a declaration, and an
   // unusable one -- unlike a host that omits the header altogether.
-  const fetchStub = sinon
-    .stub()
-    .resolves(imageResponse('<html>blocked</html>', ''))
+  const fetchStub = sinon.stub().resolves(
+    new Response(Buffer.from('<html>blocked</html>'), {
+      status: 200,
+      headers: { 'content-type': '' }
+    })
+  )
 
   const store = createMediaStore({ mediaDirectory, fetch: fetchStub as any })
   const localized = await store.localizeSite(createSite(`<img src="${url}" />`))
@@ -441,7 +444,7 @@ test('#localizeSite names files from a content type in upper case', async (t) =>
   )
 })
 
-test('#localizeSite names files from a content type padded before its parameters', async (t) => {
+test('#localizeSite names files from a content type with space before its parameters', async (t) => {
   const mediaDirectory = await createMediaDirectory('feeds-media-padded-type-')
   const url = 'https://example.com/a.png'
   const fetchStub = sinon
@@ -475,15 +478,75 @@ test('#localizeSite keeps the remote url for a content type naming an object pro
   const mediaDirectory = await createMediaDirectory('feeds-media-proto-type-')
   const url = 'https://example.com/photo.png'
   // The type is feed-controlled, and `constructor` survives lowercasing.
-  const fetchStub = sinon
-    .stub()
-    .resolves(imageResponse('<html>blocked</html>', 'constructor'))
+  const fetchStub = sinon.stub().resolves(
+    new Response(Buffer.from('<html>blocked</html>'), {
+      status: 200,
+      headers: { 'content-type': 'constructor' }
+    })
+  )
 
   const store = createMediaStore({ mediaDirectory, fetch: fetchStub as any })
   const localized = await store.localizeSite(createSite(`<img src="${url}" />`))
 
   t.true(localized.entries[0].content.includes(`src="${url}"`))
   t.deepEqual(await listMediaFiles(mediaDirectory), [])
+})
+
+test('#localizeSite names files from the content type when the url names a different image type', async (t) => {
+  const mediaDirectory = await createMediaDirectory('feeds-media-mismatch-')
+  const url = 'https://example.com/a.png'
+  // The one case that tells the two orderings apart: both name an image, and
+  // they disagree. The server wins, or "the URL does not overrule it" is empty.
+  const fetchStub = sinon
+    .stub()
+    .resolves(imageResponse('image-bytes', 'image/webp'))
+
+  const store = createMediaStore({ mediaDirectory, fetch: fetchStub as any })
+  const localized = await store.localizeSite(createSite(`<img src="${url}" />`))
+
+  t.deepEqual(await listMediaFiles(mediaDirectory), [`${mediaHash(url)}.webp`])
+  t.true(
+    localized.entries[0].content.includes(`src="/media/${mediaHash(url)}.webp"`)
+  )
+})
+
+test('#localizeSite aborts the request when it refuses the response', async (t) => {
+  const mediaDirectory = await createMediaDirectory('feeds-media-abort-')
+  const signals: AbortSignal[] = []
+  // An unread body holds its socket until the remote end drops it, so a
+  // refusal has to abort rather than just walk away.
+  const fetchStub = sinon.stub().callsFake(async (_url: string, init: any) => {
+    signals.push(init.signal)
+    return new Response('<html>blocked</html>', {
+      status: 200,
+      headers: { 'content-type': 'text/html' }
+    })
+  })
+
+  const store = createMediaStore({ mediaDirectory, fetch: fetchStub as any })
+  await store.localizeSite(
+    createSite('<img src="https://example.com/photo.png" />')
+  )
+
+  t.is(signals.length, 1)
+  t.true(signals[0].aborted)
+})
+
+test('#localizeSite leaves the request alone when it accepts the response', async (t) => {
+  const mediaDirectory = await createMediaDirectory('feeds-media-noabort-')
+  const signals: AbortSignal[] = []
+  const fetchStub = sinon.stub().callsFake(async (_url: string, init: any) => {
+    signals.push(init.signal)
+    return imageResponse()
+  })
+
+  const store = createMediaStore({ mediaDirectory, fetch: fetchStub as any })
+  await store.localizeSite(
+    createSite('<img src="https://example.com/a.png" />')
+  )
+
+  t.is(signals.length, 1)
+  t.false(signals[0].aborted)
 })
 
 test('#localizeSite names files from the content type when the url has no extension', async (t) => {

--- a/action/feeds/media.test.ts
+++ b/action/feeds/media.test.ts
@@ -513,14 +513,17 @@ test('#localizeSite names files from the content type when the url names a diffe
 test('#localizeSite aborts the request when it refuses the response', async (t) => {
   const mediaDirectory = await createMediaDirectory('feeds-media-abort-')
   const signals: AbortSignal[] = []
+  const responses: Response[] = []
   // An unread body holds its socket until the remote end drops it, so a
   // refusal has to abort rather than just walk away.
   const fetchStub = sinon.stub().callsFake(async (_url: string, init: any) => {
     signals.push(init.signal)
-    return new Response('<html>blocked</html>', {
+    const response = new Response('<html>blocked</html>', {
       status: 200,
       headers: { 'content-type': 'text/html' }
     })
+    responses.push(response)
+    return response
   })
 
   const store = createMediaStore({ mediaDirectory, fetch: fetchStub as any })
@@ -530,6 +533,9 @@ test('#localizeSite aborts the request when it refuses the response', async (t) 
 
   t.is(signals.length, 1)
   t.true(signals[0].aborted)
+  // And the refusal has to happen before the body is read, or the abort is
+  // saving a socket we already paid to drain.
+  t.false(responses[0].bodyUsed)
 })
 
 test('#localizeSite leaves the request alone when it accepts the response', async (t) => {

--- a/action/feeds/media.test.ts
+++ b/action/feeds/media.test.ts
@@ -316,6 +316,55 @@ test('#localizeSite keeps the remote url for non image responses', async (t) => 
   t.deepEqual(await listMediaFiles(mediaDirectory), [])
 })
 
+test('#localizeSite keeps the remote url for an html body served from an image url', async (t) => {
+  const mediaDirectory = await createMediaDirectory('feeds-media-html-png-')
+  const url = 'https://example.com/photo.png'
+  const fetchStub = sinon.stub().resolves(
+    new Response('<html><script>alert(document.domain)</script></html>', {
+      status: 200,
+      headers: { 'content-type': 'text/html' }
+    })
+  )
+
+  const store = createMediaStore({ mediaDirectory, fetch: fetchStub as any })
+  const localized = await store.localizeSite(createSite(`<img src="${url}" />`))
+
+  t.true(localized.entries[0].content.includes(`src="${url}"`))
+  t.deepEqual(await listMediaFiles(mediaDirectory), [])
+})
+
+test('#localizeSite keeps the remote url for an svg body served from an image url', async (t) => {
+  const mediaDirectory = await createMediaDirectory('feeds-media-svg-png-')
+  const url = 'https://example.com/logo.png'
+  const fetchStub = sinon
+    .stub()
+    .resolves(imageResponse('<svg onload="alert(1)" />', 'image/svg+xml'))
+
+  const store = createMediaStore({ mediaDirectory, fetch: fetchStub as any })
+  const localized = await store.localizeSite(createSite(`<img src="${url}" />`))
+
+  t.true(localized.entries[0].content.includes(`src="${url}"`))
+  t.deepEqual(await listMediaFiles(mediaDirectory), [])
+})
+
+test('#localizeSite names files from the url when the server declares no type', async (t) => {
+  const mediaDirectory = await createMediaDirectory('feeds-media-no-type-')
+  const url = 'https://example.com/a.png'
+  // A Buffer body leaves Response without a content-type, which is what a host
+  // that never sets the header looks like.
+  const fetchStub = sinon
+    .stub()
+    .resolves(new Response(Buffer.from('image-bytes'), { status: 200 }))
+
+  const store = createMediaStore({ mediaDirectory, fetch: fetchStub as any })
+  const localized = await store.localizeSite(createSite(`<img src="${url}" />`))
+
+  t.deepEqual(await listMediaFiles(mediaDirectory), [`${mediaHash(url)}.png`])
+  t.true(
+    localized.entries[0].content.includes(`src="/media/${mediaHash(url)}.png"`)
+  )
+})
+
 test('#localizeSite names files from the content type when the url has no extension', async (t) => {
   const mediaDirectory = await createMediaDirectory('feeds-media-content-type-')
   const url = 'https://example.com/photo?id=1'

--- a/action/feeds/media.test.ts
+++ b/action/feeds/media.test.ts
@@ -365,6 +365,127 @@ test('#localizeSite names files from the url when the server declares no type', 
   )
 })
 
+test('#localizeSite keeps the remote url when a repeated content type header ends in a non image', async (t) => {
+  const mediaDirectory = await createMediaDirectory('feeds-media-dup-html-')
+  const url = 'https://example.com/photo.png'
+  // headers.get joins repeated headers, and the fetch spec reads the last of
+  // them, so the leading image/png must not be what decides this.
+  const fetchStub = sinon.stub().resolves(
+    new Response('<html>blocked</html>', {
+      status: 200,
+      headers: [
+        ['content-type', 'image/png; charset=binary'],
+        ['content-type', 'text/html']
+      ]
+    })
+  )
+
+  const store = createMediaStore({ mediaDirectory, fetch: fetchStub as any })
+  const localized = await store.localizeSite(createSite(`<img src="${url}" />`))
+
+  t.true(localized.entries[0].content.includes(`src="${url}"`))
+  t.deepEqual(await listMediaFiles(mediaDirectory), [])
+})
+
+test('#localizeSite downloads an image whose host repeats the content type header', async (t) => {
+  const mediaDirectory = await createMediaDirectory('feeds-media-dup-png-')
+  const url = 'https://example.com/a.png'
+  const fetchStub = sinon.stub().resolves(
+    new Response(Buffer.from('image-bytes'), {
+      status: 200,
+      headers: [
+        ['content-type', 'image/png'],
+        ['content-type', 'image/png']
+      ]
+    })
+  )
+
+  const store = createMediaStore({ mediaDirectory, fetch: fetchStub as any })
+  const localized = await store.localizeSite(createSite(`<img src="${url}" />`))
+
+  t.deepEqual(await listMediaFiles(mediaDirectory), [`${mediaHash(url)}.png`])
+  t.true(
+    localized.entries[0].content.includes(`src="/media/${mediaHash(url)}.png"`)
+  )
+})
+
+test('#localizeSite keeps the remote url for an empty content type header', async (t) => {
+  const mediaDirectory = await createMediaDirectory('feeds-media-empty-type-')
+  const url = 'https://example.com/photo.png'
+  // Sending the header and naming nothing is still a declaration, and an
+  // unusable one -- unlike a host that omits the header altogether.
+  const fetchStub = sinon
+    .stub()
+    .resolves(imageResponse('<html>blocked</html>', ''))
+
+  const store = createMediaStore({ mediaDirectory, fetch: fetchStub as any })
+  const localized = await store.localizeSite(createSite(`<img src="${url}" />`))
+
+  t.true(localized.entries[0].content.includes(`src="${url}"`))
+  t.deepEqual(await listMediaFiles(mediaDirectory), [])
+})
+
+test('#localizeSite names files from a content type in upper case', async (t) => {
+  const mediaDirectory = await createMediaDirectory('feeds-media-upper-type-')
+  const url = 'https://example.com/a.png'
+  const fetchStub = sinon
+    .stub()
+    .resolves(imageResponse('image-bytes', 'IMAGE/PNG'))
+
+  const store = createMediaStore({ mediaDirectory, fetch: fetchStub as any })
+  const localized = await store.localizeSite(createSite(`<img src="${url}" />`))
+
+  t.deepEqual(await listMediaFiles(mediaDirectory), [`${mediaHash(url)}.png`])
+  t.true(
+    localized.entries[0].content.includes(`src="/media/${mediaHash(url)}.png"`)
+  )
+})
+
+test('#localizeSite names files from a content type padded before its parameters', async (t) => {
+  const mediaDirectory = await createMediaDirectory('feeds-media-padded-type-')
+  const url = 'https://example.com/a.png'
+  const fetchStub = sinon
+    .stub()
+    .resolves(imageResponse('image-bytes', 'image/png ; charset=binary'))
+
+  const store = createMediaStore({ mediaDirectory, fetch: fetchStub as any })
+  const localized = await store.localizeSite(createSite(`<img src="${url}" />`))
+
+  t.deepEqual(await listMediaFiles(mediaDirectory), [`${mediaHash(url)}.png`])
+  t.true(
+    localized.entries[0].content.includes(`src="/media/${mediaHash(url)}.png"`)
+  )
+})
+
+test('#localizeSite keeps the remote url when neither the response nor the url names a type', async (t) => {
+  const mediaDirectory = await createMediaDirectory('feeds-media-nameless-')
+  const url = 'https://example.com/photo'
+  const fetchStub = sinon
+    .stub()
+    .resolves(new Response(Buffer.from('image-bytes'), { status: 200 }))
+
+  const store = createMediaStore({ mediaDirectory, fetch: fetchStub as any })
+  const localized = await store.localizeSite(createSite(`<img src="${url}" />`))
+
+  t.true(localized.entries[0].content.includes(`src="${url}"`))
+  t.deepEqual(await listMediaFiles(mediaDirectory), [])
+})
+
+test('#localizeSite keeps the remote url for a content type naming an object property', async (t) => {
+  const mediaDirectory = await createMediaDirectory('feeds-media-proto-type-')
+  const url = 'https://example.com/photo.png'
+  // The type is feed-controlled, and `constructor` survives lowercasing.
+  const fetchStub = sinon
+    .stub()
+    .resolves(imageResponse('<html>blocked</html>', 'constructor'))
+
+  const store = createMediaStore({ mediaDirectory, fetch: fetchStub as any })
+  const localized = await store.localizeSite(createSite(`<img src="${url}" />`))
+
+  t.true(localized.entries[0].content.includes(`src="${url}"`))
+  t.deepEqual(await listMediaFiles(mediaDirectory), [])
+})
+
 test('#localizeSite names files from the content type when the url has no extension', async (t) => {
   const mediaDirectory = await createMediaDirectory('feeds-media-content-type-')
   const url = 'https://example.com/photo?id=1'

--- a/action/feeds/media.test.ts
+++ b/action/feeds/media.test.ts
@@ -538,37 +538,55 @@ test('#localizeSite aborts the request when it refuses the response', async (t) 
   t.false(responses[0].bodyUsed)
 })
 
-test('#localizeSite does not log a whole hostile content type', async (t) => {
+test('#localizeSite caps a hostile content type in the log', async (t) => {
   const mediaDirectory = await createMediaDirectory('feeds-media-logsize-')
-  // Unique so the captured lines can be filtered to this test: ava runs a
-  // file's tests concurrently, and console.error is shared.
-  const url = 'https://example.com/log-size-photo.png'
+  // One test rather than two: console.error is shared, and ava runs a file's
+  // tests concurrently, so a second stub window would clobber this one.
+  const hostileUrl = 'https://example.com/log-hostile.png'
+  const shortUrl = 'https://example.com/log-short.png'
   // The remote picks this header and the action log is public, so a refusal
   // must not echo 16 KiB of it. On main these responses were downloaded rather
   // than logged at all, so the whole line is new cost.
   const hostile = `a${' '.repeat(16198)}b`
+  // 119 characters, one under the cap: without something near the boundary,
+  // every other fixture here is 36 characters or 16 KiB and the cap has no
+  // edge to test.
+  const borderline = `text/x-${'a'.repeat(112)}`
   const captured: string[] = []
   const restore = console.error
   console.error = (message: string) => void captured.push(message)
   try {
     const fetchStub = sinon
       .stub()
-      .resolves(imageResponse('<html>blocked</html>', hostile))
+      .callsFake(async (input: string) =>
+        imageResponse(
+          '<html>blocked</html>',
+          input === hostileUrl ? hostile : borderline
+        )
+      )
     const store = createMediaStore({ mediaDirectory, fetch: fetchStub as any })
     const localized = await store.localizeSite(
-      createSite(`<img src="${url}" />`)
+      createSite(`<img src="${hostileUrl}" /><img src="${shortUrl}" />`)
     )
-    t.true(localized.entries[0].content.includes(`src="${url}"`))
+    t.true(localized.entries[0].content.includes(`src="${hostileUrl}"`))
   } finally {
     console.error = restore
   }
 
-  const logged = captured.filter((line) => line.includes(url))
-  t.is(logged.length, 1)
-  t.true(logged[0].length < 300, `logged ${logged[0].length} characters`)
+  const forHostile = captured.filter((line) => line.includes(hostileUrl))
+  t.is(forHostile.length, 1)
+  t.true(
+    forHostile[0].length < 300,
+    `logged ${forHostile[0].length} characters`
+  )
   // Still recognisable as the header it refused, and honest about the cut.
-  t.true(logged[0].includes('Unsupported media type "a   '))
-  t.true(logged[0].includes('(16200 chars)'))
+  t.true(forHostile[0].includes('Unsupported media type "a   '))
+  t.true(forHostile[0].includes('(16200 chars)'))
+
+  const forShort = captured.filter((line) => line.includes(shortUrl))
+  t.is(forShort.length, 1)
+  t.true(forShort[0].includes(`"${borderline}"`), 'one under the cap, uncut')
+  t.false(forShort[0].includes('chars)'))
 })
 
 test('#localizeSite leaves the request alone when it accepts the response', async (t) => {

--- a/action/feeds/media.test.ts
+++ b/action/feeds/media.test.ts
@@ -538,6 +538,39 @@ test('#localizeSite aborts the request when it refuses the response', async (t) 
   t.false(responses[0].bodyUsed)
 })
 
+test('#localizeSite does not log a whole hostile content type', async (t) => {
+  const mediaDirectory = await createMediaDirectory('feeds-media-logsize-')
+  // Unique so the captured lines can be filtered to this test: ava runs a
+  // file's tests concurrently, and console.error is shared.
+  const url = 'https://example.com/log-size-photo.png'
+  // The remote picks this header and the action log is public, so a refusal
+  // must not echo 16 KiB of it. On main these responses were downloaded rather
+  // than logged at all, so the whole line is new cost.
+  const hostile = `a${' '.repeat(16198)}b`
+  const captured: string[] = []
+  const restore = console.error
+  console.error = (message: string) => void captured.push(message)
+  try {
+    const fetchStub = sinon
+      .stub()
+      .resolves(imageResponse('<html>blocked</html>', hostile))
+    const store = createMediaStore({ mediaDirectory, fetch: fetchStub as any })
+    const localized = await store.localizeSite(
+      createSite(`<img src="${url}" />`)
+    )
+    t.true(localized.entries[0].content.includes(`src="${url}"`))
+  } finally {
+    console.error = restore
+  }
+
+  const logged = captured.filter((line) => line.includes(url))
+  t.is(logged.length, 1)
+  t.true(logged[0].length < 300, `logged ${logged[0].length} characters`)
+  // Still recognisable as the header it refused, and honest about the cut.
+  t.true(logged[0].includes('Unsupported media type "a   '))
+  t.true(logged[0].includes('(16200 chars)'))
+})
+
 test('#localizeSite leaves the request alone when it accepts the response', async (t) => {
   const mediaDirectory = await createMediaDirectory('feeds-media-noabort-')
   const signals: AbortSignal[] = []

--- a/action/feeds/media.ts
+++ b/action/feeds/media.ts
@@ -54,13 +54,31 @@ function createMediaHash(input: string) {
   return crypto.createHash('sha256').update(input).digest('hex')
 }
 
-// Only the whitespace the spec strips. String.trim would also take U+00A0 and
-// the other Unicode spaces, laundering a value the reader's browser refuses
-// into a clean type here.
-const HTTP_WHITESPACE = /^[\t\n\r ]+|[\t\n\r ]+$/g
+const HTTP_WHITESPACE = new Set(['\t', '\n', '\r', ' '])
+
+/**
+ * Strips only the whitespace the spec strips. String.trim would also take
+ * U+00A0 and the other Unicode spaces, laundering a value the reader's browser
+ * refuses into a clean type here.
+ *
+ * Scanned rather than matched with /[\t\n\r ]+$/, which is quadratic on an
+ * interior run: the engine has to try the trailing alternative at every
+ * position inside it. A 16 KiB header of one long run -- well inside Node's
+ * default maxHeaderSize -- costs 137ms of blocked event loop per refusal that
+ * way, and a feed's image host picks the header.
+ */
+function stripHttpWhitespace(value: string) {
+  let start = 0
+  let end = value.length
+  while (start < end && HTTP_WHITESPACE.has(value[start])) start++
+  while (end > start && HTTP_WHITESPACE.has(value[end - 1])) end--
+  return value.slice(start, end)
+}
+
 // What "parses as a media type" comes to: a type and a subtype, each a
-// non-empty run of HTTP token characters. Anchored and unnested, so it cannot
-// backtrack on a long header.
+// non-empty run of HTTP token characters. The candidate is lowercased before
+// this runs, so the class needs no A-Z. Anchored and unnested, so a long
+// header costs one linear pass rather than exponential backtracking.
 const MEDIA_TYPE = /^[!#$%&'*+\-.^_`|~0-9a-z]+\/[!#$%&'*+\-.^_`|~0-9a-z]+$/
 
 /**
@@ -106,17 +124,15 @@ export function extensionFromContentType(contentType?: string | null) {
   // judge the body by a header the reader's browser ignores.
   let essence = ''
   for (const value of splitHeaderValue(contentType)) {
-    const candidate = value
-      .split(';')[0]
-      .replace(HTTP_WHITESPACE, '')
-      .toLowerCase()
+    const candidate = stripHttpWhitespace(value.split(';')[0]).toLowerCase()
     // Fetch skips a value it cannot parse and any */* rather than letting
     // either be the answer, so junk a proxy appended cannot erase a real type.
     //
     // Requiring a media type here is also what keeps `constructor` and
     // `__proto__` -- the only Object.prototype keys that survive lowercasing --
     // away from the lookup below, which would otherwise fall through to the
-    // prototype and hand normalizeImageExtension a function to trim.
+    // prototype and hand normalizeImageExtension something with no trim to
+    // call: Object for constructor, Object.prototype for __proto__.
     if (!MEDIA_TYPE.test(candidate) || candidate === '*/*') continue
     essence = candidate
   }

--- a/action/feeds/media.ts
+++ b/action/feeds/media.ts
@@ -54,13 +54,23 @@ function createMediaHash(input: string) {
   return crypto.createHash('sha256').update(input).digest('hex')
 }
 
+/**
+ * The type the server declared, stripped of its parameters, or null when it
+ * declared none. Separate from extensionFromContentType because the two nulls
+ * mean opposite things to downloadMedia: silence hands the decision to the URL,
+ * while a type outside the map refuses the download outright.
+ */
+function declaredMediaType(contentType?: string | null) {
+  return contentType?.split(';')[0].trim().toLowerCase() || null
+}
+
 export function extensionFromContentType(contentType?: string | null) {
-  if (!contentType) return null
-  const normalizedType = contentType.split(';')[0].trim().toLowerCase()
+  const declaredType = declaredMediaType(contentType)
+  if (!declaredType) return null
   // Routed through images.ts rather than returned straight from the map, so an
   // entry added here that is not downloadable -- svg above all -- becomes a
   // refused download instead of a file served from our own origin.
-  return normalizeImageExtension(CONTENT_TYPE_EXTENSIONS[normalizedType])
+  return normalizeImageExtension(CONTENT_TYPE_EXTENSIONS[declaredType])
 }
 
 export function extensionFromUrl(url: string) {
@@ -263,14 +273,24 @@ export function createMediaStore({
         throw new Error(`Unexpected response status ${response.status}`)
       }
 
-      const contentTypeExtension = extensionFromContentType(
+      const declaredType = declaredMediaType(
         response.headers.get('content-type')
       )
+      const contentTypeExtension = extensionFromContentType(declaredType)
+      // A server that names a type is taken at its word, and the URL extension
+      // does not get to overrule it. Otherwise a text/html or image/svg+xml
+      // body answering a .png url is written to public/media on the strength of
+      // the url alone, and since rewriteLocalizedUrls sends href and cite to the
+      // local copy too, those bytes become a one-click same-origin navigation
+      // under link text the feed chose. Silence still falls back to the url,
+      // which is what hosts that set no type header rely on.
+      if (declaredType && !contentTypeExtension) {
+        throw new Error(`Unsupported media type ${declaredType}`)
+      }
+
       const extension = contentTypeExtension || urlExtension
       if (!extension) {
-        throw new Error(
-          `Unsupported media type ${response.headers.get('content-type')}`
-        )
+        throw new Error('No media type declared and no image extension in url')
       }
 
       const buffer = await readBodyWithinLimit(response, controller)

--- a/action/feeds/media.ts
+++ b/action/feeds/media.ts
@@ -63,9 +63,10 @@ const HTTP_WHITESPACE = new Set(['\t', '\n', '\r', ' '])
  *
  * Scanned rather than matched with /[\t\n\r ]+$/, which is quadratic on an
  * interior run: the engine has to try the trailing alternative at every
- * position inside it. A 16 KiB header of one long run -- well inside Node's
- * default maxHeaderSize -- costs 137ms of blocked event loop per refusal that
- * way, and a feed's image host picks the header.
+ * position inside it. A header of one run just under Node's default
+ * maxHeaderSize -- 16 KiB, and it caps the whole header block -- costs 137ms
+ * of blocked event loop per refusal that way, and a feed's image host picks
+ * the header.
  */
 function stripHttpWhitespace(value: string) {
   let start = 0

--- a/action/feeds/media.ts
+++ b/action/feeds/media.ts
@@ -54,13 +54,23 @@ function createMediaHash(input: string) {
   return crypto.createHash('sha256').update(input).digest('hex')
 }
 
+// Only the whitespace the spec strips. String.trim would also take U+00A0 and
+// the other Unicode spaces, laundering a value the reader's browser refuses
+// into a clean type here.
+const HTTP_WHITESPACE = /^[\t\n\r ]+|[\t\n\r ]+$/g
+// What "parses as a media type" comes to: a type and a subtype, each a
+// non-empty run of HTTP token characters. Anchored and unnested, so it cannot
+// backtrack on a long header.
+const MEDIA_TYPE = /^[!#$%&'*+\-.^_`|~0-9a-z]+\/[!#$%&'*+\-.^_`|~0-9a-z]+$/
+
 /**
  * Splits a header value on the commas that separate repeated headers, which is
- * how headers.get returns them. Commas inside a quoted parameter do not count,
- * the same rule Fetch splits by: on a bare split, an unterminated quote in
- * `text/html;x="a,image/png` hides a type the reader's browser never sees.
+ * how headers.get returns them. A double quote opens a run that lasts to its
+ * closing quote or to the end of the value, and commas inside that run are not
+ * separators -- the same rule Fetch splits by. A bare split on
+ * `text/html;x="a,image/png` would answer image/png, a type no browser sees.
  */
-function splitHeaderValues(value: string) {
+function splitHeaderValue(value: string) {
   const values: string[] = []
   let current = ''
   let quoted = false
@@ -68,6 +78,8 @@ function splitHeaderValues(value: string) {
     const character = value[index]
     if (quoted) {
       current += character
+      // An escaped quote must not close the run, or the comma after it splits
+      // a value Fetch keeps whole.
       if (character === '\\' && index + 1 < value.length)
         current += value[++index]
       else if (character === '"') quoted = false
@@ -93,18 +105,21 @@ export function extensionFromContentType(contentType?: string | null) {
   // resolves them to the last one it can parse -- so reading the first would
   // judge the body by a header the reader's browser ignores.
   let essence = ''
-  for (const value of splitHeaderValues(contentType)) {
-    const candidate = value.split(';')[0].trim().toLowerCase()
-    // Fetch skips a value it cannot parse and any */*, rather than letting
-    // either be the answer, so neither a trailing comma nor a junk repeat can
-    // erase the real type.
-    if (!candidate.includes('/') || candidate === '*/*') continue
+  for (const value of splitHeaderValue(contentType)) {
+    const candidate = value
+      .split(';')[0]
+      .replace(HTTP_WHITESPACE, '')
+      .toLowerCase()
+    // Fetch skips a value it cannot parse and any */* rather than letting
+    // either be the answer, so junk a proxy appended cannot erase a real type.
+    //
+    // Requiring a media type here is also what keeps `constructor` and
+    // `__proto__` -- the only Object.prototype keys that survive lowercasing --
+    // away from the lookup below, which would otherwise fall through to the
+    // prototype and hand normalizeImageExtension a function to trim.
+    if (!MEDIA_TYPE.test(candidate) || candidate === '*/*') continue
     essence = candidate
   }
-  // Requiring the slash is what keeps a response naming `constructor` off the
-  // lookup below: no Object.prototype key contains one, and `constructor`
-  // otherwise survives lowercasing where toString and valueOf do not.
-  //
   // Routed through images.ts rather than returned straight from the map, so an
   // entry added here that is not downloadable -- svg above all -- becomes a
   // refused download instead of a file served from our own origin.
@@ -342,10 +357,10 @@ export function createMediaStore({
       await fs.writeFile(path.join(mediaDirectory, fileName), buffer)
       return `${LOCAL_MEDIA_PATH}/${fileName}`
     } catch (error: any) {
-      // The early throws -- a bad status, a refused type, no usable extension
-      // -- all leave the body unread, and an unread body holds its socket
-      // until the remote end drops it. clearTimeout below has already retired
-      // the download timeout by then, so nothing else would ever release it.
+      // Every throw that lands before readBodyWithinLimit starts streaming
+      // leaves the body unread, and an unread body holds its socket until the
+      // remote end drops it. The finally below clears the download timeout on
+      // the way out, so that timer will never fire and release it for us.
       controller.abort()
       console.error(`Fail to download media ${url}: ${error.message}`)
       return null

--- a/action/feeds/media.ts
+++ b/action/feeds/media.ts
@@ -118,6 +118,15 @@ function splitHeaderValue(value: string) {
   return values
 }
 
+const LOGGED_TYPE_LIMIT = 120
+
+/** Enough of a refused type to recognise it, without logging a 16 KiB header. */
+function summarizeType(contentType: string) {
+  return contentType.length > LOGGED_TYPE_LIMIT
+    ? `${contentType.slice(0, LOGGED_TYPE_LIMIT)}... (${contentType.length} chars)`
+    : contentType
+}
+
 export function extensionFromContentType(contentType?: string | null) {
   if (!contentType) return null
   // headers.get joins repeated Content-Type headers, and the fetch spec
@@ -354,7 +363,12 @@ export function createMediaStore({
       const contentType = response.headers.get('content-type')
       const contentTypeExtension = extensionFromContentType(contentType)
       if (contentType !== null && !contentTypeExtension) {
-        throw new Error(`Unsupported media type "${contentType}"`)
+        // Truncated because the remote picks this header and the log is public:
+        // a 16 KiB one costs a 16 KiB line per refused URL, and on main these
+        // responses were downloaded rather than logged at all.
+        throw new Error(
+          `Unsupported media type "${summarizeType(contentType)}"`
+        )
       }
 
       // Anything reaching here without a content type extension had no header

--- a/action/feeds/media.ts
+++ b/action/feeds/media.ts
@@ -54,23 +54,61 @@ function createMediaHash(input: string) {
   return crypto.createHash('sha256').update(input).digest('hex')
 }
 
+/**
+ * Splits a header value on the commas that separate repeated headers, which is
+ * how headers.get returns them. Commas inside a quoted parameter do not count,
+ * the same rule Fetch splits by: on a bare split, an unterminated quote in
+ * `text/html;x="a,image/png` hides a type the reader's browser never sees.
+ */
+function splitHeaderValues(value: string) {
+  const values: string[] = []
+  let current = ''
+  let quoted = false
+  for (let index = 0; index < value.length; index++) {
+    const character = value[index]
+    if (quoted) {
+      current += character
+      if (character === '\\' && index + 1 < value.length)
+        current += value[++index]
+      else if (character === '"') quoted = false
+      continue
+    }
+    if (character === '"') {
+      quoted = true
+      current += character
+    } else if (character === ',') {
+      values.push(current)
+      current = ''
+    } else {
+      current += character
+    }
+  }
+  values.push(current)
+  return values
+}
+
 export function extensionFromContentType(contentType?: string | null) {
   if (!contentType) return null
-  // headers.get joins repeated Content-Type headers with ", " and the fetch
-  // spec reads the last of them, as every browser does -- so judging a body by
-  // the first would judge it by a header the reader's own browser ignores.
-  const declaredTypes = contentType.split(',')
-  const declaredType = declaredTypes[declaredTypes.length - 1]
-    .split(';')[0]
-    .trim()
-    .toLowerCase()
-  // hasOwn because the type is feed-controlled and `constructor` survives
-  // lowercasing, so a plain lookup hands normalizeImageExtension a function.
-  if (!Object.hasOwn(CONTENT_TYPE_EXTENSIONS, declaredType)) return null
+  // headers.get joins repeated Content-Type headers, and the fetch spec
+  // resolves them to the last one it can parse -- so reading the first would
+  // judge the body by a header the reader's browser ignores.
+  let essence = ''
+  for (const value of splitHeaderValues(contentType)) {
+    const candidate = value.split(';')[0].trim().toLowerCase()
+    // Fetch skips a value it cannot parse and any */*, rather than letting
+    // either be the answer, so neither a trailing comma nor a junk repeat can
+    // erase the real type.
+    if (!candidate.includes('/') || candidate === '*/*') continue
+    essence = candidate
+  }
+  // Requiring the slash is what keeps a response naming `constructor` off the
+  // lookup below: no Object.prototype key contains one, and `constructor`
+  // otherwise survives lowercasing where toString and valueOf do not.
+  //
   // Routed through images.ts rather than returned straight from the map, so an
   // entry added here that is not downloadable -- svg above all -- becomes a
   // refused download instead of a file served from our own origin.
-  return normalizeImageExtension(CONTENT_TYPE_EXTENSIONS[declaredType])
+  return normalizeImageExtension(CONTENT_TYPE_EXTENSIONS[essence])
 }
 
 export function extensionFromUrl(url: string) {
@@ -284,11 +322,11 @@ export function createMediaStore({
       const contentType = response.headers.get('content-type')
       const contentTypeExtension = extensionFromContentType(contentType)
       if (contentType !== null && !contentTypeExtension) {
-        throw new Error(`Unsupported media type ${JSON.stringify(contentType)}`)
+        throw new Error(`Unsupported media type "${contentType}"`)
       }
 
-      // Falling back to the URL is all there is to go on when a host sets no
-      // type header at all.
+      // Anything reaching here without a content type extension had no header
+      // at all, so the URL is the only thing left naming a type.
       const extension = contentTypeExtension || urlExtension
       if (!extension) {
         throw new Error(
@@ -304,9 +342,10 @@ export function createMediaStore({
       await fs.writeFile(path.join(mediaDirectory, fileName), buffer)
       return `${LOCAL_MEDIA_PATH}/${fileName}`
     } catch (error: any) {
-      // Every throw above can leave the body unread, and an unread body holds
-      // its socket until the request times out. Aborting here covers all of
-      // them at once rather than cancelling at each throw site.
+      // The early throws -- a bad status, a refused type, no usable extension
+      // -- all leave the body unread, and an unread body holds its socket
+      // until the remote end drops it. clearTimeout below has already retired
+      // the download timeout by then, so nothing else would ever release it.
       controller.abort()
       console.error(`Fail to download media ${url}: ${error.message}`)
       return null

--- a/action/feeds/media.ts
+++ b/action/feeds/media.ts
@@ -54,19 +54,19 @@ function createMediaHash(input: string) {
   return crypto.createHash('sha256').update(input).digest('hex')
 }
 
-/**
- * The type the server declared, stripped of its parameters, or null when it
- * declared none. Separate from extensionFromContentType because the two nulls
- * mean opposite things to downloadMedia: silence hands the decision to the URL,
- * while a type outside the map refuses the download outright.
- */
-function declaredMediaType(contentType?: string | null) {
-  return contentType?.split(';')[0].trim().toLowerCase() || null
-}
-
 export function extensionFromContentType(contentType?: string | null) {
-  const declaredType = declaredMediaType(contentType)
-  if (!declaredType) return null
+  if (!contentType) return null
+  // headers.get joins repeated Content-Type headers with ", " and the fetch
+  // spec reads the last of them, as every browser does -- so judging a body by
+  // the first would judge it by a header the reader's own browser ignores.
+  const declaredTypes = contentType.split(',')
+  const declaredType = declaredTypes[declaredTypes.length - 1]
+    .split(';')[0]
+    .trim()
+    .toLowerCase()
+  // hasOwn because the type is feed-controlled and `constructor` survives
+  // lowercasing, so a plain lookup hands normalizeImageExtension a function.
+  if (!Object.hasOwn(CONTENT_TYPE_EXTENSIONS, declaredType)) return null
   // Routed through images.ts rather than returned straight from the map, so an
   // entry added here that is not downloadable -- svg above all -- becomes a
   // refused download instead of a file served from our own origin.
@@ -273,24 +273,27 @@ export function createMediaStore({
         throw new Error(`Unexpected response status ${response.status}`)
       }
 
-      const declaredType = declaredMediaType(
-        response.headers.get('content-type')
-      )
-      const contentTypeExtension = extensionFromContentType(declaredType)
-      // A server that names a type is taken at its word, and the URL extension
-      // does not get to overrule it. Otherwise a text/html or image/svg+xml
-      // body answering a .png url is written to public/media on the strength of
-      // the url alone, and since rewriteLocalizedUrls sends href and cite to the
-      // local copy too, those bytes become a one-click same-origin navigation
-      // under link text the feed chose. Silence still falls back to the url,
-      // which is what hosts that set no type header rely on.
-      if (declaredType && !contentTypeExtension) {
-        throw new Error(`Unsupported media type ${declaredType}`)
+      // A server that sent the header at all is taken at its word, and the URL
+      // extension does not get to overrule it. Otherwise a text/html or
+      // image/svg+xml body answering a .png URL is written to public/media on
+      // the strength of the URL alone, and since rewriteLocalizedUrls sends a
+      // lightbox href to the local copy too, those bytes become a one-click
+      // same-origin navigation under link text the feed chose. headers.get
+      // returns null only for a header that is absent, so an empty or
+      // parameters-only one is refused rather than mistaken for silence.
+      const contentType = response.headers.get('content-type')
+      const contentTypeExtension = extensionFromContentType(contentType)
+      if (contentType !== null && !contentTypeExtension) {
+        throw new Error(`Unsupported media type ${JSON.stringify(contentType)}`)
       }
 
+      // Falling back to the URL is all there is to go on when a host sets no
+      // type header at all.
       const extension = contentTypeExtension || urlExtension
       if (!extension) {
-        throw new Error('No media type declared and no image extension in url')
+        throw new Error(
+          'Media response declares no type and its URL names no image extension'
+        )
       }
 
       const buffer = await readBodyWithinLimit(response, controller)
@@ -301,6 +304,10 @@ export function createMediaStore({
       await fs.writeFile(path.join(mediaDirectory, fileName), buffer)
       return `${LOCAL_MEDIA_PATH}/${fileName}`
     } catch (error: any) {
+      // Every throw above can leave the body unread, and an unread body holds
+      // its socket until the request times out. Aborting here covers all of
+      // them at once rather than cancelling at each throw site.
+      controller.abort()
       console.error(`Fail to download media ${url}: ${error.message}`)
       return null
     } finally {


### PR DESCRIPTION
`downloadMedia` took its extension from the content type when it recognised one and fell back to the URL otherwise:

```ts
const contentTypeExtension = extensionFromContentType(response.headers.get('content-type'))
const extension = contentTypeExtension || urlExtension
```

`extensionFromContentType` returns `null` for anything outside `CONTENT_TYPE_EXTENSIONS`, so a response declaring `text/html` or `image/svg+xml` from a `.png` URL was written to `public/media/<sha256>.png` with its body intact. The bytes were never inspected.

Raised across review rounds 2, 5 and 6 of #912. Two things made it worth doing now:

1. #912 made `rewriteLocalizedUrls` rewrite `href`/`cite` as well as `src`, so a feed's link to an image the store downloaded becomes a same-origin `/media/<hash>.<ext>` URL. Those bytes went from being loadable only as an `<img>` subresource to being a one-click navigation with attacker-chosen link text.
2. The SVG exclusion `action/feeds/images.ts` and `action/feeds/media.ts` both rely on — "a localized file is navigable on the published origin, and a feed could otherwise plant a scripted SVG there" — was enforced by *extension only*.

## The change

**A declared type outside `CONTENT_TYPE_EXTENSIONS` is now fatal.** The download fails the way a 404 does, so the URL keeps pointing at its origin and is hotlinked as it was before #911 — no file written, nothing rewritten. A response with no `content-type` header at all is unaffected and still takes its extension from the URL.

Getting "declared type" right turned out to be the whole of the work. `headers.get` returns *all* `Content-Type` headers joined with `", "`, so reading one type out of that string is a parsing problem, and every shortcut through it is exploitable:

| the header | naive reading | what a browser reads |
|---|---|---|
| `image/png; charset=binary, text/html` | `image/png` — **accepted** | `text/html` |
| `text/html;x="a,image/png` | `image/png` — **accepted** | `text/html` |
| `image/png ` | `image/png` — **accepted** | nothing; refused |
| `image/png; name="a,b"` | `b"` — refused | `image/png` |
| `image/png, image/png` | `image/png, image/png` — refused | `image/png` |

So `extensionFromContentType` now follows the fetch spec's "extract a MIME type" rather than approximating it: split on commas **outside quoted runs**, strip **only** HTTP whitespace (`\t \n \r` and space — `String.trim` also takes U+00A0, which the spec does not), and keep the **last value that parses** as a type/subtype token pair, skipping empties and `*/*`.

Two consequences worth naming:

- Requiring a parseable media type is also what keeps `constructor` and `__proto__` — the only `Object.prototype` keys that survive lowercasing — away from the map lookup, where they would otherwise return a function and throw.
- Both hot paths are scanned, not matched. `/[\t\n\r ]+$/` is quadratic on an interior whitespace run: a 16 KiB header, just under Node's default `maxHeaderSize`, cost 137 ms of blocked event loop per refusal, and a feed's image host picks the header. The regex that remains is anchored and unnested, so a long token run costs one linear pass.

`controller.abort()` also moves into the `catch`. The early throws leave the response body unread, and an unread body holds its socket until the remote end drops it — `clearTimeout` in the `finally` has already retired the download timeout, so nothing else would release it. Over 40 refused downloads of 512 KB `text/html` bodies, open connections drop from 40 to 1–2 (per-host concurrency is 2). That covers the pre-existing `!response.ok` path too.

## Conformance

`extensionFromContentType` is fuzzed differentially against undici's own implementation of "extract a MIME type" (`Response.blob().type`): **28,280 distinct headers, zero divergences in either direction.**

Two exclusions, stated because they are what the number does not cover:

- Headers carrying a code point outside U+0020–U+007E, because `Blob.type` blanks those. The one that could change the verdict — U+00A0, which `String.trim` would have stripped and the spec would not — is asserted by name in the tests. For the rest the oracle is the imprecise one: `image/png; x=é` blanks under `Blob.type` while both this parser and a real browser answer `image/png`.
- Headers with a U+0060 backtick in the type or subtype, because **the oracle is wrong there**: undici's `HTTP_TOKEN_CODEPOINTS` omits the backtick where Fetch includes U+005E–U+007A. On `` image/png, image/p`ng `` undici answers `image/png` and this parser answers `null`, and this parser is correct. The backtick is the only such disagreement across the printable range.

## Measured before choosing strictness

`feeds.opml` cannot answer this — 2 subscriptions, 118 media URLs, all `image/png|jpeg|gif`, zero change. So the measurement ran over a 257-feed corpus, reusing `loadFeed` → `collectDownloadableMediaUrls` so the URL set matches production exactly.

**212 feeds parsed · 13,761 unique media URLs · 13,333 downloading successfully today.**

| Under this change | Count | Share |
|---|---|---|
| Still download | 13,312 | 99.84% |
| **Newly refused** | **21** | **0.16%** |
| — `application/octet-stream` (all `storage.googleapis.com`, all `.webp`, all real images) | 19 | |
| — `text/html` at HTTP 200 | 2 | |

Those two rows partition the 21. Separately, and wholly inside the "still download" row: 6 URLs came back with no `content-type` header at all and are unaffected.

Re-run through the shipped code on a purposive 277-URL sample — all 21 predicted refusals, all 6 untyped URLs, and 250 controls — after each round of review fixes: 21 refused, 256 localized, zero deviation, zero markup bodies written.

**Both `text/html` hits are the bug, in the wild.** `http://www.codeproject.com/KB/debug/WinDBGAndSOS/SOSHelp.PNG` returns 200 + `Content-Type: text/html` + `<!DOCTYPE html><html><head><script>window.onload=function(){window.location.href="/lander"}</script></head></html>`. The other is `http://www.classicacorn.freeuk.com/8bit_focus/logo/logo_8.jpg`, a soft-404 page.

```
BEFORE  logo_8.jpg   -> LOCALIZED, wrote <sha>.jpg containing "<!DOCTYPE html>..."
BEFORE  SOSHelp.PNG  -> LOCALIZED, wrote <sha>.png containing "<script>window.location.href=..."
AFTER   both         -> kept remote, nothing written
```

**Accepting any `image/*` was measured and rejected as dead code.** No `image/*` subtype outside the map downloads successfully today. The only one in the corpus is `image/apng` (2 URLs, `planetscale.com/.../visualization{1,2}.apng`), refused because `image/apng` is absent from `CONTENT_TYPE_EXTENSIONS` — the map is the only door in, and `DOWNLOADABLE_IMAGE_EXTENSIONS` only filters what it returns. `.apng` is absent from that set too, which is what makes their URLs unusable as a fallback.

Real-world sloppiness is `application/octet-stream`, which stays refused deliberately: it means "I will not tell you what this is", and allowing it re-opens the hole an attacker walks through by choosing their own header.

## Containment — this is hardening, not an emergency

On GitHub Pages `.png` is served as `image/png` and browsers do not sniff a declared image type into HTML, so the realistic outcome today is a broken image or a drive-by download, not script execution.

## Known limitations

Both out of scope here, both belonging with the magic-byte sniff filed off #912:

- `resolveExistingMediaFile` short-circuits before the fetch and `restorePublishedMedia` restores `public/media` each run, so files already written under the old behaviour are never re-checked. The two HTML files above would persist on an existing deployment.
- **A server that sends no `Content-Type` at all bypasses the gate entirely** and still gets its bytes named from the URL extension. The fallback is deliberate — 6 corpus URLs depend on it — but it means the gate raises the cost of planting mismatched bytes rather than eliminating it. The sharpest version is a `.png` URL redirecting to an endpoint that also omits the header: the type is read from the final response, so a redirect ending in `Content-Type: text/html` is refused normally, but `urlExtension` comes from the original URL either way — and this is also the one way the `isSvgUrl` pre-check is bypassed, since it too reads the requested URL. Verified: a `.png` that redirects to an untyped `.svg` is written as `<hash>.png`. Bounded, because a browser decodes it under `.png` as an image rather than as markup.

## Tests

Twenty-three: fourteen in `action/feeds/media.test.ts`, eight in a new `action/feeds/media#extensionFromContentType.test.ts`, one in `action/feeds/images.test.ts`.

The store tests sit beside the existing `#localizeSite keeps the remote url for non image responses` and cover the gate through the real `createMediaStore`: `text/html` and `image/svg+xml` from a `.png` URL, both duplicate-header cases, an empty header, a content type naming an object property, upper case, space before the parameters, a header-less response that still names the file from the URL, the branch where neither the response nor the URL names a type, a content type that outranks a conflicting URL extension, the abort firing on a refusal but not on a success, and a cap on how much of a refused type reaches the log.

The parser suite drives `extensionFromContentType` directly, over the header shapes worth enumerating one by one — repeated headers, values the spec passes over, commas and escapes inside quoted runs, quotes that open a value rather than a parameter, whitespace the spec does not strip, and two separate linear-time axes. It follows the existing `parsers#topic.test.ts` convention; `images.test.ts` keeps only what belongs to it, that the SVG exclusion holds under a header built to slip one past the parser.

Every one was checked by mutation — each dies under a change to the line it claims to guard.

## Review

Ten rounds of sub-agent review, 102 findings, all addressed or consciously declined with reasoning on the thread. The implementation has been unchanged since round 4; rounds 5–10 were tests and comments. Two independent correctness passes came back clean (~4.8M and ~25M differential inputs, the IANA registry, raw sockets, and an adversarial feed end to end), and the final round drove the whole action against a live server — 44/44, including a second run that reused everything on disk and an upgrade path that leaves already-published media alone.

The last round also swapped technique, asking which input axes the fixtures *cannot* produce rather than which mutations survive. That found the token class was pinned on only one side of the slash: every type half in 47 assertions was one of five literals, so narrowing the left class passed all 51 tests while turning `image/png, x-image/x-png` into a download.

Four of the findings were holes in an earlier round's fix, which is the part worth knowing about if you are reading the commits in order: the round-1 duplicate-header fix re-opened the bypass it closed, and three test assertions were added to unshadow a case while remaining shadowed themselves.

`npx tsc --noEmit` is clean, as is prettier over all four touched files:

```bash
npx prettier --check action/feeds/media.ts action/feeds/media.test.ts action/feeds/images.test.ts 'action/feeds/media#extensionFromContentType.test.ts'
```

(Repo-wide, `prettier --check .` reports 7 pre-existing files, none of them touched here.) The full suite passes except `action/repository.test.ts`, which asserts the directory basename is `feeds` and gets the worktree name — pre-existing, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
