### PR TITLE
Strip the duplicated header from Blognone entries

### DIFF
--- a/action/feeds/blognone.test.ts
+++ b/action/feeds/blognone.test.ts
@@ -1,0 +1,134 @@
+import test from 'ava'
+import fs from 'fs'
+import path from 'path'
+import sanitizeHtml from 'sanitize-html'
+import { fileURLToPath } from 'url'
+
+import { isBlognoneEntry, stripBlognoneChrome } from './blognone'
+import { ENTRY_CONTENT_SANITIZE_OPTIONS, parseRss, parseXML } from './parsers'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+const TITLE = 'SpaceX ซื้อกิจการ Cursor เสร็จสิ้นทุกขั้นตอนแล้ว'
+
+// The description of a Blognone entry, as Drupal renders it: the title again,
+// the body field wrapped in its label and item divs, then the author and the
+// published date -- every one of which the reader already draws in its own
+// header.
+function createDescription(body: string, title: string = TITLE) {
+  return `<span>${title}</span>
+
+  <div class="field field--name-body field--type-text-with-summary field--label-above">
+    <div class="field__label">Body</div>
+              <div class="field-item">${body}</div>
+          </div>
+<span><a title="View user profile." href="https://www.blognone.com/user/arjin">arjin</a></span>
+<span><time datetime="2026-08-15T09:58:49+07:00" title="Saturday, August 15, 2026 - 09:58">Sat, 15/08/2026 - 09:58</time>
+</span>`
+}
+
+test('#isBlognoneEntry matches the site and its subdomains', (t) => {
+  t.true(isBlognoneEntry('https://www.blognone.com/node/151377', ''))
+  t.true(isBlognoneEntry('https://blognone.com/node/151377', ''))
+  t.true(isBlognoneEntry('http://www.blognone.com/node/151377', ''))
+})
+
+test('#isBlognoneEntry does not match another site that ends with the name', (t) => {
+  t.false(isBlognoneEntry('https://notblognone.com/node/1', ''))
+  t.false(isBlognoneEntry('https://blognone.com.example.com/node/1', ''))
+  t.false(isBlognoneEntry('https://example.com/posts/1', ''))
+})
+
+test('#isBlognoneEntry falls back to the site link when the entry link is unusable', (t) => {
+  t.true(isBlognoneEntry('', 'https://www.blognone.com/'))
+  t.true(isBlognoneEntry('/node/151377', 'https://www.blognone.com/'))
+  t.false(isBlognoneEntry('', 'https://example.com/'))
+  t.false(isBlognoneEntry('', ''))
+})
+
+test('#stripBlognoneChrome removes the span that repeats the entry title', (t) => {
+  const content = stripBlognoneChrome(createDescription('<p>body</p>'), TITLE)
+  t.false(content.includes(TITLE))
+  t.true(content.includes('<p>body</p>'))
+})
+
+test('#stripBlognoneChrome removes the Body field label', (t) => {
+  const content = stripBlognoneChrome(createDescription('<p>body</p>'), TITLE)
+  t.false(content.includes('Body'))
+})
+
+test('#stripBlognoneChrome removes the author and published date footer', (t) => {
+  const content = stripBlognoneChrome(createDescription('<p>body</p>'), TITLE)
+  t.false(content.includes('arjin'))
+  t.false(content.includes('/user/'))
+  t.false(content.includes('<time'))
+  t.false(content.includes('15/08/2026'))
+})
+
+test('#stripBlognoneChrome unwraps the field divs and keeps the body markup', (t) => {
+  const body =
+    '<p>first <b>paragraph</b></p><div class="quote">a nested div</div>' +
+    '<p>an <span>inline span</span> stays</p>'
+  const content = stripBlognoneChrome(createDescription(body), TITLE)
+  t.is(
+    content.trim(),
+    '<p>first <b>paragraph</b></p><div>a nested div</div>' +
+      '<p>an <span>inline span</span> stays</p>'
+  )
+})
+
+test('#stripBlognoneChrome keeps a span that holds an image but no text', (t) => {
+  const body =
+    '<p><span><img src="https://www.blognone.com/a.jpg" /></span></p>'
+  const content = stripBlognoneChrome(createDescription(body), TITLE)
+  t.true(content.includes('<img src="https://www.blognone.com/a.jpg" />'))
+  t.true(content.includes('<span>'))
+})
+
+test('#stripBlognoneChrome leaves content without the Drupal wrappers alone', (t) => {
+  const content = '<p>plain <a href="https://example.com">body</a></p>'
+  t.is(
+    stripBlognoneChrome(content, TITLE),
+    sanitizeHtml(content, ENTRY_CONTENT_SANITIZE_OPTIONS)
+  )
+})
+
+test('#stripBlognoneChrome keeps a span whose text is not the entry title', (t) => {
+  const content = stripBlognoneChrome(
+    '<p><span>not the title</span></p>',
+    TITLE
+  )
+  t.true(content.includes('<span>not the title</span>'))
+})
+
+test('#stripBlognoneChrome does not strip every span when the entry has no title', (t) => {
+  const content = stripBlognoneChrome('<p><span>keep me</span></p>', '')
+  t.true(content.includes('<span>keep me</span>'))
+})
+
+test('#stripBlognoneChrome matches a title that carries an escaped character', (t) => {
+  const title = 'Ford & Sons'
+  const content = stripBlognoneChrome(
+    createDescription('<p>body</p>', 'Ford &amp; Sons'),
+    title
+  )
+  t.false(content.includes('Ford'))
+  t.true(content.includes('<p>body</p>'))
+})
+
+test('#parseRss strips the duplicated header from Blognone entries', async (t) => {
+  const data = fs
+    .readFileSync(path.join(__dirname, 'stubs', 'blognone.xml'))
+    .toString('utf8')
+  const site = parseRss('Blognone', await parseXML(data))
+  t.is(site?.entries.length, 2)
+  for (const entry of site?.entries ?? []) {
+    t.true(entry.content.startsWith('<p>'))
+    t.false(entry.content.includes(entry.title))
+    t.false(entry.content.includes('Body'))
+    t.false(entry.content.includes('<time'))
+    t.false(entry.content.includes('/user/'))
+    // The article itself is untouched: its links and paragraphs survive.
+    t.true(entry.content.includes('<a href="https://'))
+  }
+})

