### PR TITLE
fix(mobile): show item list when landing on list URLs

### DIFF
--- a/lib/page.tsx
+++ b/lib/page.tsx
@@ -14,6 +14,7 @@ import {
   articleClassName,
   categoriesClassName,
   entriesClassName,
+  getInitialPageState,
   locationController,
   parseLocation
 } from '../lib/utils'
@@ -27,17 +28,20 @@ interface PageProps {
 
 export const Page: FC<PageProps> = ({ version, buildTime, initialPath }) => {
   const [status, setStatus] = useState<'loading' | 'loaded'>('loading')
-  const [pageState, setPageState] = useState<PageState>('categories')
+  const router = useRouter()
+  const originalPath = usePathname() || initialPath || '/'
+  const currentPath = initialPath || originalPath
+  const initialLocation = parseLocation(currentPath)
+  const [pageState, setPageState] = useState<PageState>(() =>
+    getInitialPageState(initialLocation)
+  )
   const [categories, setCategories] = useState<Category[]>([])
   const [listTitle, setListTitle] = useState<string>('')
   const [content, setContent] = useState<Content | null>(null)
   const [totalEntries, setTotalEntries] = useState<number | null>(null)
-  const router = useRouter()
-  const originalPath = usePathname() || initialPath || '/'
-  const currentPath = initialPath || originalPath
   const [state, dispatch] = useReducer(PathReducer, {
     pathname: currentPath,
-    location: parseLocation(currentPath)
+    location: initialLocation
   })
 
   // Handle browser history updates when pathname changes

--- a/lib/utils.test.ts
+++ b/lib/utils.test.ts
@@ -1,5 +1,12 @@
 import test from 'ava'
-import { parseLocation } from './utils'
+import sinon from 'sinon'
+import {
+  PageState,
+  getInitialPageState,
+  locationController,
+  parseLocation
+} from './utils'
+import { Content } from './storage/types'
 
 test('#parseLocation returns opml type', (t) => {
   t.deepEqual(parseLocation('/opml'), {
@@ -64,4 +71,131 @@ test('#parseLocation returns null as invalid path', (t) => {
   t.is(parseLocation('/sites/'), null)
   t.is(parseLocation('/categories'), null)
   t.is(parseLocation('/somethingelse'), null)
+})
+
+test('#getInitialPageState returns correct page state for locations', (t) => {
+  t.is(getInitialPageState(parseLocation('/sites/all')), 'entries')
+  t.is(getInitialPageState(parseLocation('/sites/siteKey')), 'entries')
+  t.is(getInitialPageState(parseLocation('/categories/Tech')), 'entries')
+  t.is(
+    getInitialPageState(parseLocation('/sites/all/entries/entryKey')),
+    'article'
+  )
+  t.is(
+    getInitialPageState(parseLocation('/categories/Tech/entries/entryKey')),
+    'article'
+  )
+  t.is(getInitialPageState(parseLocation('/opml')), 'opml')
+  t.is(getInitialPageState(parseLocation('/')), 'entries')
+  t.is(getInitialPageState(null), 'entries')
+})
+
+test('#locationController sets entries state for category and site', async (t) => {
+  let contentState: Content | null = {
+    title: 'test',
+    siteTitle: 'site',
+    siteKey: 'siteKey',
+    url: 'https://example.com',
+    content: 'test',
+    timestamp: 0
+  }
+  let pageState: PageState = 'categories'
+
+  const setContent = (c: any) => {
+    contentState = typeof c === 'function' ? c(contentState) : c
+  }
+  const setPageState = (s: any) => {
+    pageState = typeof s === 'function' ? s(pageState) : s
+  }
+
+  await locationController(
+    parseLocation('/sites/all'),
+    '',
+    setContent,
+    setPageState
+  )
+  t.is(contentState, null)
+  t.is<PageState, PageState>(pageState, 'entries')
+
+  pageState = 'categories'
+  await locationController(
+    parseLocation('/sites/my-site'),
+    '',
+    setContent,
+    setPageState
+  )
+  t.is(contentState, null)
+  t.is<PageState, PageState>(pageState, 'entries')
+
+  pageState = 'categories'
+  await locationController(
+    parseLocation('/categories/Tech'),
+    '',
+    setContent,
+    setPageState
+  )
+  t.is(contentState, null)
+  t.is<PageState, PageState>(pageState, 'entries')
+})
+
+test('#locationController sets opml state for opml', async (t) => {
+  let contentState: Content | null = null
+  let pageState: PageState = 'categories'
+
+  const setContent = (c: any) => {
+    contentState = typeof c === 'function' ? c(contentState) : c
+  }
+  const setPageState = (s: any) => {
+    pageState = typeof s === 'function' ? s(pageState) : s
+  }
+
+  await locationController(parseLocation('/opml'), '', setContent, setPageState)
+  t.is(contentState, null)
+  t.is<PageState, PageState>(pageState, 'opml')
+})
+
+test('#locationController loads entry and sets article state', async (t) => {
+  const fakeApiResponse = {
+    title: 'Article Title',
+    siteTitle: 'Site',
+    siteHash: 'siteKey',
+    link: 'https://example.com/article',
+    content: '<p>Content</p>',
+    date: 123456000
+  }
+
+  const fetchStub = sinon.stub(globalThis, 'fetch').resolves({
+    status: 200,
+    json: async () => fakeApiResponse
+  } as Response)
+
+  t.teardown(() => {
+    fetchStub.restore()
+  })
+
+  let contentState: Content | null = null
+  let pageState: PageState = 'categories'
+
+  const setContent = (c: any) => {
+    contentState = typeof c === 'function' ? c(contentState) : c
+  }
+  const setPageState = (s: any) => {
+    pageState = typeof s === 'function' ? s(pageState) : s
+  }
+
+  await locationController(
+    parseLocation('/sites/all/entries/articleKey'),
+    '',
+    setContent,
+    setPageState
+  )
+  t.deepEqual(contentState, {
+    title: 'Article Title',
+    siteTitle: 'Site',
+    siteKey: 'siteKey',
+    url: 'https://example.com/article',
+    content: '<p>Content</p>',
+    timestamp: 123456
+  })
+  t.is<PageState, PageState>(pageState, 'article')
 })

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -109,6 +109,19 @@ export const parseLocation = (url: string): LocationState => {
   }
 }
 
+export const getInitialPageState = (location: LocationState): PageState => {
+  if (!location) return 'entries'
+  switch (location.type) {
+    case 'opml':
+      return 'opml'
+    case 'entry':
+      return 'article'
+    case 'category':
+    case 'site':
+      return 'entries'
+  }
+}
+
 export const locationController = async (
   locationState: LocationState,
   basePath: string,
@@ -126,16 +139,12 @@ export const locationController = async (
     }
     case 'category': {
       setContent(null)
-      setPageState((current) =>
-        current === 'categories' ? 'categories' : 'entries'
-      )
+      setPageState('entries')
       return
     }
     case 'site': {
       setContent(null)
-      setPageState((current) =>
-        current === 'categories' ? 'categories' : 'entries'
-      )
+      setPageState('entries')
       return
     }
     case 'entry': {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feeds-fetcher",
-  "version": "4.4.1",
+  "version": "4.4.2",
   "description": "Websites feed fetcher and static feeds aggregator",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
## Summary
Fixes mobile landing behavior where navigating directly to list URLs (`/sites/all`, `/sites/[key]`, `/categories/[key]`) rendered the category navigation sidebar instead of the items list portion.

## Changes
- **`lib/utils.ts`**:
  - Simplified `locationController` so `case 'category'` and `case 'site'` unconditionally set `pageState` to `'entries'`.
  - Added `getInitialPageState(location: LocationState): PageState` to derive initial page state synchronously from current URL location.
- **`lib/page.tsx`**:
  - Initialized `pageState` using `getInitialPageState` on mount to avoid layout jumps on direct landing.
- **`lib/utils.test.ts`**:
  - Added unit tests for `getInitialPageState` and `locationController`.