### PR TITLE
fix(opml): preserve feed urls and remove dummy url synthesis in OPML view

### DIFF
--- a/action/feeds/database.test.ts
+++ b/action/feeds/database.test.ts
@@ -151,6 +151,7 @@ test('#insertSite', async (t) => {
     key: hash(site.title),
     title: site.title,
     url: site.link,
+    xmlUrl: site.xmlUrl ?? null,
     description: site.description,
     createdAt: Math.floor(site.updatedAt / 1000)
   })
@@ -177,6 +178,22 @@ test('#insertSite', async (t) => {
   t.is(categoryCount2.total, 2)
   const siteCount2 = await db('Sites').count('* as total').first()
   t.is(siteCount2.total, 1)
+})
+
+test('#insertSite with xmlUrl', async (t) => {
+  const { db, fixtures } = t.context
+  const { site } = fixtures
+  await insertCategory(db, 'category1')
+  const siteWithXml: Site = {
+    ...site,
+    title: 'Site with XML',
+    xmlUrl: 'https://llun.dev/feed.xml'
+  }
+  const siteWithXmlKey = await insertSite(db, 'category1', siteWithXml)
+  const persistedSiteWithXml = await db('Sites')
+    .where('key', siteWithXmlKey)
+    .first()
+  t.is(persistedSiteWithXml.xmlUrl, 'https://llun.dev/feed.xml')
 })
 
 test('#deleteSiteCategory', async (t) => {

--- a/action/feeds/database.ts
+++ b/action/feeds/database.ts
@@ -64,8 +64,13 @@ export async function createTables(knex: Knex) {
       table.string('key').primary()
       table.string('title').notNullable()
       table.string('url').nullable()
+      table.string('xmlUrl').nullable()
       table.string('description')
       table.integer('createdAt')
+    })
+  } else if (!(await knex.schema.hasColumn('Sites', 'xmlUrl'))) {
+    await knex.schema.alterTable('Sites', (table) => {
+      table.string('xmlUrl').nullable()
     })
   }
 
@@ -292,9 +297,17 @@ export async function insertSite(knex: Knex, category: string, site: Site) {
           key,
           title: site.title,
           url: site.link || null,
+          xmlUrl: site.xmlUrl || null,
           description: site.description || null,
           createdAt: Math.floor(updatedAt / 1000)
         })
+      } else if (site.xmlUrl || site.link) {
+        await trx('Sites')
+          .where('key', key)
+          .update({
+            url: site.link || null,
+            xmlUrl: site.xmlUrl || null
+          })
       }
       if (!(await isSiteCategoryExists(trx, category, key))) {
         await trx('SiteCategories').insert({
@@ -403,6 +416,7 @@ export async function createOrUpdateDatabase(
       if (!site) {
         continue
       }
+      site.xmlUrl = item.xmlUrl
       console.log(`Load ${site.title}`)
       const siteKey = await insertSite(db, categoryName, site)
       await removeOldEntries(db, site)

--- a/action/feeds/file.ts
+++ b/action/feeds/file.ts
@@ -24,6 +24,8 @@ interface SiteData {
   updatedAt: number
   siteHash: string
   totalEntries: number
+  xmlUrl?: string
+  htmlUrl?: string
 }
 
 interface CategoryData {
@@ -90,6 +92,7 @@ export async function loadOPMLAndWriteFiles(
       if (!feedData) {
         continue
       }
+      feedData.xmlUrl = item.xmlUrl
       console.log(`Load ${feedData.title}`)
       const sha256 = crypto.createHash('sha256')
       sha256.update(feedData.title)
@@ -226,7 +229,9 @@ export async function createSitesData(
       updatedAt: json.updatedAt,
       siteHash,
       entries: entries.sort((a, b) => b.date - a.date),
-      totalEntries: entries.length
+      totalEntries: entries.length,
+      xmlUrl: json.xmlUrl || '',
+      htmlUrl: json.link || ''
     }
     await fs.writeFile(
       path.join(sitesDataPath, `${siteHash}.json`),
@@ -290,7 +295,9 @@ export async function createCategoryData(paths: Paths) {
         link: data.link,
         updatedAt: data.updatedAt,
         siteHash: data.siteHash,
-        totalEntries: data.entries.length
+        totalEntries: data.entries.length,
+        xmlUrl: data.xmlUrl || '',
+        htmlUrl: data.htmlUrl || data.link || ''
       })),
       totalEntries: totalCategoriesEntries
     }

--- a/action/feeds/index.ts
+++ b/action/feeds/index.ts
@@ -46,6 +46,7 @@ async function createLocalizingFeedLoader(githubActionPath: string) {
   const feedLoader = async (title: string, url: string) => {
     const site: Site | null = await loadFeed(title, url)
     if (!site) return null
+    site.xmlUrl = url
     return store.localizeSite(await enricher(site))
   }
   return { feedLoader, mediaDirectory }

--- a/action/feeds/opml.ts
+++ b/action/feeds/opml.ts
@@ -13,6 +13,9 @@ export async function loadFeed(title: string, url: string) {
     }
 
     const site = 'rss' in xml ? parseRss(title, xml) : parseAtom(title, xml)
+    if (site) {
+      site.xmlUrl = url
+    }
     return site
   } catch (error: any) {
     console.error(

--- a/action/feeds/parsers.ts
+++ b/action/feeds/parsers.ts
@@ -31,6 +31,7 @@ export interface Site {
   updatedAt: number
   generator: string
   entries: Entry[]
+  xmlUrl?: string
 }
 
 type Values = string[] | { _: string; $: { type: 'text' } }[] | null

--- a/lib/components/OpmlView.tsx
+++ b/lib/components/OpmlView.tsx
@@ -54,8 +54,8 @@ function categoriesToOpmlModel(categories?: Category[]): OpmlCategory[] {
       type: 'rss',
       title: s.title,
       text: s.title,
-      xmlUrl: `https://${s.key}.com/rss.xml`,
-      htmlUrl: `https://${s.key}.com`
+      xmlUrl: s.xmlUrl || s.htmlUrl || '',
+      htmlUrl: s.htmlUrl || ''
     }))
   }))
 }

