### PR TITLE
Show the item list when re-selecting the current category or site

### DIFF
--- a/lib/page.tsx
+++ b/lib/page.tsx
@@ -172,10 +172,15 @@ export const Page: FC<PageProps> = ({ version, buildTime }) => {
             buildTime={buildTime}
             selectCategory={(category: string) => {
               setListTitle(category)
+              // The reducer bails out on a same-path dispatch, so
+              // locationController won't run; switch the mobile panel here so
+              // re-selecting the current category still shows the list
+              setPageState('entries')
               dispatch(updatePath(`/categories/${category}`))
             }}
             selectSite={(siteKey: string, siteTitle: string) => {
               setListTitle(siteTitle)
+              setPageState('entries')
               dispatch(updatePath(`/sites/${siteKey}`))
             }}
           />

--- a/lib/reducers/path.test.ts
+++ b/lib/reducers/path.test.ts
@@ -1,0 +1,22 @@
+import test from 'ava'
+import { PathReducer, updatePath } from './path'
+import { parseLocation } from '../utils'
+
+test('#PathReducer returns the same state for the current path', (t) => {
+  const state = {
+    pathname: '/sites/all',
+    location: parseLocation('/sites/all')
+  }
+  t.is(PathReducer(state, updatePath('/sites/all')), state)
+})
+
+test('#PathReducer returns new state with parsed location', (t) => {
+  const state = {
+    pathname: '/sites/all',
+    location: parseLocation('/sites/all')
+  }
+  t.deepEqual(PathReducer(state, updatePath('/categories/Apple')), {
+    pathname: '/categories/Apple',
+    location: parseLocation('/categories/Apple')
+  })
+})

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feeds-fetcher",
-  "version": "4.3.2",
+  "version": "4.3.3",
   "description": "Websites feed fetcher and static feeds aggregator",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
## Problem

On mobile the layout shows one panel at a time, driven by `pageState` in `lib/page.tsx`. Re-tapping the category, site, or **All Items** that was *already* selected left the navigation list on screen instead of showing the item list. Only tapping a *different* target worked.

## Root cause

The item list's mobile back button sets `pageState` to `'categories'` **without changing the path**, so the URL state stays at e.g. `/sites/all` while the nav panel is showing. Re-tapping that same entry then dispatches a same-path update, and `PathReducer` returns the *same state reference* for a same-path dispatch (an intentional guard from b0ca806 that keeps `history.pushState` from recording duplicate entries). React bails out of the update, so the effect that calls `locationController` — the only place that sets `pageState` back to `'entries'` — never re-runs.

## Fix

Set `pageState` directly in the two `CategoryList` handlers, which cover all three entry points (All Items, category rows, and site rows all route through `selectCategory`/`selectSite`).

`setContent(null)` is deliberately not added: on a changed path `locationController` already clears content, and adding it here would only risk blanking the desktop article pane.

The same-path dispatch stays a no-op, so no duplicate history entry is pushed, and desktop is unaffected because all three panels are visible at `md` and above regardless of `pageState`.

## Verification

Ran against a local dev server at a 375x812 viewport, measuring actual panel visibility and `history.length`:

- Re-selecting **All Items**, a **category**, and a **site** each now show the item list; each adds **0** history entries.
- Control check with the fix reverted reproduced the bug (panel stayed on `categories`), confirming this change is what fixes it.
- Real navigations still add exactly one history entry each, and browser back/forward walk the visited paths correctly.
- Article round trip (entry → article → back → list → back → nav → re-select) behaves correctly.
- At 1280x800 all three panels stay at their normal widths across a re-selection.

Added `lib/reducers/path.test.ts` covering the reducer's same-path bailout, which is the invariant this fix depends on. `yarn test` passes apart from the pre-existing `action/repository.test.ts` failure that always occurs in a git worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)