--- a/action/feeds/blognone.ts
+++ b/action/feeds/blognone.ts
@@ -1,0 +1,130 @@
+/**
+ * Blognone publishes the whole Drupal render of a node in its RSS description,
+ * not just the article. Every entry therefore arrives wrapped in chrome the
+ * reader already draws in its own header:
+ *
+ *   <span>{the entry title again}</span>
+ *   <div class="field field--name-body ...">
+ *     <div class="field__label">Body</div>
+ *     <div class="field-item">{the article}</div>
+ *   </div>
+ *   <span><a href="/user/{author}">{author}</a></span>
+ *   <span><time datetime="...">{published date}</time></span>
+ *
+ * so a reader that shows the title, the author and the date above the content
+ * shows each of them twice, under a stray "Body" heading. This strips the
+ * chrome back to the article.
+ *
+ * It runs before the content is sanitized for storage, because the Drupal
+ * classes above are what identify the chrome and the storage rules drop every
+ * class a feed publishes.
+ */
+import sanitizeHtml from 'sanitize-html'
+
+import { parseHttpUrl } from '../../lib/entry-urls'
+import { ENTRY_CONTENT_SANITIZE_OPTIONS } from './sanitize'
+
+const SITE_HOSTNAME = 'blognone.com'
+
+/** The label Drupal renders above the body field, and its two wrapper divs. */
+const LABEL_CLASS = 'field__label'
+const WRAPPER_CLASSES = ['field--name-body', 'field-item']
+
+/**
+ * A tag no feed publishes, standing in for a wrapper div that is on its way
+ * out. sanitize-html has no way to drop a tag while keeping its children, but
+ * it does exactly that to a tag it does not allow -- so the wrappers are
+ * renamed here and discarded by the second pass, which allows the entry
+ * content tags and nothing else. Renaming straight to a tag the same pass
+ * disallows corrupts the output instead: the closing tags leak through as
+ * text.
+ */
+const WRAPPER_TAG = 'blognone-wrapper'
+
+function hasClass(value: string | undefined, name: string) {
+  return Boolean(value) && value!.split(/\s+/).includes(name)
+}
+
+/** Compares rendered text to a feed value, which wraps its lines differently. */
+function sameText(text: string, value: string) {
+  const collapse = (input: string) => input.trim().replace(/\s+/g, ' ')
+  return collapse(text) === collapse(value)
+}
+
+/**
+ * Is this entry one of Blognone's? Read from the entry link, falling back to
+ * the site link for a feed whose entry links are relative.
+ */
+export function isBlognoneEntry(entryLink: string, siteLink: string) {
+  const url = parseHttpUrl(entryLink) ?? parseHttpUrl(siteLink)
+  if (!url) return false
+  // Not endsWith(SITE_HOSTNAME) alone, which notblognone.com would satisfy.
+  return (
+    url.hostname === SITE_HOSTNAME || url.hostname.endsWith(`.${SITE_HOSTNAME}`)
+  )
+}
+
+/**
+ * The article, with the Drupal chrome around it removed. Content that does not
+ * carry the chrome comes back as the entry content rules alone would leave it,
+ * so an entry Blognone renders some other way is passed through rather than
+ * cut down to nothing.
+ */
+export function stripBlognoneChrome(content: string, title: string) {
+  // Derived from the entry content rules rather than written out, so this pass
+  // can only ever drop more than they do, never allow more. It keeps the
+  // feed's classes, which are what the rules below read; the second pass drops
+  // them again.
+  const marked = sanitizeHtml(content, {
+    ...ENTRY_CONTENT_SANITIZE_OPTIONS,
+    allowedTags: [
+      ...(ENTRY_CONTENT_SANITIZE_OPTIONS.allowedTags as string[]),
+      WRAPPER_TAG
+    ],
+    // Every class on every tag, which is only as wide as allowedAttributes
+    // above lets class through in the first place -- div and p. Not the
+    // documented `false`, which the typings do not carry, nor `{'*': true}`,
+    // which they do carry and sanitize-html throws on.
+    allowedClasses: { '*': ['*'] },
+    transformTags: {
+      div: (tagName, attribs) =>
+        WRAPPER_CLASSES.some((name) => hasClass(attribs.class, name))
+          ? { tagName: WRAPPER_TAG, attribs: {} }
+          : { tagName, attribs }
+    },
+    // Called on close tags, so a child is judged before its parent and the
+    // parent's text no longer counts a child dropped here. That is what takes
+    // the author and date spans out: each is left empty by the rule above it.
+    exclusiveFilter: (frame) => {
+      if (frame.tag === 'div' && hasClass(frame.attribs.class, LABEL_CLASS)) {
+        return true
+      }
+      // The date, and the author's link to their profile page.
+      if (frame.tag === 'time') return true
+      if (frame.tag === 'a' && isUserProfileLink(frame.attribs.href)) {
+        return true
+      }
+      if (frame.tag !== 'span') return false
+      // Matched on the text rather than on being the first element, so a span
+      // that is not the title survives wherever Blognone moves it.
+      if (title.trim() && sameText(frame.text, title)) return true
+      // Whatever the rules above emptied -- but never a span that holds an
+      // image and no text of its own.
+      return !frame.text.trim() && !frame.mediaChildren.length
+    }
+  })
+
+  // Discards the wrapper tags while keeping the article inside them, and
+  // returns the content under the same rules every other entry is stored with.
+  // Trimmed because the removed chrome leaves the indentation it sat on
+  // behind, and an entry stored with a feed's own content starts at its first
+  // element.
+  return sanitizeHtml(marked, ENTRY_CONTENT_SANITIZE_OPTIONS).trim()
+}
+
+function isUserProfileLink(href: string | undefined) {
+  const url = parseHttpUrl(href)
+  return Boolean(
+    url && isBlognoneEntry(url.href, '') && url.pathname.startsWith('/user/')
+  )
+}