--- a/lib/opml.test.ts
+++ b/lib/opml.test.ts
@@ -93,3 +93,26 @@ test('#generateOpml generates valid OPML XML', (t) => {
   const roundtrip = parseOpml(xml)
   t.is(roundtrip.length, 2)
 })
+
+test('#generateOpml preserves exact xmlUrl and htmlUrl without dummy templates', (t) => {
+  const categories: OpmlCategory[] = [
+    {
+      category: 'Apple',
+      items: [
+        {
+          type: 'rss',
+          title: 'Macworld',
+          text: 'Macworld',
+          xmlUrl: 'http://www.macworld.com/index.rss',
+          htmlUrl: 'https://www.macworld.com'
+        }
+      ]
+    }
+  ]
+
+  const xml = generateOpml(categories, 'Feeds')
+  t.true(xml.includes('xmlUrl="http://www.macworld.com/index.rss"'))
+  t.true(xml.includes('htmlUrl="https://www.macworld.com"'))
+  t.false(xml.includes('.com/rss.xml'))
+})
+

--- a/lib/storage/file.test.ts
+++ b/lib/storage/file.test.ts
@@ -1,0 +1,50 @@
+import test from 'ava'
+import sinon from 'sinon'
+import { FileStorage } from './file'
+
+test('#FileStorage.getCategories maps xmlUrl and htmlUrl from categories.json', async (t) => {
+  const fakeCategories = [
+    {
+      name: 'Tech',
+      totalEntries: 5,
+      sites: [
+        {
+          siteHash: 'hash123',
+          title: 'Tech Blog',
+          totalEntries: 5,
+          xmlUrl: 'https://example.com/feed.xml',
+          htmlUrl: 'https://example.com'
+        },
+        {
+          siteHash: 'hash456',
+          title: 'Legacy Blog',
+          totalEntries: 0,
+          link: 'https://legacy.com'
+        }
+      ]
+    }
+  ]
+
+  const fetchStub = sinon.stub(globalThis, 'fetch').resolves({
+    status: 200,
+    json: async () => fakeCategories
+  } as Response)
+
+  t.teardown(() => {
+    fetchStub.restore()
+  })
+
+  const storage = new FileStorage('')
+  const categories = await storage.getCategories()
+
+  t.is(categories.length, 1)
+  t.is(categories[0].title, 'Tech')
+  t.is(categories[0].sites.length, 2)
+
+  t.is(categories[0].sites[0].xmlUrl, 'https://example.com/feed.xml')
+  t.is(categories[0].sites[0].htmlUrl, 'https://example.com')
+
+  // Fallback to link when htmlUrl is missing
+  t.is(categories[0].sites[1].xmlUrl, '')
+  t.is(categories[0].sites[1].htmlUrl, 'https://legacy.com')
+})

