### PR TITLE
fix(mobile): fix browser back and forward navigation for feed items

### DIFF
--- a/lib/page.tsx
+++ b/lib/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { FC, useState, useEffect, useReducer } from 'react'
-import { usePathname, useRouter } from 'next/navigation'
+import { FC, useState, useEffect, useReducer, useRef } from 'react'
+import { usePathname } from 'next/navigation'
 
 import { ItemList } from './components/ItemList'
 import { ItemContent } from './components/ItemContent'
@@ -28,7 +28,6 @@ interface PageProps {
 
 export const Page: FC<PageProps> = ({ version, buildTime, initialPath }) => {
   const [status, setStatus] = useState<'loading' | 'loaded'>('loading')
-  const router = useRouter()
   const originalPath = usePathname() || initialPath || '/'
   const currentPath = initialPath || originalPath
   const initialLocation = parseLocation(currentPath)
@@ -39,6 +38,7 @@ export const Page: FC<PageProps> = ({ version, buildTime, initialPath }) => {
   const [listTitle, setListTitle] = useState<string>('')
   const [content, setContent] = useState<Content | null>(null)
   const [totalEntries, setTotalEntries] = useState<number | null>(null)
+  const navSourceRef = useRef<'user' | 'popstate' | 'replace'>('user')
   const [state, dispatch] = useReducer(PathReducer, {
     pathname: currentPath,
     location: initialLocation
@@ -46,15 +46,42 @@ export const Page: FC<PageProps> = ({ version, buildTime, initialPath }) => {
 
   // Handle browser history updates when pathname changes
   useEffect(() => {
-    if (state.pathname !== originalPath) {
+    const source = navSourceRef.current
+    navSourceRef.current = 'user'
+
+    if (source === 'popstate') return
+
+    if (source === 'replace') {
+      window.history.replaceState(
+        { location: state.location },
+        '',
+        state.pathname
+      )
+      return
+    }
+
+    if (window.location.pathname !== state.pathname) {
       window.history.pushState({ location: state.location }, '', state.pathname)
     }
-  }, [state.pathname, state.location, originalPath])
+  }, [state.pathname, state.location])
+
+  // Handle browser back/forward buttons and swipe gestures
+  useEffect(() => {
+    const historyPopHandler = (event: PopStateEvent) => {
+      navSourceRef.current = 'popstate'
+      dispatch(updatePath(window.location.pathname))
+    }
+    window.addEventListener('popstate', historyPopHandler)
+    return () => {
+      window.removeEventListener('popstate', historyPopHandler)
+    }
+  }, [])
 
   useEffect(() => {
     ;(async () => {
       if (!state.location) {
         const targetPath = '/sites/all'
+        navSourceRef.current = 'replace'
         dispatch(updatePath(targetPath))
         return
       }
@@ -77,15 +104,7 @@ export const Page: FC<PageProps> = ({ version, buildTime, initialPath }) => {
         setPageState
       )
     })()
-
-    const historyPopHandler = (event: PopStateEvent) => {
-      dispatch(updatePath(originalPath))
-    }
-    window.addEventListener('popstate', historyPopHandler)
-    return () => {
-      window.removeEventListener('popstate', historyPopHandler)
-    }
-  }, [status, state, router, originalPath])
+  }, [status, state])
 
   useEffect(() => {
     const storage = getStorage(process.env.NEXT_PUBLIC_BASE_PATH ?? '')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feeds-fetcher",
-  "version": "4.4.2",
+  "version": "4.4.3",
   "description": "Websites feed fetcher and static feeds aggregator",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
## Description

Fixes an issue on mobile browsers (such as iPhone Safari swipe gestures and browser back/forward buttons) where navigating to a feed item and pressing back failed to return to the item list or became trapped in a navigation loop.

### Cause & Effect
1. **Wrong path dispatched on `popstate`**: The `popstate` event listener was previously dispatching `originalPath` (derived from `usePathname()` on initial mount, which never updated when navigating via client-side `pushState`). This caused browser back navigation to always dispatch the initial route (`/`) instead of the popped URL.
2. **Initial redirect used `pushState`**: Landing on `/` triggered a path update to `/sites/all`, which called `pushState` instead of `replaceState`, creating extra history entries and causing back navigation from `/sites/all` to cycle endlessly.
3. **Re-binding `popstate` listener**: The `popstate` event listener was registered inside an effect depending on mutable state, causing repeated re-registrations on each render.

### Solution
- Track navigation source (`'user' | 'popstate' | 'replace'`) via `navSourceRef`.
- When `popstate` fires, dispatch `window.location.pathname` so the state matches the target browser history location.
- Only call `window.history.pushState` when navigation is user-initiated and the browser location does not already match `state.pathname`.
- Use `window.history.replaceState` for the initial `/` → `/sites/all` redirect so history is not polluted.
- Register the `popstate` event listener in a single mount-only `useEffect`.
- Bump patch version to `4.4.3` as a regression fix.

### Validation
- Ran `yarn ava lib/**/*.test.ts*` (all 49 tests passed).
- Ran `yarn build` (production build and TypeScript checking succeeded).
