### PR TITLE
Bake Hacker News discussions into entries at build time

### DIFF
--- a/action/feeds/hackernews.test.ts
+++ b/action/feeds/hackernews.test.ts
@@ -5,7 +5,7 @@ import {
   enrichSiteWithHackerNewsComments,
   hackerNewsItemId
 } from './hackernews'
-import { rewriteLocalizedUrls } from './media'
+import { collectDownloadableMediaUrls, rewriteLocalizedUrls } from './media'
 import type { Site } from './parsers'
 
 const HN_ITEM_LINK = 'https://news.ycombinator.com/item?id=40001'
@@ -62,6 +62,13 @@ test('#hackerNewsItemId detects HN item links', (t) => {
   t.is(hackerNewsItemId('not a url'), null)
   t.is(hackerNewsItemId(undefined), null)
   t.is(hackerNewsItemId(''), null)
+  // An empty id must come back null, or it blocks the entry-link fallback.
+  t.is(hackerNewsItemId('https://news.ycombinator.com/item?id='), null)
+  t.is(hackerNewsItemId('https://news.ycombinator.com/item?id=1a'), null)
+  t.is(
+    hackerNewsItemId('https://news.ycombinator.com/item?id=1/../../search'),
+    null
+  )
 })
 
 test('#enrichSiteWithHackerNewsComments leaves non-HN entries alone', async (t) => {
@@ -89,6 +96,24 @@ test('#enrichSiteWithHackerNewsComments falls back to an entry link that is the 
   ).entries
   t.is(fetchStub.callCount, 1)
   t.true(entry.content.includes('<p>via entry link</p>'))
+})
+
+test('#enrichSiteWithHackerNewsComments falls back when the comments link is not a HN item', async (t) => {
+  // A non-HN comments URL must not block the entry-link fallback: this is the
+  // case that separates ?? from a truthiness bug.
+  const fetchStub = sinon.stub().resolves(
+    algoliaResponse({
+      id: 40001,
+      children: [comment(40002, '<p>still enriched</p>')]
+    })
+  )
+  const site = createSite('https://example.com/discussion/1')
+  site.entries[0].link = HN_ITEM_LINK
+  const [entry] = (
+    await enrichSiteWithHackerNewsComments(site, fetchStub as any)
+  ).entries
+  t.is(fetchStub.callCount, 1)
+  t.true(entry.content.includes('<p>still enriched</p>'))
 })
 
 test('#enrichSiteWithHackerNewsComments appends the thread after the feed content', async (t) => {
@@ -315,6 +340,169 @@ test('#enrichSiteWithHackerNewsComments keeps the original content for an empty 
   const fetchStub = sinon
     .stub()
     .resolves(algoliaResponse({ id: 40001, children: [] }))
+  const site = createSite(HN_ITEM_LINK)
+  const [entry] = (
+    await enrichSiteWithHackerNewsComments(site, fetchStub as any)
+  ).entries
+  t.is(entry.content, site.entries[0].content)
+})
+
+test('#enrichSiteWithHackerNewsComments renders live replies of a dead comment', async (t) => {
+  // HN keeps replies under a [deleted] marker; dropping the dead comment must
+  // not vanish them.
+  const fetchStub = sinon.stub().resolves(
+    algoliaResponse({
+      id: 40001,
+      children: [
+        {
+          id: 40003,
+          author: null,
+          text: null,
+          children: [comment(40004, '<p>reply to a dead comment</p>')]
+        }
+      ]
+    })
+  )
+  const [entry] = (
+    await enrichSiteWithHackerNewsComments(
+      createSite(HN_ITEM_LINK),
+      fetchStub as any
+    )
+  ).entries
+  t.true(entry.content.includes('<p>reply to a dead comment</p>'))
+  t.false(entry.content.includes('user40003'))
+})
+
+test('#enrichSiteWithHackerNewsComments bounds the total comments rendered', async (t) => {
+  // 20 top-level comments with 19 replies each: inside both the top-level and
+  // depth caps, but 400 comments in total -- the budget cuts it at 100.
+  const children = Array.from({ length: 20 }, (_, index) =>
+    comment(
+      41000 + index,
+      `<p>top ${index + 1}</p>`,
+      Array.from({ length: 19 }, (_, reply) =>
+        comment(42000 + index * 100 + reply, `<p>reply ${reply + 1}</p>`)
+      )
+    )
+  )
+  const fetchStub = sinon
+    .stub()
+    .resolves(algoliaResponse({ id: 40001, children }))
+  const [entry] = (
+    await enrichSiteWithHackerNewsComments(
+      createSite(HN_ITEM_LINK),
+      fetchStub as any
+    )
+  ).entries
+
+  t.is(entry.content.match(/class="hn-comment"/g)?.length, 100)
+  t.true(entry.content.includes('More comments on Hacker News'))
+})
+
+test('#enrichSiteWithHackerNewsComments strips images from comment html', async (t) => {
+  // HN renders no images in comments, and an img here would become a download
+  // the media store performs on a URL chosen by an arbitrary commenter.
+  const fetchStub = sinon.stub().resolves(
+    algoliaResponse({
+      id: 40001,
+      children: [
+        comment(
+          40002,
+          '<p>look</p><img src="https://example.com/planted.png" />'
+        )
+      ]
+    })
+  )
+  const [entry] = (
+    await enrichSiteWithHackerNewsComments(
+      createSite(HN_ITEM_LINK),
+      fetchStub as any
+    )
+  ).entries
+  t.false(entry.content.includes('planted.png'))
+  t.deepEqual([...collectDownloadableMediaUrls(entry.content)], [])
+})
+
+test('#enrichSiteWithHackerNewsComments tolerates an invalid comment date', async (t) => {
+  // 1e999 is valid JSON number syntax that parses to Infinity; date-fns format
+  // throws on it, and the throw must not cost the whole thread.
+  const fetchStub = sinon
+    .stub()
+    .resolves(
+      new Response(
+        '{"id":40001,"children":[' +
+          '{"id":40002,"author":"user40002","text":"<p>bad date</p>","created_at_i":1e999,"children":[]},' +
+          '{"id":40003,"author":"user40003","text":"<p>healthy</p>","created_at_i":1700000003,"children":[]}' +
+          ']}',
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      )
+    )
+  const [entry] = (
+    await enrichSiteWithHackerNewsComments(
+      createSite(HN_ITEM_LINK),
+      fetchStub as any
+    )
+  ).entries
+  t.true(entry.content.includes('<p>bad date</p>'))
+  t.true(entry.content.includes('<p>healthy</p>'))
+  // The bad comment renders without a date link, the healthy one keeps its own.
+  t.true(entry.content.includes('user40002</a>'))
+  t.true(
+    entry.content.includes(
+      '<a href="https://news.ycombinator.com/item?id=40003">'
+    )
+  )
+})
+
+test('#enrichSiteWithHackerNewsComments keys the more link on the request id', async (t) => {
+  // A response that drifts from the documented shape must not render
+  // item?id=undefined.
+  const children = Array.from({ length: 25 }, (_, index) =>
+    comment(40100 + index, `<p>comment ${index + 1}</p>`)
+  )
+  const fetchStub = sinon.stub().resolves(algoliaResponse({ children }))
+  const [entry] = (
+    await enrichSiteWithHackerNewsComments(
+      createSite(HN_ITEM_LINK),
+      fetchStub as any
+    )
+  ).entries
+  t.true(
+    entry.content.includes(
+      '<a href="https://news.ycombinator.com/item?id=40001">More comments on Hacker News</a>'
+    )
+  )
+})
+
+test('#enrichSiteWithHackerNewsComments stops enriching after the deadline', async (t) => {
+  const fetchStub = sinon.stub().resolves(
+    algoliaResponse({
+      id: 40001,
+      children: [comment(40002, '<p>first entry</p>')]
+    })
+  )
+  const site = createSite(HN_ITEM_LINK, HN_ITEM_LINK)
+  const now = sinon.stub()
+  // Deadline computed from the first call; the first entry is inside the
+  // budget, the second is past it.
+  now.onCall(0).returns(0)
+  now.onCall(1).returns(1_000)
+  now.onCall(2).returns(120_000)
+  const entries = (
+    await enrichSiteWithHackerNewsComments(site, fetchStub as any, now)
+  ).entries
+  t.is(fetchStub.callCount, 1)
+  t.true(entries[0].content.includes('<p>first entry</p>'))
+  t.is(entries[1].content, site.entries[1].content)
+})
+
+test('#enrichSiteWithHackerNewsComments keeps the original content when the response is too large', async (t) => {
+  const fetchStub = sinon.stub().resolves(
+    new Response(`{"id":40001,"text":"${'x'.repeat(6 * 1024 * 1024)}"}`, {
+      status: 200,
+      headers: { 'content-type': 'application/json' }
+    })
+  )
   const site = createSite(HN_ITEM_LINK)
   const [entry] = (
     await enrichSiteWithHackerNewsComments(site, fetchStub as any)

--- a/action/feeds/hackernews.test.ts
+++ b/action/feeds/hackernews.test.ts
@@ -693,6 +693,113 @@ test('#createHackerNewsEnricher shares one deadline across sites', async (t) => 
   t.is(fetchStub.callCount, 1)
 })
 
+test('#enrichSiteWithHackerNewsComments keeps an earlier truncation when the budget breaks on dead siblings', async (t) => {
+  // T1's subtree hits the depth cap (truncated = true), T2's replies exhaust
+  // the 100-comment budget exactly, and every remaining top-level comment is
+  // dead: the break path must not overwrite the earlier true with the
+  // remainder's false.
+  const deep = comment(40002, '<p>level 1</p>', [
+    comment(40003, '<p>level 2</p>', [
+      comment(40004, '<p>level 3</p>', [comment(40005, '<p>level 4</p>')])
+    ])
+  ])
+  const wide = comment(
+    40010,
+    '<p>wide</p>',
+    Array.from({ length: 96 }, (_, index) =>
+      comment(41000 + index, `<p>reply ${index + 1}</p>`)
+    )
+  )
+  const dead = Array.from({ length: 18 }, (_, index) => ({
+    id: 42000 + index,
+    author: null,
+    text: null,
+    children: []
+  }))
+  const fetchStub = sinon
+    .stub()
+    .resolves(algoliaResponse({ id: 40001, children: [deep, wide, ...dead] }))
+  const [entry] = (
+    await enrichSiteWithHackerNewsComments(
+      createSite(HN_ITEM_LINK),
+      fetchStub as any
+    )
+  ).entries
+  t.is(entry.content.match(/class="hn-comment"/g)?.length, 100)
+  t.true(entry.content.includes('More comments on Hacker News'))
+})
+
+test('#enrichSiteWithHackerNewsComments tolerates malformed nodes', async (t) => {
+  // null entries and a non-array children field are network input like any
+  // other; they must not cost the healthy parts of the thread.
+  const fetchStub = sinon
+    .stub()
+    .resolves(
+      new Response(
+        '{"id":40001,"children":[null,{"id":40002,"author":"user40002","text":"<p>healthy</p>","created_at_i":1700000002,"children":{}}]}',
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      )
+    )
+  const [entry] = (
+    await enrichSiteWithHackerNewsComments(
+      createSite(HN_ITEM_LINK),
+      fetchStub as any
+    )
+  ).entries
+  t.true(entry.content.includes('<p>healthy</p>'))
+})
+
+test('#enrichSiteWithHackerNewsComments normalizes lone surrogates in author names', async (t) => {
+  // JSON.parse produces lone surrogates happily and encodeURIComponent throws
+  // on them; toWellFormed replaces them with U+FFFD first.
+  const fetchStub = sinon.stub().resolves(
+    algoliaResponse({
+      id: 40001,
+      children: [
+        {
+          id: 40002,
+          author: 'bad\ud800name',
+          text: '<p>hi</p>',
+          created_at_i: 1700000002,
+          children: []
+        }
+      ]
+    })
+  )
+  const [entry] = (
+    await enrichSiteWithHackerNewsComments(
+      createSite(HN_ITEM_LINK),
+      fetchStub as any
+    )
+  ).entries
+  t.true(entry.content.includes('<p>hi</p>'))
+  t.true(entry.content.includes('bad\ufffdname'))
+})
+
+test('#enrichSiteWithHackerNewsComments strips name and target from comment anchors', async (t) => {
+  const fetchStub = sinon.stub().resolves(
+    algoliaResponse({
+      id: 40001,
+      children: [
+        comment(
+          40002,
+          '<a href="https://example.com" name="clobber0" target="_top">link</a>'
+        )
+      ]
+    })
+  )
+  const [entry] = (
+    await enrichSiteWithHackerNewsComments(
+      createSite(HN_ITEM_LINK),
+      fetchStub as any
+    )
+  ).entries
+  // (The href gains a trailing slash from the outer pass's URL resolution.)
+  t.true(entry.content.includes('<a href="https://example.com/">link</a>'))
+  t.false(entry.content.includes('clobber0'))
+  t.false(entry.content.includes('_top'))
+})
+
 test('#COMMENT_ALLOWED_TAGS permits no media-carrying tag', (t) => {
   // The img exclusion is derived, not named: a media attribute added to the
   // shared sanitize options later must not become downloadable from comments.

--- a/action/feeds/hackernews.test.ts
+++ b/action/feeds/hackernews.test.ts
@@ -1,0 +1,323 @@
+import test from 'ava'
+import sinon from 'sinon'
+
+import {
+  enrichSiteWithHackerNewsComments,
+  hackerNewsItemId
+} from './hackernews'
+import { rewriteLocalizedUrls } from './media'
+import type { Site } from './parsers'
+
+const HN_ITEM_LINK = 'https://news.ycombinator.com/item?id=40001'
+const ARTICLE_LINK = 'https://example.com/posts/story-1'
+
+// A HN feed entry as both the official RSS and hnrss publish it: the link is
+// the article, the item page is in the comments element, and the content is
+// just a "Comments" link.
+function createSite(...commentsLinks: (string | undefined)[]): Site {
+  return {
+    title: 'Hacker News',
+    link: 'https://news.ycombinator.com/',
+    description: '',
+    updatedAt: 1700000000000,
+    generator: '',
+    entries: commentsLinks.map((comments, index) => ({
+      title: `Story ${index + 1}`,
+      link: `${ARTICLE_LINK}-${index + 1}`,
+      date: 1700000000000,
+      author: '',
+      content: comments ? `<a href="${comments}">Comments</a>` : '<p>body</p>',
+      comments
+    }))
+  }
+}
+
+function algoliaResponse(item: object) {
+  return new Response(JSON.stringify(item), {
+    status: 200,
+    headers: { 'content-type': 'application/json' }
+  })
+}
+
+function comment(id: number, text: string, children: object[] = []) {
+  return {
+    id,
+    author: `user${id}`,
+    text,
+    created_at_i: 1700000000 + id,
+    children
+  }
+}
+
+test('#hackerNewsItemId detects HN item links', (t) => {
+  t.is(hackerNewsItemId(HN_ITEM_LINK), '40001')
+  t.is(hackerNewsItemId('http://news.ycombinator.com/item?id=1'), '1')
+  t.is(hackerNewsItemId('https://news.ycombinator.com/item?id=2&p=1'), '2')
+  t.is(
+    hackerNewsItemId('https://news.ycombinator.com/front?day=2024-01-01'),
+    null
+  )
+  t.is(hackerNewsItemId('https://example.com/item?id=40001'), null)
+  t.is(hackerNewsItemId('https://news.ycombinator.com/item'), null)
+  t.is(hackerNewsItemId('not a url'), null)
+  t.is(hackerNewsItemId(undefined), null)
+  t.is(hackerNewsItemId(''), null)
+})
+
+test('#enrichSiteWithHackerNewsComments leaves non-HN entries alone', async (t) => {
+  const fetchStub = sinon.stub()
+  const site = createSite('https://example.com/item?id=1', undefined)
+  const enriched = await enrichSiteWithHackerNewsComments(
+    site,
+    fetchStub as any
+  )
+  t.is(fetchStub.callCount, 0)
+  t.deepEqual(enriched, site)
+})
+
+test('#enrichSiteWithHackerNewsComments falls back to an entry link that is the item page', async (t) => {
+  const fetchStub = sinon.stub().resolves(
+    algoliaResponse({
+      id: 40001,
+      children: [comment(40002, '<p>via entry link</p>')]
+    })
+  )
+  const site = createSite(undefined)
+  site.entries[0].link = HN_ITEM_LINK
+  const [entry] = (
+    await enrichSiteWithHackerNewsComments(site, fetchStub as any)
+  ).entries
+  t.is(fetchStub.callCount, 1)
+  t.true(entry.content.includes('<p>via entry link</p>'))
+})
+
+test('#enrichSiteWithHackerNewsComments appends the thread after the feed content', async (t) => {
+  const fetchStub = sinon.stub().resolves(
+    algoliaResponse({
+      id: 40001,
+      children: [comment(40002, '<p>First point</p>')]
+    })
+  )
+  const [entry] = (
+    await enrichSiteWithHackerNewsComments(
+      createSite(HN_ITEM_LINK),
+      fetchStub as any
+    )
+  ).entries
+
+  t.is(fetchStub.callCount, 1)
+  t.is(fetchStub.firstCall.args[0], 'https://hn.algolia.com/api/v1/items/40001')
+  // The feed's own "Comments" link stays at the top.
+  t.true(entry.content.startsWith(`<a href="${HN_ITEM_LINK}">Comments</a>`))
+  t.true(
+    entry.content.includes(
+      '<a href="https://news.ycombinator.com/user?id=user40002">user40002</a>'
+    )
+  )
+  t.true(entry.content.includes('<p>First point</p>'))
+  // The comment date links to the comment permalink.
+  t.true(
+    entry.content.includes(
+      '<a href="https://news.ycombinator.com/item?id=40002">'
+    )
+  )
+  // The reader styles the thread through these classes, and the media store's
+  // rewrite pass runs over the content after enrichment -- they have to
+  // survive both sanitize passes.
+  t.true(entry.content.includes('class="hn-comments"'))
+  t.true(entry.content.includes('class="hn-comment-meta"'))
+  const rewritten = rewriteLocalizedUrls(entry.content, new Map())
+  t.true(rewritten.includes('class="hn-comments"'))
+  t.true(rewritten.includes('class="hn-comment-meta"'))
+})
+
+test('#enrichSiteWithHackerNewsComments renders the story text of self-posts', async (t) => {
+  const fetchStub = sinon.stub().resolves(
+    algoliaResponse({
+      id: 40001,
+      text: '<p>Ask HN: question body</p>',
+      children: []
+    })
+  )
+  const [entry] = (
+    await enrichSiteWithHackerNewsComments(
+      createSite(HN_ITEM_LINK),
+      fetchStub as any
+    )
+  ).entries
+  t.true(entry.content.includes('<p>Ask HN: question body</p>'))
+})
+
+test('#enrichSiteWithHackerNewsComments nests replies three levels deep', async (t) => {
+  const fetchStub = sinon.stub().resolves(
+    algoliaResponse({
+      id: 40001,
+      children: [
+        comment(40002, '<p>level 1</p>', [
+          comment(40003, '<p>level 2</p>', [
+            comment(40004, '<p>level 3</p>', [comment(40005, '<p>level 4</p>')])
+          ])
+        ])
+      ]
+    })
+  )
+  const [entry] = (
+    await enrichSiteWithHackerNewsComments(
+      createSite(HN_ITEM_LINK),
+      fetchStub as any
+    )
+  ).entries
+
+  t.true(entry.content.includes('<p>level 1</p>'))
+  t.true(entry.content.includes('<p>level 2</p>'))
+  t.true(entry.content.includes('<p>level 3</p>'))
+  t.false(entry.content.includes('<p>level 4</p>'))
+  // A thread cut short by the depth cap links back to the item page.
+  t.true(
+    entry.content.includes(
+      '<a href="https://news.ycombinator.com/item?id=40001">More comments on Hacker News</a>'
+    )
+  )
+})
+
+test('#enrichSiteWithHackerNewsComments caps the top-level comments', async (t) => {
+  const children = Array.from({ length: 25 }, (_, index) =>
+    comment(40100 + index, `<p>comment ${index + 1}</p>`)
+  )
+  const fetchStub = sinon
+    .stub()
+    .resolves(algoliaResponse({ id: 40001, children }))
+  const [entry] = (
+    await enrichSiteWithHackerNewsComments(
+      createSite(HN_ITEM_LINK),
+      fetchStub as any
+    )
+  ).entries
+
+  t.true(entry.content.includes('<p>comment 20</p>'))
+  t.false(entry.content.includes('<p>comment 21</p>'))
+  t.true(entry.content.includes('More comments on Hacker News'))
+})
+
+test('#enrichSiteWithHackerNewsComments omits the more link for short threads', async (t) => {
+  const fetchStub = sinon.stub().resolves(
+    algoliaResponse({
+      id: 40001,
+      children: [comment(40002, '<p>only comment</p>')]
+    })
+  )
+  const [entry] = (
+    await enrichSiteWithHackerNewsComments(
+      createSite(HN_ITEM_LINK),
+      fetchStub as any
+    )
+  ).entries
+  t.false(entry.content.includes('More comments on Hacker News'))
+})
+
+test('#enrichSiteWithHackerNewsComments skips dead comments', async (t) => {
+  const fetchStub = sinon.stub().resolves(
+    algoliaResponse({
+      id: 40001,
+      children: [
+        { id: 40003, author: null, text: null, children: [] },
+        comment(40004, '<p>alive</p>')
+      ]
+    })
+  )
+  const [entry] = (
+    await enrichSiteWithHackerNewsComments(
+      createSite(HN_ITEM_LINK),
+      fetchStub as any
+    )
+  ).entries
+  t.false(entry.content.includes('40003'))
+  t.true(entry.content.includes('<p>alive</p>'))
+})
+
+test('#enrichSiteWithHackerNewsComments sanitizes comment html and resolves relative urls', async (t) => {
+  const fetchStub = sinon.stub().resolves(
+    algoliaResponse({
+      id: 40001,
+      children: [
+        comment(
+          40002,
+          '<p>reply</p><script>alert(1)</script><a href="item?id=39999">parent thread</a>'
+        )
+      ]
+    })
+  )
+  const [entry] = (
+    await enrichSiteWithHackerNewsComments(
+      createSite(HN_ITEM_LINK),
+      fetchStub as any
+    )
+  ).entries
+
+  t.false(entry.content.includes('<script>'))
+  t.true(
+    entry.content.includes(
+      '<a href="https://news.ycombinator.com/item?id=39999">parent thread</a>'
+    )
+  )
+})
+
+test('#enrichSiteWithHackerNewsComments escapes the author name', async (t) => {
+  const fetchStub = sinon.stub().resolves(
+    algoliaResponse({
+      id: 40001,
+      children: [
+        {
+          id: 40002,
+          author: 'a<b>&"user',
+          text: '<p>hi</p>',
+          created_at_i: 1700000002,
+          children: []
+        }
+      ]
+    })
+  )
+  const [entry] = (
+    await enrichSiteWithHackerNewsComments(
+      createSite(HN_ITEM_LINK),
+      fetchStub as any
+    )
+  ).entries
+  // sanitize-html re-serializes the text, so the quote comes back bare --
+  // what matters is that the angle brackets can no longer open a tag.
+  t.true(entry.content.includes('a&lt;b&gt;&amp;"user'))
+  t.true(
+    entry.content.includes(
+      `href="https://news.ycombinator.com/user?id=${encodeURIComponent(
+        'a<b>&"user'
+      )}"`
+    )
+  )
+})
+
+test('#enrichSiteWithHackerNewsComments keeps the original content when the fetch fails', async (t) => {
+  const site = createSite(HN_ITEM_LINK)
+
+  const rejecting = sinon.stub().rejects(new Error('socket hang up'))
+  const [rejectedEntry] = (
+    await enrichSiteWithHackerNewsComments(site, rejecting as any)
+  ).entries
+  t.is(rejectedEntry.content, site.entries[0].content)
+
+  const erroring = sinon.stub().resolves(new Response('nope', { status: 500 }))
+  const [erroredEntry] = (
+    await enrichSiteWithHackerNewsComments(site, erroring as any)
+  ).entries
+  t.is(erroredEntry.content, site.entries[0].content)
+})
+
+test('#enrichSiteWithHackerNewsComments keeps the original content for an empty thread', async (t) => {
+  const fetchStub = sinon
+    .stub()
+    .resolves(algoliaResponse({ id: 40001, children: [] }))
+  const site = createSite(HN_ITEM_LINK)
+  const [entry] = (
+    await enrichSiteWithHackerNewsComments(site, fetchStub as any)
+  ).entries
+  t.is(entry.content, site.entries[0].content)
+})

--- a/action/feeds/hackernews.test.ts
+++ b/action/feeds/hackernews.test.ts
@@ -2,11 +2,13 @@ import test from 'ava'
 import sinon from 'sinon'
 
 import {
+  COMMENT_ALLOWED_TAGS,
+  createHackerNewsEnricher,
   enrichSiteWithHackerNewsComments,
   hackerNewsItemId
 } from './hackernews'
 import { collectDownloadableMediaUrls, rewriteLocalizedUrls } from './media'
-import type { Site } from './parsers'
+import { ENTRY_CONTENT_SANITIZE_OPTIONS, type Site } from './parsers'
 
 const HN_ITEM_LINK = 'https://news.ycombinator.com/item?id=40001'
 const ARTICLE_LINK = 'https://example.com/posts/story-1'
@@ -371,6 +373,52 @@ test('#enrichSiteWithHackerNewsComments renders live replies of a dead comment',
   ).entries
   t.true(entry.content.includes('<p>reply to a dead comment</p>'))
   t.false(entry.content.includes('user40003'))
+  // The replies sit under the same [deleted] marker HN shows.
+  t.true(entry.content.includes('<p class="hn-comment-meta">[deleted]</p>'))
+})
+
+test('#enrichSiteWithHackerNewsComments omits the more link when only dead comments were cut', async (t) => {
+  // 25 top-level comments, everything past the cap dead: nothing a reader
+  // could see was cut, so the More link would be a false promise.
+  const children = Array.from({ length: 25 }, (_, index) =>
+    index < 5
+      ? comment(40100 + index, `<p>live ${index + 1}</p>`)
+      : { id: 40200 + index, author: null, text: null, children: [] }
+  )
+  const fetchStub = sinon
+    .stub()
+    .resolves(algoliaResponse({ id: 40001, children }))
+  const [entry] = (
+    await enrichSiteWithHackerNewsComments(
+      createSite(HN_ITEM_LINK),
+      fetchStub as any
+    )
+  ).entries
+  t.false(entry.content.includes('More comments on Hacker News'))
+
+  // Same at the depth cap: a live comment whose only replies are dead.
+  const deadReplies = sinon.stub().resolves(
+    algoliaResponse({
+      id: 40001,
+      children: [
+        comment(40002, '<p>level 1</p>', [
+          comment(40003, '<p>level 2</p>', [
+            comment(40004, '<p>level 3</p>', [
+              { id: 40005, author: null, text: null, children: [] }
+            ])
+          ])
+        ])
+      ]
+    })
+  )
+  const [deadReplyEntry] = (
+    await enrichSiteWithHackerNewsComments(
+      createSite(HN_ITEM_LINK),
+      deadReplies as any
+    )
+  ).entries
+  t.true(deadReplyEntry.content.includes('<p>level 3</p>'))
+  t.false(deadReplyEntry.content.includes('More comments on Hacker News'))
 })
 
 test('#enrichSiteWithHackerNewsComments bounds the total comments rendered', async (t) => {
@@ -508,4 +556,157 @@ test('#enrichSiteWithHackerNewsComments keeps the original content when the resp
     await enrichSiteWithHackerNewsComments(site, fetchStub as any)
   ).entries
   t.is(entry.content, site.entries[0].content)
+})
+
+test('#enrichSiteWithHackerNewsComments refuses a declared oversize content-length before reading', async (t) => {
+  const fetchStub = sinon.stub().resolves(
+    new Response('{"id":40001,"children":[]}', {
+      status: 200,
+      headers: {
+        'content-type': 'application/json',
+        'content-length': String(10 * 1024 * 1024)
+      }
+    })
+  )
+  const site = createSite(HN_ITEM_LINK)
+  const [entry] = (
+    await enrichSiteWithHackerNewsComments(site, fetchStub as any)
+  ).entries
+  t.is(entry.content, site.entries[0].content)
+})
+
+test('#enrichSiteWithHackerNewsComments strips commenter classes but keeps the chrome', async (t) => {
+  // The outer sanitize pass lets the hn-* classes through for the generated
+  // chrome; commenter HTML must not wear them.
+  const fetchStub = sinon.stub().resolves(
+    algoliaResponse({
+      id: 40001,
+      children: [
+        comment(
+          40002,
+          '<p class="hn-more"><a href="https://evil.example">More comments</a></p><div class="hn-comment-meta">forged</div>'
+        )
+      ]
+    })
+  )
+  const [entry] = (
+    await enrichSiteWithHackerNewsComments(
+      createSite(HN_ITEM_LINK),
+      fetchStub as any
+    )
+  ).entries
+  t.false(
+    entry.content.includes('<p class="hn-more"><a href="https://evil.example">')
+  )
+  t.false(entry.content.includes('class="hn-comment-meta">forged'))
+  // The genuine chrome classes are unaffected.
+  t.true(entry.content.includes('class="hn-comments"'))
+  t.true(entry.content.includes('class="hn-comment-meta"'))
+})
+
+test('#enrichSiteWithHackerNewsComments renders no permalink for an unsafe comment id', async (t) => {
+  // Number.isInteger(1e21) is true; the permalink must not serialize 1e+21.
+  const fetchStub = sinon
+    .stub()
+    .resolves(
+      new Response(
+        '{"id":40001,"children":[{"id":1e21,"author":"user1","text":"<p>hi</p>","created_at_i":1700000002,"children":[]}]}',
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      )
+    )
+  const [entry] = (
+    await enrichSiteWithHackerNewsComments(
+      createSite(HN_ITEM_LINK),
+      fetchStub as any
+    )
+  ).entries
+  t.false(entry.content.includes('1e+21'))
+  t.false(entry.content.includes('1e21'))
+  // The date survives as plain text.
+  t.true(entry.content.includes('user1</a> · '))
+})
+
+test('#enrichSiteWithHackerNewsComments renders no date for a negative timestamp', async (t) => {
+  const fetchStub = sinon.stub().resolves(
+    algoliaResponse({
+      id: 40001,
+      children: [
+        {
+          id: 40002,
+          author: 'user40002',
+          text: '<p>hi</p>',
+          created_at_i: -5,
+          children: []
+        }
+      ]
+    })
+  )
+  const [entry] = (
+    await enrichSiteWithHackerNewsComments(
+      createSite(HN_ITEM_LINK),
+      fetchStub as any
+    )
+  ).entries
+  t.true(entry.content.includes('<p>hi</p>'))
+  t.false(entry.content.includes('item?id=40002'))
+})
+
+test('#enrichSiteWithHackerNewsComments enriches at the deadline boundary', async (t) => {
+  const fetchStub = sinon.stub().resolves(
+    algoliaResponse({
+      id: 40001,
+      children: [comment(40002, '<p>boundary</p>')]
+    })
+  )
+  const now = sinon.stub()
+  now.onCall(0).returns(0) // deadline = 60_000
+  now.onCall(1).returns(60_000) // exactly at the deadline: still inside
+  const [entry] = (
+    await enrichSiteWithHackerNewsComments(
+      createSite(HN_ITEM_LINK),
+      fetchStub as any,
+      now
+    )
+  ).entries
+  t.true(entry.content.includes('<p>boundary</p>'))
+})
+
+test('#createHackerNewsEnricher shares one deadline across sites', async (t) => {
+  const fetchStub = sinon.stub().resolves(
+    algoliaResponse({
+      id: 40001,
+      children: [comment(40002, '<p>thread</p>')]
+    })
+  )
+  const now = sinon.stub()
+  now.onCall(0).returns(0) // enricher creation: deadline = 60_000
+  now.onCall(1).returns(1_000) // first site's entry: inside
+  now.onCall(2).returns(70_000) // second site's entry: past the shared budget
+  const enrich = createHackerNewsEnricher(fetchStub as any, now)
+  const first = await enrich(createSite(HN_ITEM_LINK))
+  const second = await enrich(createSite(HN_ITEM_LINK))
+  t.true(first.entries[0].content.includes('<p>thread</p>'))
+  t.is(
+    second.entries[0].content,
+    '<a href="https://news.ycombinator.com/item?id=40001">Comments</a>'
+  )
+  t.is(fetchStub.callCount, 1)
+})
+
+test('#COMMENT_ALLOWED_TAGS permits no media-carrying tag', (t) => {
+  // The img exclusion is derived, not named: a media attribute added to the
+  // shared sanitize options later must not become downloadable from comments.
+  const allowedAttributes = ENTRY_CONTENT_SANITIZE_OPTIONS.allowedAttributes as
+    Record<string, string[]> | undefined
+  for (const tag of COMMENT_ALLOWED_TAGS) {
+    const attributes = [
+      ...(allowedAttributes?.[tag] || []),
+      ...(allowedAttributes?.['*'] || [])
+    ]
+    t.false(
+      attributes.some((attribute) => ['src', 'srcset'].includes(attribute)),
+      `${tag} permits a media attribute`
+    )
+  }
+  t.false(COMMENT_ALLOWED_TAGS.includes('img'))
 })

--- a/action/feeds/hackernews.ts
+++ b/action/feeds/hackernews.ts
@@ -1,0 +1,204 @@
+import { format } from 'date-fns'
+
+import { USER_AGENT } from './http'
+import {
+  mapContentUrls,
+  resolveContentUrl,
+  type Entry,
+  type Site
+} from './parsers'
+
+const ALGOLIA_ITEM_API = 'https://hn.algolia.com/api/v1/items'
+const FETCH_TIMEOUT_MS = 10_000
+const MAX_TOP_LEVEL_COMMENTS = 20
+const MAX_COMMENT_DEPTH = 3
+
+/**
+ * The shape of the Algolia HN API (`/api/v1/items/:id`), which returns a story
+ * with its whole comment tree in one request -- the official Firebase API
+ * would take one request per comment instead. Dead and deleted comments come
+ * back with null author and text.
+ */
+interface AlgoliaItem {
+  id: number
+  author?: string | null
+  text?: string | null
+  created_at_i?: number
+  children?: AlgoliaItem[]
+}
+
+/**
+ * The HN item id a URL points at, or null when it is not a HN item page.
+ * Hacker News feeds -- the official RSS, hnrss, or any other mirror -- put the
+ * item page in the entry's <comments> element (the entry link itself is the
+ * article), so that is checked first; the entry link covers feeds that point
+ * their entries straight at the item page.
+ */
+export function hackerNewsItemId(url?: string) {
+  if (!url) return null
+  try {
+    const parsed = new URL(url)
+    if (parsed.hostname !== 'news.ycombinator.com') return null
+    if (parsed.pathname !== '/item') return null
+    return parsed.searchParams.get('id')
+  } catch {
+    return null
+  }
+}
+
+function escapeHtml(value: string) {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}
+
+interface Rendered {
+  html: string
+  truncated: boolean
+}
+
+/**
+ * Renders one comment and its replies. Replies nest inside a bordered block up
+ * to MAX_COMMENT_DEPTH levels; a comment deeper than that still exists on the
+ * item page, which is what the truncated flag bubbles up for.
+ */
+function renderComment(comment: AlgoliaItem, depth: number): Rendered {
+  // Dead and deleted comments have no author or text; skip them silently.
+  if (!comment.author || !comment.text) return { html: '', truncated: false }
+
+  const author = escapeHtml(comment.author)
+  const authorLink = `<a href="https://news.ycombinator.com/user?id=${encodeURIComponent(
+    comment.author
+  )}">${author}</a>`
+  const dateLink = comment.created_at_i
+    ? ` · <a href="https://news.ycombinator.com/item?id=${comment.id}">${format(
+        new Date(comment.created_at_i * 1000),
+        'PP'
+      )}</a>`
+    : ''
+  const meta = `<p class="hn-comment-meta">${authorLink}${dateLink}</p>`
+
+  const children = comment.children ?? []
+  let childrenHtml = ''
+  let truncated = false
+  if (depth >= MAX_COMMENT_DEPTH) {
+    truncated = children.length > 0
+  } else {
+    const rendered = children.map((child) => renderComment(child, depth + 1))
+    childrenHtml = rendered
+      .map((child) => child.html)
+      .filter(Boolean)
+      .join('')
+    truncated = rendered.some((child) => child.truncated)
+  }
+  const childrenBlock = childrenHtml
+    ? `<div class="hn-comment-children">${childrenHtml}</div>`
+    : ''
+
+  return {
+    html: `<div class="hn-comment">${meta}<div class="hn-comment-body">${comment.text}</div>${childrenBlock}</div>`,
+    truncated
+  }
+}
+
+/**
+ * Turns a fetched item into the HTML appended to the entry: the story text for
+ * self-posts (Ask HN), then the top MAX_TOP_LEVEL_COMMENTS comments, and a
+ * link back to the item page whenever the caps cut the thread short.
+ */
+function renderItem(item: AlgoliaItem): string {
+  const parts: string[] = []
+  if (item.text) {
+    parts.push(`<div class="hn-story">${item.text}</div>`)
+  }
+
+  const topLevel = item.children ?? []
+  const rendered = topLevel
+    .slice(0, MAX_TOP_LEVEL_COMMENTS)
+    .map((comment) => renderComment(comment, 1))
+  const commentsHtml = rendered
+    .map((comment) => comment.html)
+    .filter(Boolean)
+    .join('')
+  if (commentsHtml) {
+    parts.push(`<div class="hn-comments">${commentsHtml}</div>`)
+  }
+
+  const truncated =
+    topLevel.length > MAX_TOP_LEVEL_COMMENTS ||
+    rendered.some((comment) => comment.truncated)
+  if (truncated) {
+    parts.push(
+      `<p class="hn-more"><a href="https://news.ycombinator.com/item?id=${item.id}">More comments on Hacker News</a></p>`
+    )
+  }
+  return parts.join('')
+}
+
+async function fetchItem(
+  id: string,
+  fetchApi: typeof globalThis.fetch
+): Promise<AlgoliaItem | null> {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+  try {
+    const response = await fetchApi(`${ALGOLIA_ITEM_API}/${id}`, {
+      headers: { 'User-Agent': USER_AGENT },
+      signal: controller.signal
+    })
+    if (!response.ok) {
+      throw new Error(`Unexpected response status ${response.status}`)
+    }
+    return (await response.json()) as AlgoliaItem
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+/**
+ * Appends the HN comment tree to every entry that links to a HN item, leaving
+ * the feed's own content -- the "Comments" link -- at the top. The generated
+ * HTML goes through the same sanitize pass as feed content, so the reader
+ * keeps trusting stored content and relative links in comments resolve against
+ * the item page.
+ *
+ * A failed fetch never fails the build: the entry keeps its original content.
+ */
+export async function enrichSiteWithHackerNewsComments(
+  site: Site,
+  fetchApi: typeof globalThis.fetch = globalThis.fetch
+): Promise<Site> {
+  const entries: Entry[] = []
+  for (const entry of site.entries) {
+    const id = hackerNewsItemId(entry.comments) ?? hackerNewsItemId(entry.link)
+    if (!id) {
+      entries.push(entry)
+      continue
+    }
+    try {
+      const item = await fetchItem(id, fetchApi)
+      const addition = item ? renderItem(item) : ''
+      if (!addition) {
+        entries.push(entry)
+        continue
+      }
+      // Comment HTML lives on the item page, so that is its document base --
+      // not the entry link, which for a HN feed is the article itself.
+      const itemUrl = `https://news.ycombinator.com/item?id=${id}`
+      const content =
+        entry.content +
+        mapContentUrls(addition, (url, target) =>
+          resolveContentUrl(url, target, site.link, itemUrl)
+        )
+      entries.push({ ...entry, content })
+    } catch (error: any) {
+      console.error(
+        `Fail to load Hacker News comments for ${entry.link}: ${error.message}`
+      )
+      entries.push(entry)
+    }
+  }
+  return { ...site, entries }
+}

--- a/action/feeds/hackernews.ts
+++ b/action/feeds/hackernews.ts
@@ -1,4 +1,5 @@
 import { format } from 'date-fns'
+import sanitizeHtml from 'sanitize-html'
 
 import { USER_AGENT } from './http'
 import {
@@ -12,9 +13,10 @@ import {
 const ALGOLIA_ITEM_API = 'https://hn.algolia.com/api/v1/items'
 const FETCH_TIMEOUT_MS = 10_000
 const MAX_RESPONSE_BYTES = 5 * 1024 * 1024
-// One budget per site, so a slow Algolia cannot eat into the media store's
-// localization deadline -- that clock starts when the loader is created,
-// before any enrichment runs.
+// One budget per run, shared across sites through createHackerNewsEnricher:
+// the media store's localization deadline starts when the loader is created,
+// so enrichment as a whole gets this much time no matter how many HN feeds
+// the OPML lists.
 const ENRICHMENT_DEADLINE_MS = 60_000
 const MAX_TOP_LEVEL_COMMENTS = 20
 const MAX_COMMENT_DEPTH = 3
@@ -24,10 +26,41 @@ const MAX_TOTAL_COMMENTS = 100
 
 // HN renders no images in comments, and enrichment runs before the media
 // store -- an img left in here would hand URLs chosen by any commenter to the
-// downloader and republish them from this site's own origin.
-const COMMENT_ALLOWED_TAGS = (
+// downloader and republish them from this site's own origin. Derived by
+// property rather than by naming img, so a media-carrying tag added to the
+// shared options later is excluded here automatically.
+const MEDIA_ATTRIBUTES = new Set(['src', 'srcset'])
+export const COMMENT_ALLOWED_TAGS = (
   (ENTRY_CONTENT_SANITIZE_OPTIONS.allowedTags as string[]) || []
-).filter((tag) => tag !== 'img')
+).filter((tag) => {
+  const allowedAttributes = ENTRY_CONTENT_SANITIZE_OPTIONS.allowedAttributes as
+    Record<string, string[]> | undefined
+  const tagAttributes = [
+    ...(allowedAttributes?.[tag] || []),
+    ...(allowedAttributes?.['*'] || [])
+  ]
+  return !tagAttributes.some((attribute) => MEDIA_ATTRIBUTES.has(attribute))
+})
+
+// Commenter-authored HTML is sanitized on its own before it is embedded in the
+// generated chrome, with every class dropped: the outer pass lets the hn-*
+// classes through for the chrome, and comment HTML must not wear them.
+const COMMENT_TEXT_SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
+  ...ENTRY_CONTENT_SANITIZE_OPTIONS,
+  allowedAttributes: {
+    ...(ENTRY_CONTENT_SANITIZE_OPTIONS.allowedAttributes as Record<
+      string,
+      string[]
+    >),
+    div: [],
+    p: []
+  },
+  allowedClasses: {}
+}
+
+function sanitizeCommentText(text: string) {
+  return sanitizeHtml(text, COMMENT_TEXT_SANITIZE_OPTIONS)
+}
 
 /**
  * The shape of the Algolia HN API (`/api/v1/items/:id`), which returns a story
@@ -47,6 +80,23 @@ type LiveComment = AlgoliaItem & { author: string; text: string }
 
 function isLiveComment(comment: AlgoliaItem): comment is LiveComment {
   return Boolean(comment.author && comment.text)
+}
+
+/**
+ * Is there anything a reader could see on HN below any of these comments --
+ * a live comment, or a dead one with a live descendant? Iterative because the
+ * tree is network input of unbounded depth. This is what the truncated flag
+ * means; counting dead leaves would render a More-comments link over a thread
+ * that shows nothing new.
+ */
+function hasLiveComment(items: AlgoliaItem[]): boolean {
+  const stack = [...items]
+  while (stack.length > 0) {
+    const item = stack.pop()!
+    if (isLiveComment(item)) return true
+    if (item.children) stack.push(...item.children)
+  }
+  return false
 }
 
 /**
@@ -83,7 +133,7 @@ function formatCommentDate(timestamp?: number) {
   // Untrusted input: JSON parses a literal like 1e999 to Infinity, and
   // date-fns format throws a RangeError on an invalid Date, which the
   // per-entry catch would turn into the whole thread being dropped.
-  if (!timestamp || !Number.isFinite(timestamp)) return ''
+  if (!timestamp || !Number.isFinite(timestamp) || timestamp < 0) return ''
   const date = new Date(timestamp * 1000)
   if (Number.isNaN(date.getTime())) return ''
   return format(date, 'PP')
@@ -105,9 +155,9 @@ function renderChildren(
 ): Rendered {
   const parts: string[] = []
   let truncated = false
-  for (const child of children) {
+  for (const [index, child] of children.entries()) {
     if (budget.remaining <= 0) {
-      truncated = true
+      truncated = hasLiveComment(children.slice(index))
       break
     }
     const rendered = renderComment(child, depth, budget)
@@ -130,15 +180,17 @@ function renderComment(
   const children = comment.children ?? []
 
   // Dead and deleted comments have no author or text. HN keeps their live
-  // replies under a [deleted] marker, so render the children in the dead
-  // comment's place rather than vanishing the whole subtree.
+  // replies under a [deleted] marker, so render the children under the same
+  // marker rather than vanishing the whole subtree.
   if (!isLiveComment(comment)) {
     if (!children.length) return { html: '', truncated: false }
-    if (depth >= MAX_COMMENT_DEPTH) return { html: '', truncated: true }
+    if (depth >= MAX_COMMENT_DEPTH) {
+      return { html: '', truncated: hasLiveComment(children) }
+    }
     const rendered = renderChildren(children, depth + 1, budget)
     return {
       html: rendered.html
-        ? `<div class="hn-comment-children">${rendered.html}</div>`
+        ? `<div class="hn-comment"><p class="hn-comment-meta">[deleted]</p><div class="hn-comment-children">${rendered.html}</div></div>`
         : '',
       truncated: rendered.truncated
     }
@@ -150,9 +202,10 @@ function renderComment(
   const authorLink = `<a href="https://news.ycombinator.com/user?id=${encodeURIComponent(
     comment.author
   )}">${author}</a>`
-  // The id comes from the network; only a positive integer is interpolated
-  // into the permalink.
-  const id = Number.isInteger(comment.id) && comment.id > 0 ? comment.id : null
+  // The id comes from the network; only a safe positive integer is
+  // interpolated into the permalink.
+  const id =
+    Number.isSafeInteger(comment.id) && comment.id > 0 ? comment.id : null
   const date = formatCommentDate(comment.created_at_i)
   const dateLink = date
     ? id
@@ -164,7 +217,7 @@ function renderComment(
   let childrenHtml = ''
   let truncated = false
   if (depth >= MAX_COMMENT_DEPTH) {
-    truncated = children.length > 0
+    truncated = hasLiveComment(children)
   } else {
     const rendered = renderChildren(children, depth + 1, budget)
     childrenHtml = rendered.html
@@ -175,7 +228,9 @@ function renderComment(
     : ''
 
   return {
-    html: `<div class="hn-comment">${meta}<div class="hn-comment-body">${comment.text}</div>${childrenBlock}</div>`,
+    html: `<div class="hn-comment">${meta}<div class="hn-comment-body">${sanitizeCommentText(
+      comment.text
+    )}</div>${childrenBlock}</div>`,
     truncated
   }
 }
@@ -190,7 +245,7 @@ function renderComment(
 function renderItem(item: AlgoliaItem, id: string): string {
   const parts: string[] = []
   if (item.text) {
-    parts.push(`<div class="hn-story">${item.text}</div>`)
+    parts.push(`<div class="hn-story">${sanitizeCommentText(item.text)}</div>`)
   }
 
   const budget = { remaining: MAX_TOTAL_COMMENTS }
@@ -205,7 +260,7 @@ function renderItem(item: AlgoliaItem, id: string): string {
   }
 
   const truncated =
-    topLevel.length > MAX_TOP_LEVEL_COMMENTS || rendered.truncated
+    hasLiveComment(topLevel.slice(MAX_TOP_LEVEL_COMMENTS)) || rendered.truncated
   if (truncated) {
     parts.push(
       `<p class="hn-more"><a href="https://news.ycombinator.com/item?id=${id}">More comments on Hacker News</a></p>`
@@ -268,29 +323,35 @@ async function fetchItem(
 /**
  * Appends the HN comment tree to every entry that links to a HN item, leaving
  * the feed's own content -- the "Comments" link -- at the top. The generated
- * HTML goes through the same sanitize pass as feed content (minus img, which
- * HN comments never render), so the reader keeps trusting stored content and
- * relative links in comments resolve against the item page.
+ * HTML goes through the same sanitize pass as feed content (minus any
+ * media-carrying tag, which HN comments never render), so the reader keeps
+ * trusting stored content and relative links in comments resolve against the
+ * item page.
  *
  * A failed fetch never fails the build: the entry keeps its original content.
  */
 export async function enrichSiteWithHackerNewsComments(
   site: Site,
   fetchApi: typeof globalThis.fetch = globalThis.fetch,
-  now: () => number = Date.now
+  now: () => number = Date.now,
+  deadline: number = now() + ENRICHMENT_DEADLINE_MS
 ): Promise<Site> {
-  const deadline = now() + ENRICHMENT_DEADLINE_MS
   const entries: Entry[] = []
+  let deadlineExceeded = false
   for (const entry of site.entries) {
     const id = hackerNewsItemId(entry.comments) ?? hackerNewsItemId(entry.link)
     if (!id) {
       entries.push(entry)
       continue
     }
-    if (now() > deadline) {
-      console.error(
-        `Skip Hacker News comments for ${entry.link}: enrichment deadline exceeded`
-      )
+    if (deadlineExceeded || now() > deadline) {
+      // Logged once per site rather than per entry left behind.
+      if (!deadlineExceeded) {
+        console.error(
+          `Skip remaining Hacker News comments for ${site.title}: enrichment deadline exceeded`
+        )
+        deadlineExceeded = true
+      }
       entries.push(entry)
       continue
     }
@@ -320,4 +381,18 @@ export async function enrichSiteWithHackerNewsComments(
     }
   }
   return { ...site, entries }
+}
+
+/**
+ * The enricher the feed loader uses: one deadline per run, shared across every
+ * site, so a slow Algolia cannot eat into the media store's localization
+ * deadline no matter how many HN feeds the OPML lists.
+ */
+export function createHackerNewsEnricher(
+  fetchApi: typeof globalThis.fetch = globalThis.fetch,
+  now: () => number = Date.now
+) {
+  const deadline = now() + ENRICHMENT_DEADLINE_MS
+  return (site: Site) =>
+    enrichSiteWithHackerNewsComments(site, fetchApi, now, deadline)
 }

--- a/action/feeds/hackernews.ts
+++ b/action/feeds/hackernews.ts
@@ -2,6 +2,7 @@ import { format } from 'date-fns'
 
 import { USER_AGENT } from './http'
 import {
+  ENTRY_CONTENT_SANITIZE_OPTIONS,
   mapContentUrls,
   resolveContentUrl,
   type Entry,
@@ -10,8 +11,23 @@ import {
 
 const ALGOLIA_ITEM_API = 'https://hn.algolia.com/api/v1/items'
 const FETCH_TIMEOUT_MS = 10_000
+const MAX_RESPONSE_BYTES = 5 * 1024 * 1024
+// One budget per site, so a slow Algolia cannot eat into the media store's
+// localization deadline -- that clock starts when the loader is created,
+// before any enrichment runs.
+const ENRICHMENT_DEADLINE_MS = 60_000
 const MAX_TOP_LEVEL_COMMENTS = 20
 const MAX_COMMENT_DEPTH = 3
+// The depth and top-level caps alone do not bound reply breadth (20 comments
+// can each carry hundreds of replies), so the total is capped too.
+const MAX_TOTAL_COMMENTS = 100
+
+// HN renders no images in comments, and enrichment runs before the media
+// store -- an img left in here would hand URLs chosen by any commenter to the
+// downloader and republish them from this site's own origin.
+const COMMENT_ALLOWED_TAGS = (
+  (ENTRY_CONTENT_SANITIZE_OPTIONS.allowedTags as string[]) || []
+).filter((tag) => tag !== 'img')
 
 /**
  * The shape of the Algolia HN API (`/api/v1/items/:id`), which returns a story
@@ -27,6 +43,12 @@ interface AlgoliaItem {
   children?: AlgoliaItem[]
 }
 
+type LiveComment = AlgoliaItem & { author: string; text: string }
+
+function isLiveComment(comment: AlgoliaItem): comment is LiveComment {
+  return Boolean(comment.author && comment.text)
+}
+
 /**
  * The HN item id a URL points at, or null when it is not a HN item page.
  * Hacker News feeds -- the official RSS, hnrss, or any other mirror -- put the
@@ -40,7 +62,10 @@ export function hackerNewsItemId(url?: string) {
     const parsed = new URL(url)
     if (parsed.hostname !== 'news.ycombinator.com') return null
     if (parsed.pathname !== '/item') return null
-    return parsed.searchParams.get('id')
+    const id = parsed.searchParams.get('id')
+    // An empty id would slip past ?? at the call site and block the entry-link
+    // fallback; a non-numeric one has no business in the fetch path.
+    return id && /^\d+$/.test(id) ? id : null
   } catch {
     return null
   }
@@ -54,9 +79,42 @@ function escapeHtml(value: string) {
     .replace(/"/g, '&quot;')
 }
 
+function formatCommentDate(timestamp?: number) {
+  // Untrusted input: JSON parses a literal like 1e999 to Infinity, and
+  // date-fns format throws a RangeError on an invalid Date, which the
+  // per-entry catch would turn into the whole thread being dropped.
+  if (!timestamp || !Number.isFinite(timestamp)) return ''
+  const date = new Date(timestamp * 1000)
+  if (Number.isNaN(date.getTime())) return ''
+  return format(date, 'PP')
+}
+
 interface Rendered {
   html: string
   truncated: boolean
+}
+
+interface Budget {
+  remaining: number
+}
+
+function renderChildren(
+  children: AlgoliaItem[],
+  depth: number,
+  budget: Budget
+): Rendered {
+  const parts: string[] = []
+  let truncated = false
+  for (const child of children) {
+    if (budget.remaining <= 0) {
+      truncated = true
+      break
+    }
+    const rendered = renderComment(child, depth, budget)
+    parts.push(rendered.html)
+    truncated = truncated || rendered.truncated
+  }
+  return { html: parts.filter(Boolean).join(''), truncated }
 }
 
 /**
@@ -64,34 +122,53 @@ interface Rendered {
  * to MAX_COMMENT_DEPTH levels; a comment deeper than that still exists on the
  * item page, which is what the truncated flag bubbles up for.
  */
-function renderComment(comment: AlgoliaItem, depth: number): Rendered {
-  // Dead and deleted comments have no author or text; skip them silently.
-  if (!comment.author || !comment.text) return { html: '', truncated: false }
+function renderComment(
+  comment: AlgoliaItem,
+  depth: number,
+  budget: Budget
+): Rendered {
+  const children = comment.children ?? []
+
+  // Dead and deleted comments have no author or text. HN keeps their live
+  // replies under a [deleted] marker, so render the children in the dead
+  // comment's place rather than vanishing the whole subtree.
+  if (!isLiveComment(comment)) {
+    if (!children.length) return { html: '', truncated: false }
+    if (depth >= MAX_COMMENT_DEPTH) return { html: '', truncated: true }
+    const rendered = renderChildren(children, depth + 1, budget)
+    return {
+      html: rendered.html
+        ? `<div class="hn-comment-children">${rendered.html}</div>`
+        : '',
+      truncated: rendered.truncated
+    }
+  }
+
+  budget.remaining--
 
   const author = escapeHtml(comment.author)
   const authorLink = `<a href="https://news.ycombinator.com/user?id=${encodeURIComponent(
     comment.author
   )}">${author}</a>`
-  const dateLink = comment.created_at_i
-    ? ` · <a href="https://news.ycombinator.com/item?id=${comment.id}">${format(
-        new Date(comment.created_at_i * 1000),
-        'PP'
-      )}</a>`
+  // The id comes from the network; only a positive integer is interpolated
+  // into the permalink.
+  const id = Number.isInteger(comment.id) && comment.id > 0 ? comment.id : null
+  const date = formatCommentDate(comment.created_at_i)
+  const dateLink = date
+    ? id
+      ? ` · <a href="https://news.ycombinator.com/item?id=${id}">${date}</a>`
+      : ` · ${date}`
     : ''
   const meta = `<p class="hn-comment-meta">${authorLink}${dateLink}</p>`
 
-  const children = comment.children ?? []
   let childrenHtml = ''
   let truncated = false
   if (depth >= MAX_COMMENT_DEPTH) {
     truncated = children.length > 0
   } else {
-    const rendered = children.map((child) => renderComment(child, depth + 1))
-    childrenHtml = rendered
-      .map((child) => child.html)
-      .filter(Boolean)
-      .join('')
-    truncated = rendered.some((child) => child.truncated)
+    const rendered = renderChildren(children, depth + 1, budget)
+    childrenHtml = rendered.html
+    truncated = rendered.truncated
   }
   const childrenBlock = childrenHtml
     ? `<div class="hn-comment-children">${childrenHtml}</div>`
@@ -106,35 +183,61 @@ function renderComment(comment: AlgoliaItem, depth: number): Rendered {
 /**
  * Turns a fetched item into the HTML appended to the entry: the story text for
  * self-posts (Ask HN), then the top MAX_TOP_LEVEL_COMMENTS comments, and a
- * link back to the item page whenever the caps cut the thread short.
+ * link back to the item page whenever the caps cut the thread short. The More
+ * link keys on the request id rather than item.id, which a drifting response
+ * shape could drop.
  */
-function renderItem(item: AlgoliaItem): string {
+function renderItem(item: AlgoliaItem, id: string): string {
   const parts: string[] = []
   if (item.text) {
     parts.push(`<div class="hn-story">${item.text}</div>`)
   }
 
+  const budget = { remaining: MAX_TOTAL_COMMENTS }
   const topLevel = item.children ?? []
-  const rendered = topLevel
-    .slice(0, MAX_TOP_LEVEL_COMMENTS)
-    .map((comment) => renderComment(comment, 1))
-  const commentsHtml = rendered
-    .map((comment) => comment.html)
-    .filter(Boolean)
-    .join('')
-  if (commentsHtml) {
-    parts.push(`<div class="hn-comments">${commentsHtml}</div>`)
+  const rendered = renderChildren(
+    topLevel.slice(0, MAX_TOP_LEVEL_COMMENTS),
+    1,
+    budget
+  )
+  if (rendered.html) {
+    parts.push(`<div class="hn-comments">${rendered.html}</div>`)
   }
 
   const truncated =
-    topLevel.length > MAX_TOP_LEVEL_COMMENTS ||
-    rendered.some((comment) => comment.truncated)
+    topLevel.length > MAX_TOP_LEVEL_COMMENTS || rendered.truncated
   if (truncated) {
     parts.push(
-      `<p class="hn-more"><a href="https://news.ycombinator.com/item?id=${item.id}">More comments on Hacker News</a></p>`
+      `<p class="hn-more"><a href="https://news.ycombinator.com/item?id=${id}">More comments on Hacker News</a></p>`
     )
   }
   return parts.join('')
+}
+
+/**
+ * Reads an item response with a size cap, the way the media store reads
+ * downloads: the thread for a popular story is unbounded user content, and the
+ * 10s timeout alone does not stop a multi-hundred-MB body from buffering.
+ */
+async function readBodyWithLimit(response: Response) {
+  const declaredLength = Number(response.headers.get('content-length'))
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_RESPONSE_BYTES) {
+    throw new Error(`Item response is larger than ${MAX_RESPONSE_BYTES} bytes`)
+  }
+  if (!response.body) throw new Error('Item response has no body')
+
+  const chunks: Buffer[] = []
+  let total = 0
+  for await (const chunk of response.body as unknown as AsyncIterable<Uint8Array>) {
+    total += chunk.length
+    if (total > MAX_RESPONSE_BYTES) {
+      throw new Error(
+        `Item response is larger than ${MAX_RESPONSE_BYTES} bytes`
+      )
+    }
+    chunks.push(Buffer.from(chunk))
+  }
+  return Buffer.concat(chunks).toString('utf8')
 }
 
 async function fetchItem(
@@ -151,7 +254,12 @@ async function fetchItem(
     if (!response.ok) {
       throw new Error(`Unexpected response status ${response.status}`)
     }
-    return (await response.json()) as AlgoliaItem
+    return JSON.parse(await readBodyWithLimit(response)) as AlgoliaItem
+  } catch (error) {
+    // A throw before the body is fully read leaves the socket held until the
+    // remote end drops it; abort releases it.
+    controller.abort()
+    throw error
   } finally {
     clearTimeout(timeout)
   }
@@ -160,16 +268,18 @@ async function fetchItem(
 /**
  * Appends the HN comment tree to every entry that links to a HN item, leaving
  * the feed's own content -- the "Comments" link -- at the top. The generated
- * HTML goes through the same sanitize pass as feed content, so the reader
- * keeps trusting stored content and relative links in comments resolve against
- * the item page.
+ * HTML goes through the same sanitize pass as feed content (minus img, which
+ * HN comments never render), so the reader keeps trusting stored content and
+ * relative links in comments resolve against the item page.
  *
  * A failed fetch never fails the build: the entry keeps its original content.
  */
 export async function enrichSiteWithHackerNewsComments(
   site: Site,
-  fetchApi: typeof globalThis.fetch = globalThis.fetch
+  fetchApi: typeof globalThis.fetch = globalThis.fetch,
+  now: () => number = Date.now
 ): Promise<Site> {
+  const deadline = now() + ENRICHMENT_DEADLINE_MS
   const entries: Entry[] = []
   for (const entry of site.entries) {
     const id = hackerNewsItemId(entry.comments) ?? hackerNewsItemId(entry.link)
@@ -177,9 +287,16 @@ export async function enrichSiteWithHackerNewsComments(
       entries.push(entry)
       continue
     }
+    if (now() > deadline) {
+      console.error(
+        `Skip Hacker News comments for ${entry.link}: enrichment deadline exceeded`
+      )
+      entries.push(entry)
+      continue
+    }
     try {
       const item = await fetchItem(id, fetchApi)
-      const addition = item ? renderItem(item) : ''
+      const addition = item ? renderItem(item, id) : ''
       if (!addition) {
         entries.push(entry)
         continue
@@ -189,8 +306,10 @@ export async function enrichSiteWithHackerNewsComments(
       const itemUrl = `https://news.ycombinator.com/item?id=${id}`
       const content =
         entry.content +
-        mapContentUrls(addition, (url, target) =>
-          resolveContentUrl(url, target, site.link, itemUrl)
+        mapContentUrls(
+          addition,
+          (url, target) => resolveContentUrl(url, target, site.link, itemUrl),
+          COMMENT_ALLOWED_TAGS
         )
       entries.push({ ...entry, content })
     } catch (error: any) {

--- a/action/feeds/hackernews.ts
+++ b/action/feeds/hackernews.ts
@@ -45,6 +45,8 @@ export const COMMENT_ALLOWED_TAGS = (
 // Commenter-authored HTML is sanitized on its own before it is embedded in the
 // generated chrome, with every class dropped: the outer pass lets the hn-*
 // classes through for the chrome, and comment HTML must not wear them.
+// Anchors keep only href -- the reader overwrites target/rel at render time,
+// and name has no legitimate use in a comment.
 const COMMENT_TEXT_SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
   ...ENTRY_CONTENT_SANITIZE_OPTIONS,
   allowedAttributes: {
@@ -52,6 +54,7 @@ const COMMENT_TEXT_SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
       string,
       string[]
     >),
+    a: ['href'],
     div: [],
     p: []
   },
@@ -78,8 +81,18 @@ interface AlgoliaItem {
 
 type LiveComment = AlgoliaItem & { author: string; text: string }
 
-function isLiveComment(comment: AlgoliaItem): comment is LiveComment {
-  return Boolean(comment.author && comment.text)
+// The tree is network input: nodes can be null, non-objects, or carry their
+// fields under the wrong types, and none of that may cost the whole thread.
+function isLiveComment(comment: unknown): comment is LiveComment {
+  if (!comment || typeof comment !== 'object') return false
+  const { author, text } = comment as AlgoliaItem
+  return Boolean(
+    typeof author === 'string' && author && typeof text === 'string' && text
+  )
+}
+
+function liveChildrenOf(comment: AlgoliaItem): AlgoliaItem[] {
+  return Array.isArray(comment.children) ? comment.children : []
 }
 
 /**
@@ -92,9 +105,12 @@ function isLiveComment(comment: AlgoliaItem): comment is LiveComment {
 function hasLiveComment(items: AlgoliaItem[]): boolean {
   const stack = [...items]
   while (stack.length > 0) {
-    const item = stack.pop()!
+    const item = stack.pop()
+    if (!item || typeof item !== 'object') continue
     if (isLiveComment(item)) return true
-    if (item.children) stack.push(...item.children)
+    // A loop, not stack.push(...children): the spread form hits V8's
+    // argument-count limit on a node with hundreds of thousands of children.
+    for (const child of liveChildrenOf(item)) stack.push(child)
   }
   return false
 }
@@ -157,7 +173,9 @@ function renderChildren(
   let truncated = false
   for (const [index, child] of children.entries()) {
     if (budget.remaining <= 0) {
-      truncated = hasLiveComment(children.slice(index))
+      // Accumulate, never assign: an earlier sibling may already have had
+      // visible content cut, and an all-dead remainder must not wipe that.
+      truncated = truncated || hasLiveComment(children.slice(index))
       break
     }
     const rendered = renderComment(child, depth, budget)
@@ -177,7 +195,10 @@ function renderComment(
   depth: number,
   budget: Budget
 ): Rendered {
-  const children = comment.children ?? []
+  if (!comment || typeof comment !== 'object') {
+    return { html: '', truncated: false }
+  }
+  const children = liveChildrenOf(comment)
 
   // Dead and deleted comments have no author or text. HN keeps their live
   // replies under a [deleted] marker, so render the children under the same
@@ -198,9 +219,12 @@ function renderComment(
 
   budget.remaining--
 
-  const author = escapeHtml(comment.author)
+  // toWellFormed replaces lone surrogates, which JSON.parse produces happily
+  // and encodeURIComponent throws on.
+  const authorName = comment.author.toWellFormed()
+  const author = escapeHtml(authorName)
   const authorLink = `<a href="https://news.ycombinator.com/user?id=${encodeURIComponent(
-    comment.author
+    authorName
   )}">${author}</a>`
   // The id comes from the network; only a safe positive integer is
   // interpolated into the permalink.
@@ -244,12 +268,12 @@ function renderComment(
  */
 function renderItem(item: AlgoliaItem, id: string): string {
   const parts: string[] = []
-  if (item.text) {
+  if (typeof item.text === 'string' && item.text) {
     parts.push(`<div class="hn-story">${sanitizeCommentText(item.text)}</div>`)
   }
 
   const budget = { remaining: MAX_TOTAL_COMMENTS }
-  const topLevel = item.children ?? []
+  const topLevel = liveChildrenOf(item)
   const rendered = renderChildren(
     topLevel.slice(0, MAX_TOP_LEVEL_COMMENTS),
     1,
@@ -260,7 +284,7 @@ function renderItem(item: AlgoliaItem, id: string): string {
   }
 
   const truncated =
-    hasLiveComment(topLevel.slice(MAX_TOP_LEVEL_COMMENTS)) || rendered.truncated
+    rendered.truncated || hasLiveComment(topLevel.slice(MAX_TOP_LEVEL_COMMENTS))
   if (truncated) {
     parts.push(
       `<p class="hn-more"><a href="https://news.ycombinator.com/item?id=${id}">More comments on Hacker News</a></p>`

--- a/action/feeds/index.ts
+++ b/action/feeds/index.ts
@@ -27,6 +27,7 @@ import {
   createMediaStore,
   getMediaDirectory
 } from './media'
+import { enrichSiteWithHackerNewsComments } from './hackernews'
 import { loadFeed, readOpml } from './opml'
 import type { Site } from './parsers'
 
@@ -41,7 +42,10 @@ async function createLocalizingFeedLoader(githubActionPath: string) {
   const feedLoader = async (title: string, url: string) => {
     const site: Site | null = await loadFeed(title, url)
     if (!site) return null
-    return store.localizeSite(site)
+    // HN entries carry only a "Comments" link, so the discussion is fetched
+    // and appended before media localization walks the content.
+    const enriched = await enrichSiteWithHackerNewsComments(site)
+    return store.localizeSite(enriched)
   }
   return { feedLoader, mediaDirectory }
 }

--- a/action/feeds/index.ts
+++ b/action/feeds/index.ts
@@ -27,7 +27,7 @@ import {
   createMediaStore,
   getMediaDirectory
 } from './media'
-import { enrichSiteWithHackerNewsComments } from './hackernews'
+import { createHackerNewsEnricher } from './hackernews'
 import { loadFeed, readOpml } from './opml'
 import type { Site } from './parsers'
 
@@ -39,13 +39,14 @@ async function createLocalizingFeedLoader(githubActionPath: string) {
   await restorePublishedMedia(getPublicPath(githubActionPath))
   const mediaDirectory = getMediaDirectory(githubActionPath)
   const store = createMediaStore({ mediaDirectory })
+  // HN entries carry only a "Comments" link, so the discussion is fetched and
+  // appended before media localization walks the content. One enricher per
+  // run: its deadline is shared across sites, like the media store's.
+  const enricher = createHackerNewsEnricher()
   const feedLoader = async (title: string, url: string) => {
     const site: Site | null = await loadFeed(title, url)
     if (!site) return null
-    // HN entries carry only a "Comments" link, so the discussion is fetched
-    // and appended before media localization walks the content.
-    const enriched = await enrichSiteWithHackerNewsComments(site)
-    return store.localizeSite(enriched)
+    return store.localizeSite(await enricher(site))
   }
   return { feedLoader, mediaDirectory }
 }

--- a/action/feeds/parsers#media-url-resolution.test.ts
+++ b/action/feeds/parsers#media-url-resolution.test.ts
@@ -120,7 +120,10 @@ const NON_URL_ATTRIBUTES = new Set([
   'title',
   'width',
   'height',
-  'loading'
+  'loading',
+  // Allowed on div and p for the Hacker News discussion markup; a class name
+  // is not a URL.
+  'class'
 ])
 
 test('#parseRss resolves every allowed attribute that carries a URL', (t) => {

--- a/action/feeds/parsers#parseRss.test.ts
+++ b/action/feeds/parsers#parseRss.test.ts
@@ -28,6 +28,8 @@ test('#parseAtom returns site information with empty string for fields that does
     link: firstEntry.link.join('').trim(),
     date: new Date('2021-02-08T10:05:48Z').getTime(),
     content: firstEntry['content:encoded'].join('').trim(),
-    author: 'icez'
+    author: 'icez',
+    comments:
+      'https://www.icez.net/blog/167459/rsyslog-log-remote-host-to-separate-file#respond'
   })
 })

--- a/action/feeds/parsers#parseRss.test.ts
+++ b/action/feeds/parsers#parseRss.test.ts
@@ -7,7 +7,7 @@ import { parseRss, parseXML } from './parsers'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
-test('#parseAtom returns site information with empty string for fields that does not have information', async (t) => {
+test('#parseRss returns site information with empty string for fields that does not have information', async (t) => {
   const data = fs
     .readFileSync(path.join(__dirname, 'stubs', 'rss1.xml'))
     .toString('utf8')
@@ -32,4 +32,29 @@ test('#parseAtom returns site information with empty string for fields that does
     comments:
       'https://www.icez.net/blog/167459/rsyslog-log-remote-host-to-separate-file#respond'
   })
+})
+
+test('#parseRss leaves comments undefined when the item has no comments element', async (t) => {
+  const xml = await parseXML(
+    '<rss version="2.0"><channel>' +
+      '<link>https://example.com</link>' +
+      '<item><title>x</title><link>https://example.com/1</link></item>' +
+      '</channel></rss>'
+  )
+  const site = parseRss('site', xml)
+  t.is(site?.entries[0].comments, undefined)
+  // And the key stays out of the stored JSON entirely.
+  t.false('comments' in JSON.parse(JSON.stringify(site?.entries[0])))
+})
+
+test('#parseRss resolves a relative comments url against the site link', async (t) => {
+  const xml = await parseXML(
+    '<rss version="2.0"><channel>' +
+      '<link>https://news.ycombinator.com/</link>' +
+      '<item><title>x</title><link>https://example.com/1</link>' +
+      '<comments>item?id=42</comments></item>' +
+      '</channel></rss>'
+  )
+  const site = parseRss('site', xml)
+  t.is(site?.entries[0].comments, 'https://news.ycombinator.com/item?id=42')
 })

--- a/action/feeds/parsers.ts
+++ b/action/feeds/parsers.ts
@@ -203,7 +203,9 @@ export function mapContentUrls(
 ) {
   return sanitizeHtml(content, {
     ...ENTRY_CONTENT_SANITIZE_OPTIONS,
-    ...(allowedTags ? { allowedTags } : {}),
+    // !== undefined, not truthiness: an empty array is a real tag set (strip
+    // every tag), not a request for the defaults.
+    ...(allowedTags !== undefined ? { allowedTags } : {}),
     transformTags: {
       '*': (tagName, attribs) => ({
         tagName,

--- a/action/feeds/parsers.ts
+++ b/action/feeds/parsers.ts
@@ -14,6 +14,10 @@ export interface Entry {
   date: number
   content: string
   author: string
+  // The RSS <comments> URL, when the feed offers one. Hacker News feeds link
+  // entries at the article and put the item page here, which is what the
+  // comment enrichment (action/feeds/hackernews.ts) keys on.
+  comments?: string
 }
 
 export interface Site {
@@ -106,7 +110,7 @@ function absolutizeEntryLink(rawLink: string, siteLink: string) {
  * Sharing a base also keeps the action in step with the reader, which can only
  * resolve against the entry link because stored Content carries no site link.
  */
-function resolveContentUrl(
+export function resolveContentUrl(
   url: string,
   target: UrlTarget,
   siteLink: string,
@@ -137,7 +141,25 @@ export const ENTRY_CONTENT_SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
     // Kept so the source of a quotation survives into the stored JSON, and
     // resolved like any other URL rather than left pointing at this site.
     blockquote: ['cite'],
-    q: ['cite']
+    q: ['cite'],
+    // The Hacker News discussion markup (action/feeds/hackernews.ts) styles
+    // the thread through classes. Every pass over stored content goes through
+    // these options, so class has to survive here or the media store's rewrite
+    // would strip it back off.
+    div: ['class'],
+    p: ['class']
+  },
+  // Only the classes the HN markup uses; a feed's own classes keep being
+  // discarded as before.
+  allowedClasses: {
+    div: [
+      'hn-story',
+      'hn-comments',
+      'hn-comment',
+      'hn-comment-body',
+      'hn-comment-children'
+    ],
+    p: ['hn-comment-meta', 'hn-more']
   },
   // Nothing beyond http(s) by default, so an attribute allowed later inherits
   // the safe set rather than data: or mailto:. Anything that needs more says so
@@ -256,7 +278,12 @@ export function parseRss(feedTitle: string, xml: any): Site {
               siteLink,
               entryLink
             ),
-            author: joinValuesOrEmptyString(item['dc:creator'])
+            author: joinValuesOrEmptyString(item['dc:creator']),
+            comments:
+              absolutizeEntryLink(
+                joinValuesOrEmptyString(item.comments),
+                siteLink
+              ) || undefined
           }
         })) ||
       []

--- a/action/feeds/parsers.ts
+++ b/action/feeds/parsers.ts
@@ -16,7 +16,9 @@ export interface Entry {
   author: string
   // The RSS <comments> URL, when the feed offers one. Hacker News feeds link
   // entries at the article and put the item page here, which is what the
-  // comment enrichment (action/feeds/hackernews.ts) keys on.
+  // comment enrichment (action/feeds/hackernews.ts) keys on. Build-time-only
+  // data: files storage persists it in the entry JSON, sqlite drops it (no
+  // column), and nothing reads it back either way.
   comments?: string
 }
 
@@ -189,13 +191,19 @@ export const ENTRY_CONTENT_SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
  * Every tag is visited rather than img and a alone, so a relative URL is
  * resolved wherever it hides. Schemes are filtered after this runs, so a
  * javascript: href is still dropped even though it is resolved here.
+ *
+ * A caller that generates content rather than reading a feed can narrow the
+ * tag set -- the Hacker News enrichment drops img, since comment HTML is
+ * written by arbitrary internet users and must never reach the media store.
  */
 export function mapContentUrls(
   content: string,
-  mapUrl: (url: string, target: UrlTarget) => string
+  mapUrl: (url: string, target: UrlTarget) => string,
+  allowedTags?: string[]
 ) {
   return sanitizeHtml(content, {
     ...ENTRY_CONTENT_SANITIZE_OPTIONS,
+    ...(allowedTags ? { allowedTags } : {}),
     transformTags: {
       '*': (tagName, attribs) => ({
         tagName,

--- a/app/globals.css
+++ b/app/globals.css
@@ -448,4 +448,29 @@
     color: var(--text-primary);
     font-weight: 600;
   }
+
+  /* Hacker News discussions baked into an entry at build time. The feed's own
+     "Comments" link stays on top; this is the thread below it. */
+  .feeds-prose .hn-comments {
+    margin-top: 1.6em;
+    padding-top: 0.4em;
+    border-top: 1px solid var(--border);
+  }
+
+  .feeds-prose .hn-comment {
+    margin: 1.1em 0;
+  }
+
+  .feeds-prose .hn-comment-meta {
+    margin: 0 0 0.35em;
+    color: var(--text-muted);
+    font-size: 0.8125rem;
+  }
+
+  .feeds-prose .hn-comment-children {
+    margin-top: 0.6em;
+    margin-left: 0.6em;
+    padding-left: 0.9em;
+    border-left: 2px solid var(--border);
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feeds-fetcher",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "description": "Websites feed fetcher and static feeds aggregator",
   "main": "index.js",
   "type": "module",

--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,10 @@ Images that cannot be downloaded keep their original URL and are rendered with `
 
 Each run restores the media files of the published branch before downloading, so only images that have not been seen before are fetched, and files no longer referenced by any entry are removed. Schedule only one run at a time (a workflow `concurrency` group) because the publish step force pushes the whole site.
 
+## Hacker News comments
+
+Hacker News feeds (the official RSS, hnrss, or any mirror) publish entries whose content is only a "Comments" link. For those entries the action fetches the discussion from the HN Algolia API and appends it to the entry, so the reader shows the story text and the top 20 comments, nested 3 levels deep, right below the link. Threads cut short by those caps end with a link to the full discussion on Hacker News, and an entry whose discussion cannot be fetched keeps its original content.
+
 ## Configurations
 
 This action can be configured to use a custom domain and different types of storage. Here are the available configuration options:


### PR DESCRIPTION
## What

Hacker News feeds (the official RSS, hnrss, mirrors) publish entries whose entire content is a **Comments** link, so the reader has nothing to show. This bakes the actual discussion into the entry while the action builds the site:

- **Detection** — `parseRss` now carries the RSS `<comments>` element on the entry (both the official HN RSS and hnrss put the item page there; the entry link is the article). Entries that link directly to the item page are also caught, as a fallback.
- **Fetching** — one request per entry to the HN Algolia API (`/api/v1/items/:id`), which returns the whole comment tree; the Firebase API would take one request per comment. Sequential, 10s timeout, and a failed fetch just keeps the original content — the build never breaks over it.
- **Rendering** — the feed's **Comments link stays at the top**; below it the story text (Ask HN self-posts) and the **top 20 comments, nested 3 levels deep**, with author profile links and date permalinks, ending in a "More comments on Hacker News" link when the caps cut the thread. Dead/deleted comments are skipped.
- **Sanitization** — the generated markup goes through the same `mapContentUrls` pass as feed content (relative comment links resolve against the item page, not the article). `class` is now allowed on `div`/`p`, restricted via `allowedClasses` to the `hn-*` classes, so the thread markup survives both the enrichment pass and the media store's rewrite; feed content classes keep being discarded.
- **Reader** — no component changes; a few `feeds-prose` rules style the thread (indent border for replies, muted meta line).

Verified end to end against the live HN RSS + Algolia API, and covered by 13 new tests (detection, caps, nesting, sanitization, escaping, failure fallback, class survival through the media rewrite pass). Full suite: 165 passing.

## Notes

- The enrichment runs inside `createLocalizingFeedLoader`, so both `files` and `sqlite` storage get it.
- Comments are a build-time snapshot, refreshed on every scheduled run — same freshness model as the feeds themselves.