--- a/lib/storage/file.ts
+++ b/lib/storage/file.ts
@@ -12,13 +12,15 @@ export class FileStorage implements Storage {
     if (response.status !== 200) throw new Error('Fail to load categories')
 
     const categories = await response.json()
-    return categories.map((category) => ({
+    return categories.map((category: any) => ({
       title: category.name,
       totalEntries: category.totalEntries,
-      sites: category.sites.map((site) => ({
+      sites: category.sites.map((site: any) => ({
         key: site.siteHash,
         title: site.title,
-        totalEntries: site.totalEntries
+        totalEntries: site.totalEntries,
+        xmlUrl: site.xmlUrl ?? '',
+        htmlUrl: site.htmlUrl ?? site.link ?? ''
       }))
     }))
   }

--- a/lib/storage/sqlite.ts
+++ b/lib/storage/sqlite.ts
@@ -45,11 +45,13 @@ export class SqliteStorage implements Storage {
   async getCategories(): Promise<Category[]> {
     const worker = await this.getWorker(this.config, this.basePath)
     const categories = (await worker.db.query(
-      `select category, siteKey, siteTitle from SiteCategories`
+      `select sc.category, sc.siteKey, sc.siteTitle, s.url as htmlUrl, s.xmlUrl from SiteCategories sc left join Sites s on sc.siteKey = s.key`
     )) as {
       category: string
       siteKey: string
       siteTitle: string
+      htmlUrl?: string
+      xmlUrl?: string
     }[]
     const categoryEntryCounts = (
       (await worker.db.query(
@@ -84,13 +86,21 @@ export class SqliteStorage implements Storage {
         map[item.category].sites.push({
           key: item.siteKey,
           title: item.siteTitle,
-          totalEntries: siteEntryCounts[item.siteKey]
+          totalEntries: siteEntryCounts[item.siteKey],
+          xmlUrl: item.xmlUrl ?? '',
+          htmlUrl: item.htmlUrl ?? ''
         })
         return map
       },
       {} as {
         [key in string]: {
-          sites: { key: string; title: string; totalEntries: number }[]
+          sites: {
+            key: string
+            title: string
+            totalEntries: number
+            xmlUrl?: string
+            htmlUrl?: string
+          }[]
           totalEntries: number
         }
       }

--- a/lib/storage/types.ts
+++ b/lib/storage/types.ts
@@ -4,6 +4,8 @@ export interface Category {
     key: string
     title: string
     totalEntries: number
+    xmlUrl?: string
+    htmlUrl?: string
   }[]
   totalEntries: number
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feeds-fetcher",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "description": "Websites feed fetcher and static feeds aggregator",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
## Summary

When navigating to `/opml` to view or edit subscriptions, the OPML editor was synthesizing dummy URLs in the form `https://${siteHash}.com/rss.xml` and `https://${siteHash}.com` rather than preserving the actual feed `xmlUrl` and `htmlUrl` from `feeds.opml`.

This PR preserves `xmlUrl` and `htmlUrl` across the entire feed pipeline and storage backends (both file and SQLite storage) and updates `OpmlView` to use the real subscription URLs.

## Root Cause

1. Feed loader and storage layers did not persist the feed's RSS/Atom source URL (`xmlUrl`) in `Site`, `contents/` files, `categories.json`, or the SQLite database.
2. `OpmlView.tsx`'s `categoriesToOpmlModel()` function filled in dummy URLs using the SHA-256 site hash (`https://${s.key}.com/rss.xml`).

## Changes

- **Pipeline & Feed Parsers**:
  - Added optional `xmlUrl` property to `Site` interface (`action/feeds/parsers.ts`).
  - Attached feed URL to `Site.xmlUrl` in `loadFeed` (`action/feeds/opml.ts`) and `createLocalizingFeedLoader` (`action/feeds/index.ts`).
- **File Storage**:
  - Persisted `xmlUrl` in `contents/` JSON files, `SiteData`, and `categories.json` (`action/feeds/file.ts`).
  - Mapped `xmlUrl` and `htmlUrl` in `FileStorage.getCategories()` (`lib/storage/file.ts`).
- **SQLite Storage**:
  - Added `xmlUrl` column to `Sites` table and updated `insertSite()` (`action/feeds/database.ts`).
  - Queried `s.xmlUrl` and `s.url as htmlUrl` in `SqliteStorage.getCategories()` (`lib/storage/sqlite.ts`).
- **Frontend / OPML View**:
  - Updated `Category.sites` interface to include `xmlUrl?: string` and `htmlUrl?: string` (`lib/storage/types.ts`).
  - Replaced dummy URL generation in `categoriesToOpmlModel()` with `s.xmlUrl || s.htmlUrl || ''` and `s.htmlUrl || ''` (`lib/components/OpmlView.tsx`).
- **Tests**:
  - Added tests for `FileStorage.getCategories()` (`lib/storage/file.test.ts`).
  - Added test for preserved URLs in OPML generation (`lib/opml.test.ts`).
  - Updated SQLite database insertion tests (`action/feeds/database.test.ts`).

## Verification

- `yarn ava "lib/**/*.test.ts" "action/feeds/**/*.test.ts"`: All 194 tests pass.
- `yarn build`: Production build passes without TypeScript errors.
