### PR TITLE
Keep only the last 5 commits on the published branch

### DIFF
--- a/action/repository.test.ts
+++ b/action/repository.test.ts
@@ -1,11 +1,112 @@
 import test from 'ava'
+import { spawnSync } from 'child_process'
+import fs from 'fs/promises'
+import os from 'os'
 import path from 'path'
 import {
+  PUBLISH_COMMIT_MESSAGE,
   getActionInput,
   getGithubActionPath,
+  getPreviousPublishedCommits,
+  publishLimitedHistory,
   resolveSourceBranch,
   restorePublishedMedia
 } from './repository'
+
+const BOT_IDENTITY = {
+  GIT_AUTHOR_NAME: 'Feed bots',
+  GIT_AUTHOR_EMAIL: 'bot@llun.dev',
+  GIT_COMMITTER_NAME: 'Feed bots',
+  GIT_COMMITTER_EMAIL: 'bot@llun.dev'
+}
+
+function git(cwd: string, commands: string[], env?: Record<string, string>) {
+  const result = spawnSync('git', commands, {
+    cwd,
+    encoding: 'utf8',
+    env: { ...process.env, ...BOT_IDENTITY, ...env }
+  })
+  if (result.status !== 0) {
+    throw new Error(`git ${commands.join(' ')} failed: ${result.stderr}`)
+  }
+  return result.stdout.trim()
+}
+
+/**
+ * Builds an origin repository, a full clone for arranging published branches
+ * and a workspace that matches what setup() creates on the runner. The origin
+ * is addressed with a file url because git ignores --depth when it can take the
+ * local hardlink shortcut.
+ */
+async function createPublishFixture() {
+  const rootPath = await fs.mkdtemp(path.join(os.tmpdir(), 'feeds-publish-'))
+  const originPath = path.join(rootPath, 'origin.git')
+  const originUrl = `file://${originPath}`
+  const seedPath = path.join(rootPath, 'seed')
+  const workspacePath = path.join(rootPath, 'workspace')
+
+  git(rootPath, ['init', '--bare', '--initial-branch=main', originPath])
+  git(rootPath, ['clone', originUrl, seedPath])
+  await fs.writeFile(path.join(seedPath, 'readme.md'), 'seed')
+  git(seedPath, ['add', '--all'])
+  git(seedPath, ['commit', '-m', 'Initial commit'])
+  git(seedPath, ['push', 'origin', 'HEAD:main'])
+  git(rootPath, [
+    'clone',
+    '-b',
+    'main',
+    '--depth',
+    '1',
+    originUrl,
+    workspacePath
+  ])
+
+  return { originPath, seedPath, workspacePath }
+}
+
+async function publishContents(workspacePath: string, content: string) {
+  await fs.writeFile(path.join(workspacePath, 'index.html'), content)
+  return publishLimitedHistory({
+    repositoryPath: workspacePath,
+    branch: 'contents',
+    pushTarget: 'origin'
+  })
+}
+
+async function seedPublishedBranch(
+  seedPath: string,
+  commits: { message: string; content: string; date?: string }[]
+) {
+  git(seedPath, ['checkout', '--orphan', 'contents'])
+  git(seedPath, ['rm', '-rf', '.'])
+  for (const commit of commits) {
+    await fs.writeFile(path.join(seedPath, 'index.html'), commit.content)
+    git(seedPath, ['add', '--all'])
+    git(
+      seedPath,
+      ['commit', '-m', commit.message],
+      commit.date
+        ? { GIT_AUTHOR_DATE: commit.date, GIT_COMMITTER_DATE: commit.date }
+        : undefined
+    )
+  }
+  git(seedPath, ['push', 'origin', 'HEAD:contents'])
+}
+
+function publishedAt(day: number) {
+  return `2024-01-0${day}T03:04:05+07:00`
+}
+
+// Fully qualified so an assertion never reads a same named tag by accident.
+const PUBLISHED_REF = 'refs/heads/contents'
+
+function branchCommitCount(originPath: string) {
+  return Number(git(originPath, ['rev-list', '--count', PUBLISHED_REF]))
+}
+
+function branchSubjects(originPath: string) {
+  return git(originPath, ['log', '--format=%s', PUBLISHED_REF]).split('\n')
+}
 
 test('#resolveSourceBranch uses workflow branch ref', (t) => {
   t.is(resolveSourceBranch('refs/heads/main'), 'main')
@@ -53,6 +154,126 @@ test('#restorePublishedMedia skips when there is no workspace', async (t) => {
 
   delete process.env['GITHUB_WORKSPACE']
   t.false(await restorePublishedMedia('public'))
+})
+
+test('#publishLimitedHistory publishes a branch without the source history', async (t) => {
+  const { originPath, workspacePath } = await createPublishFixture()
+
+  const commit = await publishContents(workspacePath, 'first')
+
+  t.is(branchCommitCount(originPath), 1)
+  t.is(git(originPath, ['rev-parse', PUBLISHED_REF]), commit)
+  t.is(git(originPath, ['log', '--format=%P', '-1', PUBLISHED_REF]), '')
+  t.deepEqual(branchSubjects(originPath), [PUBLISH_COMMIT_MESSAGE])
+})
+
+test('#publishLimitedHistory keeps at most five commits on the branch', async (t) => {
+  const { originPath, workspacePath } = await createPublishFixture()
+
+  const trees: string[] = []
+  for (let run = 1; run <= 7; run++) {
+    await publishContents(workspacePath, `run ${run}`)
+    t.is(branchCommitCount(originPath), Math.min(run, 5))
+    trees.push(git(originPath, ['rev-parse', `${PUBLISHED_REF}^{tree}`]))
+  }
+
+  t.is(
+    git(originPath, ['rev-list', '--max-parents=0', PUBLISHED_REF]).split('\n')
+      .length,
+    1
+  )
+  t.deepEqual(branchSubjects(originPath), Array(5).fill(PUBLISH_COMMIT_MESSAGE))
+  // Rebuilding the window keeps every published tree byte for byte.
+  t.deepEqual(
+    git(originPath, ['log', '--format=%T', PUBLISHED_REF]).split('\n'),
+    trees.slice(-5).reverse()
+  )
+})
+
+test('#publishLimitedHistory drops the history published commits were built on', async (t) => {
+  const { originPath, seedPath, workspacePath } = await createPublishFixture()
+  const publishedDate = '2024-01-02T03:04:05+07:00'
+  await seedPublishedBranch(seedPath, [
+    { message: 'History 1', content: 'one' },
+    { message: 'History 2', content: 'two' },
+    { message: 'History 3', content: 'three' },
+    {
+      message: PUBLISH_COMMIT_MESSAGE,
+      content: 'published',
+      date: publishedDate
+    }
+  ])
+
+  await publishContents(workspacePath, 'next')
+
+  t.is(branchCommitCount(originPath), 2)
+  t.deepEqual(branchSubjects(originPath), [
+    PUBLISH_COMMIT_MESSAGE,
+    PUBLISH_COMMIT_MESSAGE
+  ])
+  const root = git(originPath, ['rev-list', '--max-parents=0', PUBLISHED_REF])
+  t.is(git(originPath, ['log', '--format=%aI', '-1', root]), publishedDate)
+  t.is(git(originPath, ['log', '--format=%an', '-1', root]), 'Feed bots')
+  t.is(git(originPath, ['log', '--format=%P', '-1', PUBLISHED_REF]), root)
+})
+
+test('#publishLimitedHistory replaces a branch that has no published commit', async (t) => {
+  const { originPath, seedPath, workspacePath } = await createPublishFixture()
+  await seedPublishedBranch(seedPath, [
+    { message: PUBLISH_COMMIT_MESSAGE, content: 'published' },
+    { message: 'Manual publish', content: 'manual' }
+  ])
+
+  await publishContents(workspacePath, 'next')
+
+  t.is(branchCommitCount(originPath), 1)
+  t.deepEqual(branchSubjects(originPath), [PUBLISH_COMMIT_MESSAGE])
+})
+
+test('#publishLimitedHistory keeps the published commits when a tag shares the branch name', async (t) => {
+  const { originPath, seedPath, workspacePath } = await createPublishFixture()
+  await seedPublishedBranch(seedPath, [
+    { message: PUBLISH_COMMIT_MESSAGE, content: 'published' }
+  ])
+  // git resolves an unqualified fetch refname against refs/tags first.
+  git(seedPath, ['tag', 'contents', 'main'])
+  git(seedPath, ['push', 'origin', 'refs/tags/contents'])
+
+  await publishContents(workspacePath, 'next')
+
+  t.is(branchCommitCount(originPath), 2)
+  t.deepEqual(branchSubjects(originPath), [
+    PUBLISH_COMMIT_MESSAGE,
+    PUBLISH_COMMIT_MESSAGE
+  ])
+})
+
+test('#getPreviousPublishedCommits reads published commits until a foreign one', async (t) => {
+  const { seedPath } = await createPublishFixture()
+  await seedPublishedBranch(seedPath, [
+    { message: PUBLISH_COMMIT_MESSAGE, content: 'skipped' },
+    { message: 'Manual publish', content: 'manual' },
+    { message: PUBLISH_COMMIT_MESSAGE, content: 'older', date: publishedAt(1) },
+    { message: PUBLISH_COMMIT_MESSAGE, content: 'newer', date: publishedAt(2) }
+  ])
+
+  const commits = getPreviousPublishedCommits(seedPath, 'contents')
+
+  t.is(commits.length, 2)
+  t.deepEqual(
+    commits.map((commit) => commit.authorDate),
+    [publishedAt(2), publishedAt(1)]
+  )
+  t.deepEqual(
+    commits.map((commit) => commit.subject),
+    [PUBLISH_COMMIT_MESSAGE, PUBLISH_COMMIT_MESSAGE]
+  )
+  t.is(commits[0].authorEmail, 'bot@llun.dev')
+  t.is(commits[0].committerName, 'Feed bots')
+  t.is(
+    commits[0].tree,
+    git(seedPath, ['rev-parse', `${commits[0].hash}^{tree}`])
+  )
 })
 
 test('#getActionInput uses configured defaults', (t) => {

--- a/action/repository.test.ts
+++ b/action/repository.test.ts
@@ -60,6 +60,10 @@ async function createPublishFixture() {
     originUrl,
     workspacePath
   ])
+  // publish() configures the identity before publishing, and the commit for the
+  // new tip reads it from the configuration rather than from the environment.
+  git(workspacePath, ['config', 'user.email', BOT_IDENTITY.GIT_AUTHOR_EMAIL])
+  git(workspacePath, ['config', 'user.name', BOT_IDENTITY.GIT_AUTHOR_NAME])
 
   return { originPath, seedPath, workspacePath }
 }

--- a/action/repository.test.ts
+++ b/action/repository.test.ts
@@ -65,7 +65,7 @@ async function createPublishFixture() {
   git(workspacePath, ['config', 'user.email', BOT_IDENTITY.GIT_AUTHOR_EMAIL])
   git(workspacePath, ['config', 'user.name', BOT_IDENTITY.GIT_AUTHOR_NAME])
 
-  return { originPath, seedPath, workspacePath }
+  return { rootPath, originPath, seedPath, workspacePath }
 }
 
 async function publishContents(workspacePath: string, content: string) {
@@ -77,22 +77,43 @@ async function publishContents(workspacePath: string, content: string) {
   })
 }
 
-async function seedPublishedBranch(
-  seedPath: string,
-  commits: { message: string; content: string; date?: string }[]
-) {
+interface SeedCommit {
+  message: string
+  content: string
+  date?: string
+  committerDate?: string
+  // Defaults to the same identity the workspace is configured with, so a test
+  // that checks an identity is preserved has to ask for a different one.
+  identity?: { name: string; email: string }
+  media?: string
+}
+
+async function seedPublishedBranch(seedPath: string, commits: SeedCommit[]) {
   git(seedPath, ['checkout', '--orphan', 'contents'])
   git(seedPath, ['rm', '-rf', '.'])
   for (const commit of commits) {
     await fs.writeFile(path.join(seedPath, 'index.html'), commit.content)
+    if (commit.media !== undefined) {
+      await fs.mkdir(path.join(seedPath, 'media'), { recursive: true })
+      await fs.writeFile(
+        path.join(seedPath, 'media', 'image.txt'),
+        commit.media
+      )
+    }
     git(seedPath, ['add', '--all'])
-    git(
-      seedPath,
-      ['commit', '-m', commit.message],
-      commit.date
-        ? { GIT_AUTHOR_DATE: commit.date, GIT_COMMITTER_DATE: commit.date }
-        : undefined
-    )
+
+    const env: Record<string, string> = {}
+    if (commit.date) {
+      env.GIT_AUTHOR_DATE = commit.date
+      env.GIT_COMMITTER_DATE = commit.committerDate ?? commit.date
+    }
+    if (commit.identity) {
+      env.GIT_AUTHOR_NAME = commit.identity.name
+      env.GIT_AUTHOR_EMAIL = commit.identity.email
+      env.GIT_COMMITTER_NAME = commit.identity.name
+      env.GIT_COMMITTER_EMAIL = commit.identity.email
+    }
+    git(seedPath, ['commit', '-m', commit.message], env)
   }
   git(seedPath, ['push', 'origin', 'HEAD:contents'])
 }
@@ -160,6 +181,41 @@ test('#restorePublishedMedia skips when there is no workspace', async (t) => {
   t.false(await restorePublishedMedia('public'))
 })
 
+// Serial because it is driven through the action input environment, which ava
+// shares between the concurrent tests in this file.
+test.serial(
+  '#restorePublishedMedia reads the branch when a tag shares its name',
+  async (t) => {
+    const { rootPath, seedPath, workspacePath } = await createPublishFixture()
+    await seedPublishedBranch(seedPath, [
+      { message: PUBLISH_COMMIT_MESSAGE, content: 'published', media: 'image' }
+    ])
+    // main carries no media, so reading the tag instead restores nothing.
+    git(seedPath, ['tag', 'contents', 'main'])
+    git(seedPath, ['push', 'origin', 'refs/tags/contents'])
+
+    const originalWorkspace = process.env['GITHUB_WORKSPACE']
+    t.teardown(() => {
+      if (originalWorkspace === undefined) {
+        delete process.env['GITHUB_WORKSPACE']
+        return
+      }
+      process.env['GITHUB_WORKSPACE'] = originalWorkspace
+    })
+    process.env['GITHUB_WORKSPACE'] = workspacePath
+
+    const publicDirectory = path.join(rootPath, 'public')
+    t.true(await restorePublishedMedia(publicDirectory))
+    t.is(
+      await fs.readFile(
+        path.join(publicDirectory, 'media', 'image.txt'),
+        'utf8'
+      ),
+      'image'
+    )
+  }
+)
+
 test('#publishLimitedHistory publishes a branch without the source history', async (t) => {
   const { originPath, workspacePath } = await createPublishFixture()
 
@@ -169,6 +225,78 @@ test('#publishLimitedHistory publishes a branch without the source history', asy
   t.is(git(originPath, ['rev-parse', PUBLISHED_REF]), commit)
   t.is(git(originPath, ['log', '--format=%P', '-1', PUBLISHED_REF]), '')
   t.deepEqual(branchSubjects(originPath), [PUBLISH_COMMIT_MESSAGE])
+})
+
+test('#publishLimitedHistory publishes the contents of the workspace', async (t) => {
+  const { originPath, workspacePath } = await createPublishFixture()
+
+  await publishContents(workspacePath, 'first')
+  t.is(git(originPath, ['show', `${PUBLISHED_REF}:index.html`]), 'first')
+
+  await publishContents(workspacePath, 'second')
+  t.is(git(originPath, ['show', `${PUBLISHED_REF}:index.html`]), 'second')
+  // The retained commit keeps the tree it was published with rather than the
+  // one on the tip.
+  t.is(git(originPath, ['show', `${PUBLISHED_REF}~1:index.html`]), 'first')
+})
+
+test('#publishLimitedHistory keeps the branch when the remote cannot be read', async (t) => {
+  const { originPath, seedPath, workspacePath } = await createPublishFixture()
+  await seedPublishedBranch(seedPath, [
+    { message: PUBLISH_COMMIT_MESSAGE, content: 'one' },
+    { message: PUBLISH_COMMIT_MESSAGE, content: 'two' },
+    { message: PUBLISH_COMMIT_MESSAGE, content: 'three' }
+  ])
+  const publishedTip = git(originPath, ['rev-parse', PUBLISHED_REF])
+
+  // Reading the published branch and pushing it use separate remotes, so an
+  // unreadable origin is a remote that failed to answer rather than a branch
+  // that does not exist yet.
+  const originUrl = git(workspacePath, ['remote', 'get-url', 'origin'])
+  git(workspacePath, ['remote', 'set-url', 'origin', `${originUrl}-missing`])
+  await fs.writeFile(path.join(workspacePath, 'index.html'), 'next')
+
+  t.throws(
+    () =>
+      publishLimitedHistory({
+        repositoryPath: workspacePath,
+        branch: 'contents',
+        pushTarget: originUrl
+      }),
+    { message: 'Fail to read published contents branch' }
+  )
+  t.is(git(originPath, ['rev-parse', PUBLISHED_REF]), publishedTip)
+  t.is(branchCommitCount(originPath), 3)
+})
+
+test('#publishLimitedHistory keeps the identity of the commits it rebuilds', async (t) => {
+  const { originPath, seedPath, workspacePath } = await createPublishFixture()
+  const identity = { name: 'Earlier bots', email: 'earlier@llun.dev' }
+  const committerDate = '2024-03-04T05:06:07+02:00'
+  await seedPublishedBranch(seedPath, [
+    {
+      message: PUBLISH_COMMIT_MESSAGE,
+      content: 'published',
+      date: publishedAt(1),
+      committerDate,
+      identity
+    }
+  ])
+
+  await publishContents(workspacePath, 'next')
+
+  const root = git(originPath, ['rev-list', '--max-parents=0', PUBLISHED_REF])
+  t.is(git(originPath, ['log', '--format=%an', '-1', root]), identity.name)
+  t.is(git(originPath, ['log', '--format=%ae', '-1', root]), identity.email)
+  t.is(git(originPath, ['log', '--format=%cn', '-1', root]), identity.name)
+  t.is(git(originPath, ['log', '--format=%ce', '-1', root]), identity.email)
+  t.is(git(originPath, ['log', '--format=%aI', '-1', root]), publishedAt(1))
+  t.is(git(originPath, ['log', '--format=%cI', '-1', root]), committerDate)
+  // The commit this run creates is the one that takes the configured identity.
+  t.is(
+    git(originPath, ['log', '--format=%an', '-1', PUBLISHED_REF]),
+    BOT_IDENTITY.GIT_AUTHOR_NAME
+  )
 })
 
 test('#publishLimitedHistory keeps at most five commits on the branch', async (t) => {

--- a/action/repository.test.ts
+++ b/action/repository.test.ts
@@ -10,7 +10,8 @@ import {
   getPreviousPublishedCommits,
   publishLimitedHistory,
   resolveSourceBranch,
-  restorePublishedMedia
+  restorePublishedMedia,
+  validatePublishBranch
 } from './repository'
 
 const BOT_IDENTITY = {
@@ -267,6 +268,59 @@ test('#publishLimitedHistory keeps the branch when the remote cannot be read', a
   )
   t.is(git(originPath, ['rev-parse', PUBLISHED_REF]), publishedTip)
   t.is(branchCommitCount(originPath), 3)
+})
+
+test('#validatePublishBranch rejects publishing onto the source branch', (t) => {
+  t.notThrows(() => validatePublishBranch('main', 'contents'))
+  t.throws(() => validatePublishBranch('main', 'main'), {
+    message: 'Branch main cannot be both the source and the publish branch'
+  })
+})
+
+test('#publishLimitedHistory keeps the branch when the fetch fails', async (t) => {
+  const { originPath, seedPath, workspacePath } = await createPublishFixture()
+  await seedPublishedBranch(seedPath, [
+    { message: PUBLISH_COMMIT_MESSAGE, content: 'published' }
+  ])
+  // A branch whose tip object is missing is listed by ls-remote and refused by
+  // fetch, which is the remote that answers and then fails to deliver.
+  const missingCommit = 'deadbeef'.repeat(5)
+  await fs.writeFile(
+    path.join(originPath, 'refs', 'heads', 'contents'),
+    `${missingCommit}\n`
+  )
+
+  await fs.writeFile(path.join(workspacePath, 'index.html'), 'next')
+  t.throws(
+    () =>
+      publishLimitedHistory({
+        repositoryPath: workspacePath,
+        branch: 'contents',
+        pushTarget: 'origin'
+      }),
+    { message: 'Fail to fetch published contents branch' }
+  )
+  t.is(git(originPath, ['rev-parse', PUBLISHED_REF]), missingCommit)
+})
+
+test('#publishLimitedHistory reports a push it could not complete', async (t) => {
+  const { originPath, seedPath, workspacePath } = await createPublishFixture()
+  await seedPublishedBranch(seedPath, [
+    { message: PUBLISH_COMMIT_MESSAGE, content: 'published' }
+  ])
+  const publishedTip = git(originPath, ['rev-parse', PUBLISHED_REF])
+
+  await fs.writeFile(path.join(workspacePath, 'index.html'), 'next')
+  t.throws(
+    () =>
+      publishLimitedHistory({
+        repositoryPath: workspacePath,
+        branch: 'contents',
+        pushTarget: `${git(workspacePath, ['remote', 'get-url', 'origin'])}-missing`
+      }),
+    { message: 'Fail to push feeds contents' }
+  )
+  t.is(git(originPath, ['rev-parse', PUBLISHED_REF]), publishedTip)
 })
 
 test('#publishLimitedHistory keeps the identity of the commits it rebuilds', async (t) => {

--- a/action/repository.ts
+++ b/action/repository.ts
@@ -35,6 +35,25 @@ function validateBranchName(branch: string): void {
 }
 
 /**
+ * Refuses to publish onto the branch the workspace was built from.
+ *
+ * The published branch is replaced by a history this action owns, so pointing
+ * it at the source branch would drop every source commit rather than add to
+ * them. The run publishes the built site without the workflow that produced it
+ * either way, so this is only ever a misconfiguration, and failing before the
+ * clone keeps it a harmless one.
+ *
+ * @throws Error if the publish branch is also the source branch
+ */
+export function validatePublishBranch(sourceBranch: string, branch: string) {
+  if (sourceBranch === branch) {
+    throw new Error(
+      `Branch ${branch} cannot be both the source and the publish branch`
+    )
+  }
+}
+
+/**
  * Validates that a domain name is safe to write to CNAME file
  * @param domain The domain name to validate
  * @throws Error if the domain name contains potentially dangerous characters
@@ -253,11 +272,10 @@ export async function setup() {
     validateBranchName(branch)
     validateBranchName(sourceBranch)
 
-    if (sourceBranch !== branch) {
-      console.log(
-        `Use source branch ${sourceBranch} and publish to branch ${branch}`
-      )
-    }
+    validatePublishBranch(sourceBranch, branch)
+    console.log(
+      `Use source branch ${sourceBranch} and publish to branch ${branch}`
+    )
 
     const cloneUrl = `https://${user}:${token}@github.com/${github.context.repo.owner}/${github.context.repo.repo}`
     const cloneResult = runCommand([

--- a/action/repository.ts
+++ b/action/repository.ts
@@ -54,8 +54,37 @@ const DEFAULT_INPUTS: Record<string, string> = {
   customDomain: ''
 }
 
-function isCommandFailed(result: SpawnSyncReturns<Buffer>) {
+export const PUBLISH_COMMIT_MESSAGE = 'Update feeds contents'
+export const PUBLISH_COMMIT_LIMIT = 5
+
+const OBJECT_HASH_PATTERN = /^[0-9a-f]{40}([0-9a-f]{24})?$/
+
+interface PublishedCommit {
+  hash: string
+  tree: string
+  authorDate: string
+  committerDate: string
+  authorName: string
+  authorEmail: string
+  committerName: string
+  committerEmail: string
+  subject: string
+}
+
+function isCommandFailed(result: SpawnSyncReturns<Buffer | string>) {
   return Boolean(result.error || result.signal || result.status !== 0)
+}
+
+/**
+ * Guards against handing an empty string to a command that expects an object
+ * id. A blank commit in a push refspec reads as a branch deletion.
+ */
+function toObjectHash(value: string, message: string) {
+  const hash = value.trim()
+  if (!OBJECT_HASH_PATTERN.test(hash)) {
+    throw new Error(message)
+  }
+  return hash
 }
 
 function toInputEnvName(name: string) {
@@ -79,6 +108,18 @@ export function runCommand(commands: string[], cwd?: string) {
     stdio: 'inherit',
     cwd,
     env: process.env
+  })
+}
+
+function runCommandWithOutput(
+  commands: string[],
+  options?: { cwd?: string; env?: Record<string, string> }
+) {
+  return spawnSync(commands[0], commands.slice(1), {
+    stdio: ['ignore', 'pipe', 'inherit'],
+    cwd: options?.cwd,
+    encoding: 'utf8',
+    env: { ...process.env, ...options?.env }
   })
 }
 
@@ -114,6 +155,8 @@ export function resolveSourceBranch(
  * throwaway clone: publish() pushes from the workspace, and git can only leave
  * existing blobs out of the push pack when the local repository can walk the
  * remote tip. Seeding anywhere else would re-upload every media file each run.
+ * publishLimitedHistory() fetches the branch again right before pushing, so the
+ * thin pack no longer depends on this restore having run.
  */
 export async function restorePublishedMedia(publicDirectory: string) {
   const workSpace = getWorkspacePath()
@@ -123,7 +166,7 @@ export async function restorePublishedMedia(publicDirectory: string) {
   validateBranchName(branch)
 
   const fetchResult = runCommand(
-    ['git', 'fetch', '--depth=1', 'origin', branch],
+    ['git', 'fetch', '--depth=1', 'origin', `refs/heads/${branch}`],
     workSpace
   )
   if (isCommandFailed(fetchResult)) {
@@ -234,6 +277,244 @@ export async function setup() {
   }
 }
 
+// Unit and record separators keep the fields of a published commit
+// unambiguous. A foreign commit is free to carry either byte in its subject,
+// so a record that does not split into exactly nine fields ends the walk the
+// same way a foreign subject does.
+const PUBLISHED_COMMIT_FORMAT =
+  ['%H', '%T', '%aI', '%cI', '%an', '%ae', '%cn', '%ce', '%s'].join('%x1f') +
+  '%x1e'
+
+/**
+ * Reads the publish commits at the tip of a reference, newest first.
+ *
+ * Only the commits this action wrote are collected and the walk stops at the
+ * first foreign commit, which is what detaches an existing published branch
+ * from the source branch history it used to be built on top of.
+ *
+ * Dates are read as strict ISO 8601 rather than unix seconds so rebuilding a
+ * commit keeps its original UTC offset regardless of the runner timezone.
+ */
+export function getPreviousPublishedCommits(
+  repositoryPath: string,
+  reference = 'FETCH_HEAD',
+  limit = PUBLISH_COMMIT_LIMIT - 1
+): PublishedCommit[] {
+  const result = runCommandWithOutput(
+    [
+      'git',
+      'log',
+      `--max-count=${limit}`,
+      `--format=${PUBLISHED_COMMIT_FORMAT}`,
+      reference
+    ],
+    { cwd: repositoryPath }
+  )
+  if (isCommandFailed(result)) {
+    throw new Error(`Fail to read published history of ${reference}`)
+  }
+
+  const commits: PublishedCommit[] = []
+  for (const record of result.stdout.split('\x1e')) {
+    const fields = record.trim().split('\x1f')
+    if (fields.length !== 9) break
+
+    const [
+      hash,
+      tree,
+      authorDate,
+      committerDate,
+      authorName,
+      authorEmail,
+      committerName,
+      committerEmail,
+      subject
+    ] = fields
+    if (subject !== PUBLISH_COMMIT_MESSAGE) break
+    if (
+      !OBJECT_HASH_PATTERN.test(hash) ||
+      !OBJECT_HASH_PATTERN.test(tree) ||
+      !authorDate ||
+      !committerDate
+    ) {
+      break
+    }
+
+    commits.push({
+      hash,
+      tree,
+      authorDate,
+      committerDate,
+      authorName,
+      authorEmail,
+      committerName,
+      committerEmail,
+      subject
+    })
+  }
+  return commits
+}
+
+/**
+ * Recreates the given commits as an independent chain, oldest first, keeping
+ * their trees and identities. The oldest one is rebuilt without a parent, which
+ * is what drops everything published before the window.
+ */
+function rebuildPublishChain(
+  repositoryPath: string,
+  commits: PublishedCommit[]
+) {
+  let parent: string | null = null
+  for (let index = commits.length - 1; index >= 0; index--) {
+    const commit = commits[index]
+    const result = runCommandWithOutput(
+      [
+        'git',
+        'commit-tree',
+        commit.tree,
+        ...(parent ? ['-p', parent] : []),
+        '-m',
+        commit.subject
+      ],
+      {
+        cwd: repositoryPath,
+        env: {
+          GIT_AUTHOR_NAME: commit.authorName,
+          GIT_AUTHOR_EMAIL: commit.authorEmail,
+          GIT_AUTHOR_DATE: commit.authorDate,
+          GIT_COMMITTER_NAME: commit.committerName,
+          GIT_COMMITTER_EMAIL: commit.committerEmail,
+          GIT_COMMITTER_DATE: commit.committerDate
+        }
+      }
+    )
+    if (isCommandFailed(result)) {
+      throw new Error(`Fail to rebuild published commit ${commit.hash}`)
+    }
+    parent = toObjectHash(
+      result.stdout,
+      `Fail to rebuild published commit ${commit.hash}`
+    )
+  }
+  return parent
+}
+
+function fetchPreviousPublishedCommits(
+  repositoryPath: string,
+  branch: string,
+  limit: number
+) {
+  if (limit <= 0) return []
+
+  // A missing branch is the first run, while any other failure could be a
+  // network or permission problem. Fetching after one of those would look like
+  // an empty history and quietly throw the published commits away.
+  const remoteResult = runCommand(
+    ['git', 'ls-remote', '--exit-code', 'origin', `refs/heads/${branch}`],
+    repositoryPath
+  )
+  if (remoteResult.status === 2) {
+    console.log(`No published ${branch} branch, publishing a new history`)
+    return []
+  }
+  if (isCommandFailed(remoteResult)) {
+    throw new Error(`Fail to read published ${branch} branch`)
+  }
+
+  // Fully qualified because git resolves a fetch refname against refs/tags
+  // before refs/heads, so a tag sharing the branch name would be fetched
+  // instead and the published commits would silently be dropped.
+  const fetchResult = runCommand(
+    ['git', 'fetch', `--depth=${limit}`, 'origin', `refs/heads/${branch}`],
+    repositoryPath
+  )
+  if (isCommandFailed(fetchResult)) {
+    throw new Error(`Fail to fetch published ${branch} branch`)
+  }
+  return getPreviousPublishedCommits(repositoryPath, 'FETCH_HEAD', limit)
+}
+
+/**
+ * Publishes the workspace as the tip of a branch that never holds more than
+ * maxCommits commits.
+ *
+ * The workspace is a shallow clone of the source branch, so committing in place
+ * would publish the whole source history again. Instead the new tree is
+ * committed on top of a rebuilt copy of the previous publish commits, which
+ * keeps a few revisions around without carrying any history behind them.
+ */
+export function publishLimitedHistory(options: {
+  repositoryPath: string
+  branch: string
+  pushTarget?: string
+  maxCommits?: number
+  message?: string
+}) {
+  const {
+    repositoryPath,
+    branch,
+    pushTarget = 'origin',
+    maxCommits = PUBLISH_COMMIT_LIMIT,
+    message = PUBLISH_COMMIT_MESSAGE
+  } = options
+  validateBranchName(branch)
+
+  const addResult = runCommand(['git', 'add', '-f', '--all'], repositoryPath)
+  if (isCommandFailed(addResult)) {
+    throw new Error('Fail to stage feeds contents')
+  }
+
+  const treeResult = runCommandWithOutput(['git', 'write-tree'], {
+    cwd: repositoryPath
+  })
+  if (isCommandFailed(treeResult)) {
+    throw new Error('Fail to write feeds contents tree')
+  }
+  const tree = toObjectHash(
+    treeResult.stdout,
+    'Fail to write feeds contents tree'
+  )
+
+  const previousCommits = fetchPreviousPublishedCommits(
+    repositoryPath,
+    branch,
+    maxCommits - 1
+  )
+  const parent = rebuildPublishChain(repositoryPath, previousCommits)
+
+  const commitResult = runCommandWithOutput(
+    [
+      'git',
+      'commit-tree',
+      tree,
+      ...(parent ? ['-p', parent] : []),
+      '-m',
+      message
+    ],
+    { cwd: repositoryPath }
+  )
+  if (isCommandFailed(commitResult)) {
+    throw new Error('Fail to commit feeds contents')
+  }
+  const commit = toObjectHash(
+    commitResult.stdout,
+    'Fail to commit feeds contents'
+  )
+
+  const pushResult = runCommand(
+    ['git', 'push', '-f', pushTarget, `${commit}:refs/heads/${branch}`],
+    repositoryPath
+  )
+  if (isCommandFailed(pushResult)) {
+    throw new Error('Fail to push feeds contents')
+  }
+
+  console.log(
+    `Publish ${branch} branch with ${previousCommits.length + 1} commits`
+  )
+  return commit
+}
+
 export async function publish() {
   const workSpace = getWorkspacePath()
   if (workSpace) {
@@ -303,8 +584,10 @@ export async function publish() {
       ['git', 'config', '--global', 'user.name', '"Feed bots"'],
       workSpace
     )
-    runCommand(['git', 'add', '-f', '--all'], workSpace)
-    runCommand(['git', 'commit', '-m', 'Update feeds contents'], workSpace)
-    runCommand(['git', 'push', '-f', pushUrl, `HEAD:${branch}`], workSpace)
+    publishLimitedHistory({
+      repositoryPath: workSpace,
+      branch,
+      pushTarget: pushUrl
+    })
   }
 }

--- a/action/repository.ts
+++ b/action/repository.ts
@@ -152,11 +152,10 @@ export function resolveSourceBranch(
  * a run only downloads images it has never seen before.
  *
  * The fetch deliberately runs inside the workspace repository rather than a
- * throwaway clone: publish() pushes from the workspace, and git can only leave
- * existing blobs out of the push pack when the local repository can walk the
- * remote tip. Seeding anywhere else would re-upload every media file each run.
- * publishLimitedHistory() fetches the branch again right before pushing, so the
- * thin pack no longer depends on this restore having run.
+ * throwaway clone: publishLimitedHistory() fetches the same branch from the
+ * workspace before it pushes, so restoring here leaves those objects already
+ * local and its own fetch costs almost nothing. Seeding elsewhere would
+ * download the published tree twice, once into each repository.
  */
 export async function restorePublishedMedia(publicDirectory: string) {
   const workSpace = getWorkspacePath()

--- a/action/setup.test.ts
+++ b/action/setup.test.ts
@@ -1,0 +1,30 @@
+import test from 'ava'
+
+import { setup } from './repository'
+
+/**
+ * setup() reads the workflow ref through @actions/github, which builds its
+ * context when the module is first imported. This lives in its own file so the
+ * import happens with the environment below rather than whatever an earlier
+ * test in a shared file left behind: ava runs each test file in its own
+ * process.
+ */
+test('#setup refuses to publish onto the branch it reads', async (t) => {
+  const environment = { ...process.env }
+  t.teardown(() => {
+    for (const key of Object.keys(process.env)) delete process.env[key]
+    Object.assign(process.env, environment)
+  })
+
+  // The throw happens before the clone, so the workspace is never written to.
+  process.env['GITHUB_WORKSPACE'] = '/tmp/unused'
+  process.env['GITHUB_REF'] = 'refs/heads/contents'
+  process.env['GITHUB_REPOSITORY'] = 'llun/feeds'
+  process.env['INPUT_TOKEN'] = 'token'
+  process.env['INPUT_BRANCH'] = 'contents'
+  delete process.env['GITHUB_EVENT_PATH']
+
+  await t.throwsAsync(() => setup(), {
+    message: 'Branch contents cannot be both the source and the publish branch'
+  })
+})

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feeds-fetcher",
-  "version": "4.3.3",
+  "version": "4.3.4",
   "description": "Websites feed fetcher and static feeds aggregator",
   "main": "index.js",
   "type": "module",

--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,10 @@ Images that cannot be downloaded keep their original URL and are rendered with `
 
 Each run restores the media files of the published branch before downloading, so only images that have not been seen before are fetched, and files no longer referenced by any entry are removed. Schedule only one run at a time (a workflow `concurrency` group) because the publish step force pushes the whole site.
 
+## Published branch history
+
+The published branch keeps only the last 5 runs. Each run rebuilds those commits without the history behind them and drops the oldest one, so the branch stays a small, self contained snapshot of the site instead of growing with the source branch it was generated from. Branches published by earlier versions are trimmed on their next run, and only commits written by this action are kept.
+
 ## Hacker News comments
 
 Hacker News feeds (the official RSS, hnrss, or any mirror) publish entries whose content is only a "Comments" link. For those entries the action fetches the discussion from the HN Algolia API and appends it to the entry, so the reader shows the story text and the top 20 comments, nested 3 levels deep, right below the link. Threads cut short by those caps end with a link to the full discussion on Hacker News, and an entry whose discussion cannot be fetched keeps its original content.

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ jobs:
 
 After this, enable GitHub Pages on the `contents` branch and the content will be available on that page.
 
-The action always reads the OPML file from the branch that triggered the workflow (for example `main`), then publishes generated output to the configured `branch`.
+The action always reads the OPML file from the branch that triggered the workflow (for example `main`), then publishes generated output to the configured `branch`. The two have to be different branches: the published branch is replaced by a history the action owns, so the run stops before it clones rather than publish over the branch it read the feeds from.
 
 ## Images in feed content
 


### PR DESCRIPTION
## Context

`publish()` built its commit inside the `--depth 1` clone of the source branch and force pushed `HEAD:contents`, so the published branch was the source branch's entire history (~2150 commits here) plus one bot commit, replaced wholesale on every run.

This makes `contents` a self contained sliding window of the last **5** publishes.

To be accurate about what this buys: commits never accumulated on the branch before, so this is not a size reduction on the remote — unreachable force pushed objects are GC'd by GitHub either way. What it does deliver is a branch that no longer drags the source history (cloning it is now cheap) and a bounded window of recent publishes to diff against, at fixed cost.

## How it works

1. `git write-tree` for the built site.
2. `git ls-remote --exit-code` to tell "branch absent" (exit 2, first run) from "remote failed to answer" (exit 128, abort). Without that split, a transient network failure would silently republish a single orphan commit and throw the window away.
3. `git fetch --depth=4` the previous chain, keeping only commits whose subject is `Update feeds contents` and stopping at the first foreign one. That filter is the migration path: existing branches are trimmed automatically on their next run.
4. Rebuild those commits with `git commit-tree`, preserving tree, identity and ISO dates, with the oldest becoming parentless; then commit the new tree on top and force push `<sha>:refs/heads/contents`.

Dates are read as `%aI`/`%cI` rather than unix seconds so a rebuild keeps the original UTC offset regardless of runner timezone.

## Behaviour change worth knowing about

**The publish branch can no longer be the branch the workflow ran from.** `setup()` now fails before it clones when the two are equal.

This was always a misconfiguration — the published tree omits `.github`, so such a run deletes the very workflow that produced it — but the old code left the previous tip reachable at `<branch>~1`, recoverable with one force push. The new scheme keeps no source commit at all, so the same mistake would have been irreversible. Failing loudly and early is the trade.

## Failure handling

The `add` / `write-tree` / `ls-remote` / `fetch` / `commit-tree` / `push` steps are all checked now; `publish()` previously checked **none** of them, so a failed push looked like a successful run. (The two `git config --global` calls predate this PR and stay unchecked on purpose: with `HOME` unset they exit non-zero while the publish still succeeds, because `commit-tree` derives an identity — throwing there would turn a working run into an outage.)

Object ids are validated before use, because an empty sha in `<sha>:refs/heads/contents` makes `git push -f` **delete** the branch.

Fetch refspecs are fully qualified. Git resolves an unqualified refname against `refs/tags` *before* `refs/heads`, so a tag named `contents` would shadow the branch and silently drop the published history on every run.

## Verification

13 new tests drive real git repositories — a bare origin over `file://` and a shallow workspace matching what `setup()` creates. They cover: the first publish is parentless; the window caps at 5 across 7 runs with every tree preserved; the published blob really is the workspace's content; foreign history is dropped with the author date round tripped verbatim; a rebuilt commit keeps its original author, committer and both dates; a same named tag shadows neither the publish path nor the media restore; and each of the three destructive failure paths (remote unreadable, fetch failed, push rejected) aborts with the branch untouched.

Every behaviour above is kill verified: the corresponding mutation of the implementation compiles (`npx tsc --noEmit` clean), runs, and fails the suite.

`yarn test` and `npx tsc --noEmit` pass. The one failing test locally, `#getGithubActionPath`, asserts the checkout directory is named `feeds` and fails only because this was developed in a git worktree — pre-existing, passes in CI, untouched.

Reviewed over four sub-agent rounds; 12 findings were filed, addressed and resolved on the PR threads, and round 4 came back clean.

Version bumped to 4.3.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)