--- a/action/feeds/parsers.ts
+++ b/action/feeds/parsers.ts
@@ -7,6 +7,8 @@ import {
   resolveAgainstBase,
   type UrlTarget
 } from '../../lib/entry-urls'
+import { isBlognoneEntry, stripBlognoneChrome } from './blognone'
+import { ENTRY_CONTENT_SANITIZE_OPTIONS } from './sanitize'
 
 export interface Entry {
   title: string
@@ -130,57 +132,10 @@ export function resolveContentUrl(
   return resolveUrl(url, entryLink, siteLink)
 }
 
-export const ENTRY_CONTENT_SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
-  allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img']),
-  allowedAttributes: {
-    // An attribute added here that carries a URL has to be listed in
-    // URL_ATTRIBUTES in lib/entry-urls.ts too, or it keeps whatever relative
-    // URL the feed published and lands on the reader's own domain -- and its
-    // tag needs an allowedSchemesByTag entry below if http(s) is not the right
-    // set.
-    ...sanitizeHtml.defaults.allowedAttributes,
-    img: ['src', 'alt', 'title', 'width', 'height', 'loading', 'srcset'],
-    // Kept so the source of a quotation survives into the stored JSON, and
-    // resolved like any other URL rather than left pointing at this site.
-    blockquote: ['cite'],
-    q: ['cite'],
-    // The Hacker News discussion markup (action/feeds/hackernews.ts) styles
-    // the thread through classes. Every pass over stored content goes through
-    // these options, so class has to survive here or the media store's rewrite
-    // would strip it back off.
-    div: ['class'],
-    p: ['class']
-  },
-  // Only the classes the HN markup uses; a feed's own classes keep being
-  // discarded as before.
-  allowedClasses: {
-    div: [
-      'hn-story',
-      'hn-comments',
-      'hn-comment',
-      'hn-comment-body',
-      'hn-comment-children'
-    ],
-    p: ['hn-comment-meta', 'hn-more']
-  },
-  // Nothing beyond http(s) by default, so an attribute allowed later inherits
-  // the safe set rather than data: or mailto:. Anything that needs more says so
-  // below.
-  allowedSchemes: ['http', 'https'],
-  allowedSchemesByTag: {
-    // Only an inline image has any use for data:.
-    img: ['http', 'https', 'data'],
-    // sanitize-html looks srcset up by attribute name rather than by tag, so
-    // this is what covers <img srcset>, not the img entry above.
-    srcset: ['http', 'https', 'data'],
-    a: ['http', 'https', 'mailto'],
-    // A citation is a document, so it has no use for either.
-    blockquote: ['http', 'https'],
-    q: ['http', 'https']
-  },
-  disallowedTagsMode: 'discard',
-  enforceHtmlBoundary: true
-}
+// Re-exported so every module that already reads it here keeps doing so; the
+// constant itself lives in ./sanitize, out of the import cycle this file's own
+// import of ./blognone would otherwise close.
+export { ENTRY_CONTENT_SANITIZE_OPTIONS } from './sanitize'
 
 /**
  * Rewrites every URL in entry content through `mapUrl`, under the sanitizer
@@ -215,12 +170,25 @@ export function mapContentUrls(
   })
 }
 
+/**
+ * Entry content, ready to store: the chrome a site wraps its articles in taken
+ * off first, then every URL in what is left resolved and the whole thing
+ * sanitized.
+ *
+ * A site-specific parser runs here rather than on the parsed Site, the way the
+ * Hacker News enrichment does, because it reads the classes the feed published
+ * and the sanitize pass below drops them.
+ */
 function sanitizeEntryContent(
   content: string,
+  title: string,
   siteLink: string,
   entryLink: string
 ) {
-  return mapContentUrls(content, (url, target) =>
+  const article = isBlognoneEntry(entryLink, siteLink)
+    ? stripBlognoneChrome(content, title)
+    : content
+  return mapContentUrls(article, (url, target) =>
     resolveContentUrl(url, target, siteLink, entryLink)
   )
 }
@@ -275,8 +243,9 @@ export function parseRss(feedTitle: string, xml: any): Site {
             joinValuesOrEmptyString(entryLinks),
             siteLink
           )
+          const entryTitle = joinValuesOrEmptyString(title).trim()
           return {
-            title: joinValuesOrEmptyString(title).trim(),
+            title: entryTitle,
             link: entryLink,
             date: parseDate(
               joinValuesOrEmptyString(pubDate || item['dc:date'])
@@ -285,6 +254,7 @@ export function parseRss(feedTitle: string, xml: any): Site {
               joinValuesOrEmptyString(
                 item['content:encoded'] || entryDescription
               ),
+              entryTitle,
               siteLink,
               entryLink
             ),
@@ -329,11 +299,17 @@ export function parseAtom(feedTitle: string, xml: any): Site {
             (itemLink && itemLink.$.href) || '',
             siteUrl
           )
+          const entryTitle = joinValuesOrEmptyString(title).trim()
           return {
-            title: joinValuesOrEmptyString(title).trim(),
+            title: entryTitle,
             link: entryLink,
             date: parseDate(joinValuesOrEmptyString(published || updated)),
-            content: sanitizeEntryContent(feedContent, siteUrl, entryLink),
+            content: sanitizeEntryContent(
+              feedContent,
+              entryTitle,
+              siteUrl,
+              entryLink
+            ),
             author:
               (author && joinValuesOrEmptyString(author[0].name)) || siteAuthor
           }

--- a/action/feeds/sanitize.ts
+++ b/action/feeds/sanitize.ts
@@ -1,0 +1,65 @@
+import sanitizeHtml from 'sanitize-html'
+
+/**
+ * The rules every pass over entry content runs under.
+ *
+ * They live here rather than in action/feeds/parsers.ts so that a site-specific
+ * content parser can derive its own pass from them -- deriving is what keeps
+ * such a pass from ever widening the tag or scheme set on its own. parsers.ts
+ * imports those parsers, so a parser importing this constant back from
+ * parsers.ts would close an import cycle and read it before it is initialized.
+ * parsers.ts re-exports it, so every existing importer still reads it there.
+ */
+export const ENTRY_CONTENT_SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
+  allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img']),
+  allowedAttributes: {
+    // An attribute added here that carries a URL has to be listed in
+    // URL_ATTRIBUTES in lib/entry-urls.ts too, or it keeps whatever relative
+    // URL the feed published and lands on the reader's own domain -- and its
+    // tag needs an allowedSchemesByTag entry below if http(s) is not the right
+    // set.
+    ...sanitizeHtml.defaults.allowedAttributes,
+    img: ['src', 'alt', 'title', 'width', 'height', 'loading', 'srcset'],
+    // Kept so the source of a quotation survives into the stored JSON, and
+    // resolved like any other URL rather than left pointing at this site.
+    blockquote: ['cite'],
+    q: ['cite'],
+    // The Hacker News discussion markup (action/feeds/hackernews.ts) styles
+    // the thread through classes. Every pass over stored content goes through
+    // these options, so class has to survive here or the media store's rewrite
+    // would strip it back off.
+    div: ['class'],
+    p: ['class']
+  },
+  // Only the classes the HN markup uses; a feed's own classes keep being
+  // discarded as before. A parser that has to read a feed's own classes --
+  // action/feeds/blognone.ts does -- turns this off for its own pass, whose
+  // output still goes through these rules afterwards.
+  allowedClasses: {
+    div: [
+      'hn-story',
+      'hn-comments',
+      'hn-comment',
+      'hn-comment-body',
+      'hn-comment-children'
+    ],
+    p: ['hn-comment-meta', 'hn-more']
+  },
+  // Nothing beyond http(s) by default, so an attribute allowed later inherits
+  // the safe set rather than data: or mailto:. Anything that needs more says so
+  // below.
+  allowedSchemes: ['http', 'https'],
+  allowedSchemesByTag: {
+    // Only an inline image has any use for data:.
+    img: ['http', 'https', 'data'],
+    // sanitize-html looks srcset up by attribute name rather than by tag, so
+    // this is what covers <img srcset>, not the img entry above.
+    srcset: ['http', 'https', 'data'],
+    a: ['http', 'https', 'mailto'],
+    // A citation is a document, so it has no use for either.
+    blockquote: ['http', 'https'],
+    q: ['http', 'https']
+  },
+  disallowedTagsMode: 'discard',
+  enforceHtmlBoundary: true
+}

--- a/action/feeds/stubs/blognone.xml
+++ b/action/feeds/stubs/blognone.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss xmlns:dc="http://purl.org/dc/elements/1.1/" version="2.0" xml:base="https://www.blognone.com/">
+  <channel>
+    <title>Blognone - ข่าวไอที เทคโนโลยี มือถือ เกม ความปลอดภัย โอเพนซอร์ส</title>
+    <link>https://www.blognone.com/</link>
+    <description/>
+    <language>en</language>
+    
+    <item>
+  <title>เผย Anthropic มีรายได้ไตรมาสที่ผ่านมา 1.15 หมื่นล้านดอลลาร์ โต 14 เท่าจากปีก่อน</title>
+  <link>https://www.blognone.com/node/151381</link>
+  <description>&lt;span&gt;เผย Anthropic มีรายได้ไตรมาสที่ผ่านมา 1.15 หมื่นล้านดอลลาร์ โต 14 เท่าจากปีก่อน&lt;/span&gt;
+
+  &lt;div class="field field--name-body field--type-text-with-summary field--label-above"&gt;
+    &lt;div class="field__label"&gt;Body&lt;/div&gt;
+              &lt;div class="field-item"&gt;&lt;p&gt;มีรายงานจากเอกสารที่ Anthropic แจ้งกับนักลงทุนบริษัท ถึงผลประกอบการของไตรมาสที่ 2 ปี 2026 ที่ผ่านมา ระบุว่าบริษัทมีรายได้ประมาณ 1.15 หมื่นล้านดอลลาร์ เพิ่มขึ้น 14 เท่าจากไตรมาสเดียวกันในปีก่อนซึ่งมีรายได้ 787 ล้านดอลลาร์ ทำให้รายได้เฉพาะไตรมาสที่ผ่านมาไตรมาสเดียวรวมกันมากกว่ารายได้ตลอดปีที่แล้ว&lt;/p&gt;
+&lt;p&gt;Anthropic ยังบอกว่าบริษัทมีกำไรจากการดำเนินงานสุทธิที่ปรับปรุงตัวเลขแล้วเป็นบวกเป็นครั้งแรกในไตรมาสนี้ด้วย โดยมีกำไรจากการดำเนินงาน 559 ล้านดอลลาร์ ในรายงานนี้ Anthropic ประเมินรายได้ในอนาคตของปี 2028 คาดมีรายได้ตลอดปีราว 1.9-2 แสนล้านดอลลาร์ ซึ่งตัวเลขนี้เป็นการประเมินเพื่อสะท้อนโอกาสการเติบโตอีกมากในอนาคต&lt;/p&gt;
+&lt;p&gt;ตัวเลขคาดการณ์ในอนาคตนี้มีผลมากต่อการกำหนดมูลค่ากิจการ Anthropic ทั้งการเพิ่มทุนรอบใหม่ถ้าหากมี หรือหากบริษัทไอพีโอเข้าตลาดหุ้น มูลค่ากิจการตอนนี้อาจไปถึง 2 ล้านล้านดอลลาร์ ตั้งแต่เริ่มเสนอขาย&lt;/p&gt;
+&lt;p&gt;ที่มา: &lt;a href="https://www.reuters.com/business/anthropic-ipo-valuation-hinges-190-200-billion-2028-revenue-forecast-sources-say-2026-08-15/"&gt;Reuters&lt;/a&gt; และ &lt;a href="https://www.bloomberg.com/news/articles/2026-08-14/anthropic-revenue-ahead-of-ipo-surges-over-14-fold-in-second-quarter"&gt;Bloomberg&lt;/a&gt;&lt;/p&gt;
+&lt;/div&gt;
+          &lt;/div&gt;
+&lt;span&gt;&lt;a title="View user profile." href="https://www.blognone.com/user/arjin"&gt;arjin&lt;/a&gt;&lt;/span&gt;
+&lt;span&gt;&lt;time datetime="2026-08-15T17:45:19+07:00" title="Saturday, August 15, 2026 - 17:45"&gt;Sat, 15/08/2026 - 17:45&lt;/time&gt;
+&lt;/span&gt;
+</description>
+  <pubDate>Sat, 15 Aug 2026 10:45:19 +0000</pubDate>
+    <dc:creator>arjin</dc:creator>
+    <guid isPermaLink="false">151381 at https://www.blognone.com</guid>
+    </item>
+
+    <item>
+  <title>SpaceX ซื้อกิจการ Cursor เสร็จสิ้นทุกขั้นตอนแล้ว</title>
+  <link>https://www.blognone.com/node/151377</link>
+  <description>&lt;span&gt;SpaceX ซื้อกิจการ Cursor เสร็จสิ้นทุกขั้นตอนแล้ว&lt;/span&gt;
+
+  &lt;div class="field field--name-body field--type-text-with-summary field--label-above"&gt;
+    &lt;div class="field__label"&gt;Body&lt;/div&gt;
+              &lt;div class="field-item"&gt;&lt;p&gt;Cursor ประกาศว่าการขายกิจการให้ SpaceX เสร็จสิ้นทุกขั้นตอนแล้ว โดย&lt;a href="https://www.blognone.com/node/150918"&gt;มูลค่า&lt;/a&gt;ของการซื้อขายกิจการนี้อยู่ที่ 60,000 ล้านดอลลาร์&lt;/p&gt;
+&lt;p&gt;SpaceX ประกาศแผนซื้อกิจการ Cursor มา&lt;a href="https://www.blognone.com/node/150319"&gt;ตั้งแต่เดือนเมษายน&lt;/a&gt; โดยตอนนั้นเป็นข้อตกลงแบบมีเงื่อนไขให้ SpaceX สามารถยกเลิกข้อเสนอได้ ซึ่งคาดว่าเป็นการระบุไว้กรณีที่ SpaceX ไม่สามารถไอพีโอเข้าตลาดหุ้นได้ตามแผน เมื่อ SpaceX &lt;a href="https://www.blognone.com/node/150888"&gt;สามารถเข้าตลาดหุ้น&lt;/a&gt;ได้สำเร็จ กระบวนการซื้อกิจการ Cursor จึงดำเนินต่อไป&lt;/p&gt;
+&lt;p&gt;Cursor บอกว่าการเป็นส่วนหนึ่งของ SpaceX ทำให้บริษัทเข้าถึงทรัพยากรประมวลผลจีพียูขนาดใหญ่ที่สุดแห่งหนึ่งในโลก จึงรองรับการรันโมเดลขนาดใหญ่ด้วยต้นทุนที่คุ้มค่า ซึ่งเห็นได้จาก &lt;a href="https://www.blognone.com/node/151364"&gt;Grok 4.6&lt;/a&gt; ที่เป็นความร่วมมือล่าสุด&lt;/p&gt;
+&lt;p&gt;นอกจากการแชร์ทรัพยากรประมวลผลและร่วมพัฒนาโมเดลหลักแล้ว คาดว่า SpaceX จะปรับรูปแบบการขาย subscription ของ Grok กับ Cursor ให้รวมกันมากยิ่งขึ้นจากตอนนี้ยังขายแยกกัน&lt;/p&gt;
+&lt;p&gt;ที่มา: &lt;a href="https://cursor.com/blog/joining-spacex"&gt;Cursor&lt;/a&gt; และ &lt;a href="https://www.businessinsider.com/spacex-cursor-acquisition-partnership-grok-bot-colossus-2026-8"&gt;Business Insider&lt;/a&gt;&lt;/p&gt;
+&lt;/div&gt;
+          &lt;/div&gt;
+&lt;span&gt;&lt;a title="View user profile." href="https://www.blognone.com/user/arjin"&gt;arjin&lt;/a&gt;&lt;/span&gt;
+&lt;span&gt;&lt;time datetime="2026-08-15T09:58:49+07:00" title="Saturday, August 15, 2026 - 09:58"&gt;Sat, 15/08/2026 - 09:58&lt;/time&gt;
+&lt;/span&gt;
+</description>
+  <pubDate>Sat, 15 Aug 2026 02:58:49 +0000</pubDate>
+    <dc:creator>arjin</dc:creator>
+    <guid isPermaLink="false">151377 at https://www.blognone.com</guid>
+    </item>
+  </channel>
+</rss>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feeds-fetcher",
-  "version": "4.3.4",
+  "version": "4.3.5",
   "description": "Websites feed fetcher and static feeds aggregator",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
Blognone publishes the whole Drupal render of a node in its RSS description rather than just the article, so every entry arrives wrapped in chrome the reader already draws in its own header:

```html
<span>{the entry title again}</span>
<div class="field field--name-body ...">
  <div class="field__label">Body</div>
  <div class="field-item">{the article}</div>
</div>
<span><a href="/user/{author}">{author}</a></span>
<span><time datetime="...">{published date}</time></span>
```

The reader shows the title, the site and the date above the content, so each of them appeared twice, under a stray "Body" heading.

## What this does

`action/feeds/blognone.ts` takes the chrome back off, leaving the article. It runs before the content is sanitized for storage — not on the parsed `Site` the way the Hacker News enrichment does — because the Drupal classes are what identify the chrome and the storage rules drop every class a feed publishes.

A few things worth calling out:

- **The pass is derived from `ENTRY_CONTENT_SANITIZE_OPTIONS`** rather than written out, so it can only ever drop more than the storage rules do, never allow more.
- **Wrapper divs are renamed to a tag the second pass does not allow**, which is how sanitize-html drops a tag while keeping its children. Renaming straight to a disallowed tag within the same pass corrupts the output instead — the closing tags leak through as text.
- **The author and date spans go by cascade**: the filter runs on close tags, so each span is left empty once its link or `<time>` is dropped. A span holding an image and no text of its own is kept.
- **The title span is matched on its text**, not on being the first element, and everything is gated on the entry's hostname (`blognone.com` and its subdomains — `notblognone.com` does not match). Content that does not carry the chrome is passed through rather than cut down to nothing.

`ENTRY_CONTENT_SANITIZE_OPTIONS` moves to `action/feeds/sanitize.ts` so a site parser can derive from it without closing an import cycle back through `parsers.ts`, which now imports those parsers. `parsers.ts` re-exports it, so every existing importer is untouched.

## Testing

13 new tests in `action/feeds/blognone.test.ts`, including an end-to-end pass through `parseRss` over a fixture captured from the live feed. Full suite is green (the one `getGithubActionPath` failure is the pre-existing worktree-only assertion on the directory name).

Also verified against the full live feed: all 10 entries lose the chrome and keep their article, images and links intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)