### PR TITLE
fix(opml): fix add feed in category on edit OPML page

### DIFF
--- a/action/feeds/index.ts
+++ b/action/feeds/index.ts
@@ -59,8 +59,9 @@ export async function createFeedDatabase(githubActionPath: string) {
     // This feed site uses files
     if (storageType !== 'sqlite') return
     const feedsFile = getActionInput('opmlFile', { required: true })
+    const opmlFilePath = path.join(getWorkspacePath(), feedsFile)
     const opmlContent = (
-      await fs.readFile(path.join(getWorkspacePath(), feedsFile))
+      await fs.readFile(opmlFilePath)
     ).toString('utf8')
     const opml = await readOpml(opmlContent)
     const publicPath = getPublicPath(githubActionPath)
@@ -81,6 +82,9 @@ export async function createFeedDatabase(githubActionPath: string) {
     )
     await cleanup(database)
     await database.destroy()
+    const dataDir = path.join(publicPath, 'data')
+    await fs.mkdir(dataDir, { recursive: true })
+    await fs.copyFile(opmlFilePath, path.join(dataDir, 'feeds.opml'))
   } catch (error: any) {
     console.error(error.message)
     console.error(error.stack)
@@ -96,6 +100,7 @@ export async function createFeedFiles(githubActionPath: string) {
     // This feed site uses database
     if (storageType === 'sqlite') return
     const feedsFile = getActionInput('opmlFile', { required: true })
+    const opmlFilePath = path.join(getWorkspacePath(), feedsFile)
     const publicPath = githubActionPath
       ? path.join(githubActionPath, 'contents')
       : path.join('contents')
@@ -103,7 +108,7 @@ export async function createFeedFiles(githubActionPath: string) {
       await createLocalizingFeedLoader(githubActionPath)
     await loadOPMLAndWriteFiles(
       publicPath,
-      path.join(getWorkspacePath(), feedsFile),
+      opmlFilePath,
       feedLoader
     )
     const customDomainName = getActionInput('customDomain')
@@ -113,6 +118,7 @@ export async function createFeedFiles(githubActionPath: string) {
     await createRepositoryData(DEFAULT_PATHS, githubRootName, customDomainName)
     await createCategoryData(DEFAULT_PATHS)
     await createAllEntriesData()
+    await fs.copyFile(opmlFilePath, path.join(DEFAULT_PATHS.dataPath, 'feeds.opml'))
     await cleanupUnusedMediaFiles(
       mediaDirectory,
       await collectReferencedMediaFromEntryDirectory(

--- a/lib/opml.test.ts
+++ b/lib/opml.test.ts
@@ -116,3 +116,53 @@ test('#generateOpml preserves exact xmlUrl and htmlUrl without dummy templates',
   t.false(xml.includes('.com/rss.xml'))
 })
 
+test('#parseOpml preserves newly added empty feed in category', (t) => {
+  const categories: OpmlCategory[] = [
+    {
+      category: 'Tech',
+      items: [
+        {
+          type: 'rss',
+          title: 'Existing Feed',
+          text: 'Existing Feed',
+          xmlUrl: 'https://example.com/rss.xml',
+          htmlUrl: 'https://example.com'
+        },
+        {
+          type: 'rss',
+          title: '',
+          text: '',
+          xmlUrl: '',
+          htmlUrl: ''
+        }
+      ]
+    }
+  ]
+
+  const xml = generateOpml(categories, 'Feeds')
+  const result = parseOpml(xml)
+
+  t.is(result.length, 1)
+  t.is(result[0].category, 'Tech')
+  t.is(result[0].items.length, 2)
+  t.is(result[0].items[1].title, '')
+  t.is(result[0].items[1].xmlUrl, '')
+})
+
+test('#parseOpml preserves empty category', (t) => {
+  const categories: OpmlCategory[] = [
+    {
+      category: 'Empty Category',
+      items: []
+    }
+  ]
+
+  const xml = generateOpml(categories, 'Feeds')
+  const result = parseOpml(xml)
+
+  t.is(result.length, 1)
+  t.is(result[0].category, 'Empty Category')
+  t.is(result[0].items.length, 0)
+})
+
+

--- a/lib/opml.ts
+++ b/lib/opml.ts
@@ -87,12 +87,12 @@ export const parseOpml = (xmlString: string): OpmlCategory[] => {
     const innerContent = topOutlineMatch[2]
     const topAttrs = parseAttributes(topAttrsStr)
 
-    if (topAttrs.xmlUrl) {
+    if (topAttrs.xmlUrl !== undefined || (topAttrs.type && !innerContent)) {
       const item: OpmlItem = {
         type: topAttrs.type || 'rss',
         text: topAttrs.text || topAttrs.title || '',
         title: topAttrs.title || topAttrs.text || '',
-        xmlUrl: topAttrs.xmlUrl,
+        xmlUrl: topAttrs.xmlUrl || '',
         htmlUrl: topAttrs.htmlUrl || '',
         description: topAttrs.description || ''
       }
@@ -112,17 +112,15 @@ export const parseOpml = (xmlString: string): OpmlCategory[] => {
         let nestedMatch: RegExpExecArray | null
         while ((nestedMatch = nestedTagRegex.exec(innerContent)) !== null) {
           const nestedAttrs = parseAttributes(nestedMatch[1])
-          if (nestedAttrs.xmlUrl) {
-            const item: OpmlItem = {
-              type: nestedAttrs.type || 'rss',
-              text: nestedAttrs.text || nestedAttrs.title || '',
-              title: nestedAttrs.title || nestedAttrs.text || '',
-              xmlUrl: nestedAttrs.xmlUrl,
-              htmlUrl: nestedAttrs.htmlUrl || '',
-              description: nestedAttrs.description || ''
-            }
-            categoryMap.get(categoryName)!.push(item)
+          const item: OpmlItem = {
+            type: nestedAttrs.type || 'rss',
+            text: nestedAttrs.text || nestedAttrs.title || '',
+            title: nestedAttrs.title || nestedAttrs.text || '',
+            xmlUrl: nestedAttrs.xmlUrl || '',
+            htmlUrl: nestedAttrs.htmlUrl || '',
+            description: nestedAttrs.description || ''
           }
+          categoryMap.get(categoryName)!.push(item)
         }
       }
     }
@@ -151,7 +149,7 @@ export const generateOpml = (
   const formatItem = (item: OpmlItem, pad: string): string => {
     const text = escapeXml(item.text || item.title || '')
     const itemTitle = escapeXml(item.title || item.text || '')
-    const xmlUrl = escapeXml(item.xmlUrl)
+    const xmlUrl = escapeXml(item.xmlUrl || '')
     const htmlUrlAttr = item.htmlUrl ? ` htmlUrl="${escapeXml(item.htmlUrl)}"` : ''
     const typeAttr = item.type ? ` type="${escapeXml(item.type)}"` : ' type="rss"'
     return `${pad}<outline${typeAttr} text="${text}" title="${itemTitle}" xmlUrl="${xmlUrl}"${htmlUrlAttr}/>`

--- a/lib/page.tsx
+++ b/lib/page.tsx
@@ -35,6 +35,7 @@ export const Page: FC<PageProps> = ({ version, buildTime, initialPath }) => {
     getInitialPageState(initialLocation)
   )
   const [categories, setCategories] = useState<Category[]>([])
+  const [initialOpml, setInitialOpml] = useState<string | undefined>()
   const [listTitle, setListTitle] = useState<string>('')
   const [content, setContent] = useState<Content | null>(null)
   const [totalEntries, setTotalEntries] = useState<number | null>(null)
@@ -88,12 +89,14 @@ export const Page: FC<PageProps> = ({ version, buildTime, initialPath }) => {
 
       if (status === 'loading') {
         const storage = getStorage(process.env.NEXT_PUBLIC_BASE_PATH ?? '')
-        const [categories, totalEntries] = await Promise.all([
+        const [categories, totalEntries, opml] = await Promise.all([
           storage.getCategories(),
-          storage.countAllEntries()
+          storage.countAllEntries(),
+          storage.getOpml ? storage.getOpml() : Promise.resolve(null)
         ])
         setTotalEntries(totalEntries)
         setCategories(categories)
+        if (opml) setInitialOpml(opml)
         setStatus('loaded')
       }
 
@@ -229,6 +232,7 @@ export const Page: FC<PageProps> = ({ version, buildTime, initialPath }) => {
             }`}
           >
             <OpmlView
+              initialOpml={initialOpml}
               categories={categories}
               active={true}
               onBack={() => {

--- a/lib/storage/file.test.ts
+++ b/lib/storage/file.test.ts
@@ -2,7 +2,7 @@ import test from 'ava'
 import sinon from 'sinon'
 import { FileStorage } from './file'
 
-test('#FileStorage.getCategories maps xmlUrl and htmlUrl from categories.json', async (t) => {
+test.serial('#FileStorage.getCategories maps xmlUrl and htmlUrl from categories.json', async (t) => {
   const fakeCategories = [
     {
       name: 'Tech',
@@ -48,3 +48,35 @@ test('#FileStorage.getCategories maps xmlUrl and htmlUrl from categories.json', 
   t.is(categories[0].sites[1].xmlUrl, '')
   t.is(categories[0].sites[1].htmlUrl, 'https://legacy.com')
 })
+
+test.serial('#FileStorage.getOpml returns raw OPML text when feeds.opml exists', async (t) => {
+  const fakeOpml = '<opml version="2.0"><head><title>Feeds</title></head><body></body></opml>'
+  const fetchStub = sinon.stub(globalThis, 'fetch').resolves({
+    status: 200,
+    text: async () => fakeOpml
+  } as Response)
+
+  t.teardown(() => {
+    fetchStub.restore()
+  })
+
+  const storage = new FileStorage('')
+  const opml = await storage.getOpml()
+  t.is(opml, fakeOpml)
+})
+
+test.serial('#FileStorage.getOpml returns null when feeds.opml is not found', async (t) => {
+  const fetchStub = sinon.stub(globalThis, 'fetch').resolves({
+    status: 404,
+    text: async () => 'Not Found'
+  } as Response)
+
+  t.teardown(() => {
+    fetchStub.restore()
+  })
+
+  const storage = new FileStorage('')
+  const opml = await storage.getOpml()
+  t.is(opml, null)
+})
+

--- a/lib/storage/file.ts
+++ b/lib/storage/file.ts
@@ -118,4 +118,15 @@ export class FileStorage implements Storage {
       timestamp: Math.floor(json.date / 1000)
     }
   }
+
+  async getOpml(): Promise<string | null> {
+    try {
+      const response = await fetch(`${this.basePath}/feeds.opml`)
+      if (response.status !== 200) return null
+      return await response.text()
+    } catch {
+      return null
+    }
+  }
 }
+

--- a/lib/storage/sqlite.ts
+++ b/lib/storage/sqlite.ts
@@ -220,4 +220,18 @@ export class SqliteStorage implements Storage {
     if (entry.length === 0) return null
     return entry[0] as Content
   }
+
+  async getOpml(): Promise<string | null> {
+    try {
+      let response = await fetch(`${this.basePath}/data/feeds.opml`)
+      if (response.status !== 200) {
+        response = await fetch(`${this.basePath}/feeds.opml`)
+      }
+      if (response.status !== 200) return null
+      return await response.text()
+    } catch {
+      return null
+    }
+  }
 }
+

--- a/lib/storage/types.ts
+++ b/lib/storage/types.ts
@@ -38,4 +38,6 @@ export interface Storage {
   countCategoryEntries(category: string): Promise<number>
   getAllEntries(page?: number): Promise<SiteEntry[]>
   getContent(key: string): Promise<Content>
+  getOpml?(): Promise<string | null>
 }
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feeds-fetcher",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "description": "Websites feed fetcher and static feeds aggregator",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
## Description
1. Fixes an issue on the edit OPML page where clicking "Add feed" inside a category did not add a new feed row due to `parseOpml` dropping items with empty `xmlUrl`.
2. Preserves the original `feeds.opml` in static build outputs and loads it directly into the OPML editor (`/opml`), ensuring all configured feeds appear in the editor even if they failed to fetch or encountered bot protection.

### Changes
- Updated `parseOpml` in `lib/opml.ts` to preserve nested outline items and feeds with empty attributes.
- Updated `generateOpml` to safely format feeds with empty `xmlUrl`.
- Updated GitHub Action publishers (`action/feeds/index.ts`) to copy `feeds.opml` to static data output.
- Added `getOpml()` to Storage interface, `FileStorage`, and `SqliteStorage`.
- Updated `Page` to load `storage.getOpml()` and pass `initialOpml` to `OpmlView`.
- Added unit tests in `lib/opml.test.ts` and `lib/storage/file.test.ts`.
- Bumped patch version to `4.5.1` in `package.json`.