### PR TITLE
feat(opml): add Save OPML via GitHub issue workflow

### DIFF
--- a/.github/workflows/opml-update.yml
+++ b/.github/workflows/opml-update.yml
@@ -1,0 +1,21 @@
+name: Update OPML
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+jobs:
+  update-opml:
+    if: startsWith(github.event.issue.title || github.event.pull_request.title, 'Update OPML file')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Run Action
+        uses: llun/feeds@main
+        with:
+          storageType: files

--- a/action/issue.test.ts
+++ b/action/issue.test.ts
@@ -3,6 +3,7 @@ import fs from 'fs/promises'
 import os from 'os'
 import path from 'path'
 import sinon from 'sinon'
+import { parseOpml } from '../lib/opml'
 import {
   extractOpmlFromIssueBody,
   isAuthorizedAuthor,
@@ -14,7 +15,8 @@ test('#extractOpmlFromIssueBody extracts OPML from code fence', (t) => {
   const opml = extractOpmlFromIssueBody(body)
   t.truthy(opml)
   t.true(opml!.startsWith('<opml'))
-  t.true(opml!.includes('https://example.com/rss'))
+  const parsed = parseOpml(opml!)
+  t.is(parsed[0].items[0].xmlUrl, 'https://example.com/rss')
 })
 
 test('#extractOpmlFromIssueBody extracts OPML without code fence', (t) => {

--- a/action/issue.test.ts
+++ b/action/issue.test.ts
@@ -1,0 +1,202 @@
+import test from 'ava'
+import fs from 'fs/promises'
+import os from 'os'
+import path from 'path'
+import sinon from 'sinon'
+import {
+  extractOpmlFromIssueBody,
+  isAuthorizedAuthor,
+  handleOpmlIssue
+} from './issue'
+
+test('#extractOpmlFromIssueBody extracts OPML from code fence', (t) => {
+  const body = `## Changes\n\n### Added\n- Feed 1\n\n\`\`\`xml\n<opml version="2.0"><head><title>Feeds</title></head><body><outline text="Tech" title="Tech"><outline type="rss" text="Feed 1" xmlUrl="https://example.com/rss"/></outline></body></opml>\n\`\`\``
+  const opml = extractOpmlFromIssueBody(body)
+  t.truthy(opml)
+  t.true(opml!.startsWith('<opml'))
+  t.true(opml!.includes('https://example.com/rss'))
+})
+
+test('#extractOpmlFromIssueBody extracts OPML without code fence', (t) => {
+  const body = `<opml version="2.0"><body><outline text="Tech" title="Tech"><outline type="rss" xmlUrl="https://example.com"/></outline></body></opml>`
+  const opml = extractOpmlFromIssueBody(body)
+  t.truthy(opml)
+  t.true(opml!.startsWith('<opml'))
+})
+
+test('#extractOpmlFromIssueBody returns null for placeholder', (t) => {
+  const body = `## Changes\n\n\`\`\`xml\nPASTE_OPML_HERE\n\`\`\``
+  t.is(extractOpmlFromIssueBody(body), null)
+})
+
+test('#extractOpmlFromIssueBody returns null for invalid body', (t) => {
+  t.is(extractOpmlFromIssueBody(''), null)
+  t.is(
+    extractOpmlFromIssueBody('Just a regular issue comment with no XML'),
+    null
+  )
+  t.is(extractOpmlFromIssueBody('<opml><body><noOutline/></body></opml>'), null)
+})
+
+test('#isAuthorizedAuthor allows OWNER, MEMBER, COLLABORATOR', (t) => {
+  t.true(isAuthorizedAuthor('OWNER'))
+  t.true(isAuthorizedAuthor('member'))
+  t.true(isAuthorizedAuthor('collaborator'))
+  t.false(isAuthorizedAuthor('CONTRIBUTOR'))
+  t.false(isAuthorizedAuthor('FIRST_TIMER'))
+  t.false(isAuthorizedAuthor('NONE'))
+  t.false(isAuthorizedAuthor(null))
+  t.false(isAuthorizedAuthor(undefined))
+})
+
+test.serial('#handleOpmlIssue skips non-issue/pr events', async (t) => {
+  const result = await handleOpmlIssue({
+    githubContext: {
+      eventName: 'schedule',
+      payload: {},
+      repo: { owner: 'llun', repo: 'feeds' }
+    }
+  })
+  t.false(result.handled)
+  t.false(result.updated)
+})
+
+test.serial(
+  '#handleOpmlIssue skips issues with unrelated titles',
+  async (t) => {
+    const result = await handleOpmlIssue({
+      githubContext: {
+        eventName: 'issues',
+        payload: {
+          issue: {
+            number: 1,
+            title: 'Bug report',
+            author_association: 'OWNER'
+          }
+        },
+        repo: { owner: 'llun', repo: 'feeds' }
+      }
+    })
+    t.false(result.handled)
+    t.false(result.updated)
+  }
+)
+
+test.serial('#handleOpmlIssue rejects unauthorized authors', async (t) => {
+  const fakeOctokit = {
+    rest: {
+      issues: {
+        createComment: sinon.stub().resolves(),
+        update: sinon.stub().resolves()
+      }
+    }
+  }
+
+  const result = await handleOpmlIssue({
+    githubContext: {
+      eventName: 'issues',
+      payload: {
+        issue: {
+          number: 42,
+          title: 'Update OPML file',
+          author_association: 'NONE',
+          body: '<opml version="2.0"><body><outline xmlUrl="https://test.com"/></body></opml>'
+        }
+      },
+      repo: { owner: 'llun', repo: 'feeds' }
+    },
+    token: 'fake-token',
+    octokit: fakeOctokit
+  })
+
+  t.true(result.handled)
+  t.false(result.updated)
+  t.true(fakeOctokit.rest.issues.createComment.calledOnce)
+  t.true(
+    fakeOctokit.rest.issues.createComment.firstCall.args[0].body.includes(
+      'Permission denied'
+    )
+  )
+})
+
+test.serial(
+  '#handleOpmlIssue updates file and closes issue on valid OPML',
+  async (t) => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'feeds-issue-test-'))
+    const opmlFile = 'feeds.opml'
+    const initialOpml =
+      '<opml version="2.0"><body><outline text="Old"/></body></opml>'
+    await fs.writeFile(path.join(tmpDir, opmlFile), initialOpml, 'utf8')
+
+    const fakeOctokit = {
+      rest: {
+        issues: {
+          createComment: sinon.stub().resolves(),
+          update: sinon.stub().resolves()
+        }
+      }
+    }
+
+    // Initialize git repo in tmpDir
+    const { spawnSync } = await import('child_process')
+    spawnSync('git', ['init', '-b', 'main'], { cwd: tmpDir })
+    spawnSync('git', ['config', 'user.name', 'Test'], { cwd: tmpDir })
+    spawnSync('git', ['config', 'user.email', 'test@test.com'], { cwd: tmpDir })
+    spawnSync('git', ['add', opmlFile], { cwd: tmpDir })
+    spawnSync('git', ['commit', '-m', 'Initial commit'], { cwd: tmpDir })
+
+    const runCommandStub = sinon.stub().callsFake((cmds, cwd) => {
+      if (cmds[0] === 'git' && cmds[1] === 'push') {
+        return { status: 0 }
+      }
+      return spawnSync(cmds[0], cmds.slice(1), { cwd, stdio: 'pipe' })
+    })
+
+    t.teardown(async () => {
+      await fs.rm(tmpDir, { recursive: true, force: true })
+    })
+
+    const newOpml =
+      '<opml version="2.0"><head><title>Feeds</title></head><body><outline text="NewCat"><outline type="rss" xmlUrl="https://newfeed.com/rss.xml"/></outline></body></opml>'
+    const body = `## Changes\n\n### Added\n- New Feed\n\n\`\`\`xml\n${newOpml}\n\`\`\``
+
+    const result = await handleOpmlIssue({
+      githubContext: {
+        eventName: 'issues',
+        payload: {
+          issue: {
+            number: 99,
+            title: 'Update OPML file',
+            author_association: 'OWNER',
+            body
+          }
+        },
+        repo: { owner: 'llun', repo: 'feeds' }
+      },
+      token: 'fake-token',
+      octokit: fakeOctokit,
+      runCommand: runCommandStub as any,
+      workspacePath: tmpDir,
+      opmlFile,
+      sourceBranch: 'main'
+    })
+
+    t.true(result.handled)
+    t.true(result.updated)
+
+    const updatedContent = await fs.readFile(
+      path.join(tmpDir, opmlFile),
+      'utf8'
+    )
+    t.is(updatedContent, newOpml)
+
+    t.true(fakeOctokit.rest.issues.update.calledOnce)
+    t.is(fakeOctokit.rest.issues.update.firstCall.args[0].state, 'closed')
+    t.true(fakeOctokit.rest.issues.createComment.calledOnce)
+    t.true(
+      fakeOctokit.rest.issues.createComment.firstCall.args[0].body.includes(
+        'Successfully updated'
+      )
+    )
+  }
+)

--- a/action/issue.ts
+++ b/action/issue.ts
@@ -1,0 +1,167 @@
+import fs from 'fs/promises'
+import path from 'path'
+import {
+  getActionInput,
+  getWorkspacePath,
+  resolveSourceBranch,
+  runCommand as defaultRunCommand
+} from './repository'
+
+export function extractOpmlFromIssueBody(body: string): string | null {
+  if (!body) return null
+
+  if (body.includes('PASTE_OPML_HERE')) {
+    return null
+  }
+
+  const codeBlockMatch = body.match(/```(?:xml|opml)?\s*([\s\S]*?)```/i)
+  if (codeBlockMatch) {
+    const candidate = codeBlockMatch[1].trim()
+    const opmlMatch = candidate.match(/<opml[\s\S]*?<\/opml>/i)
+    if (opmlMatch && opmlMatch[0].includes('<outline')) {
+      return opmlMatch[0]
+    }
+  }
+
+  const directMatch = body.match(/<opml[\s\S]*?<\/opml>/i)
+  if (directMatch && directMatch[0].includes('<outline')) {
+    return directMatch[0]
+  }
+
+  return null
+}
+
+export function isAuthorizedAuthor(association?: string | null): boolean {
+  if (!association) return false
+  const allowed = ['OWNER', 'MEMBER', 'COLLABORATOR']
+  return allowed.includes(association.toUpperCase())
+}
+
+export interface HandleIssueOptions {
+  githubContext?: any
+  token?: string
+  workspacePath?: string
+  opmlFile?: string
+  sourceBranch?: string
+  octokit?: any
+  runCommand?: (commands: string[], cwd?: string) => any
+}
+
+export async function handleOpmlIssue(
+  options: HandleIssueOptions = {}
+): Promise<{
+  handled: boolean
+  updated: boolean
+}> {
+  const github = await import('@actions/github')
+  const context = options.githubContext || github.context
+  const run = options.runCommand || defaultRunCommand
+
+  const isIssue = context.eventName === 'issues'
+  const isPr = context.eventName === 'pull_request'
+
+  if (!isIssue && !isPr) {
+    return { handled: false, updated: false }
+  }
+
+  const payload = context.payload
+  const item = isIssue ? payload?.issue : payload?.pull_request
+  if (!item) {
+    return { handled: false, updated: false }
+  }
+
+  const title = (item.title || '').trim()
+  if (!title.toLowerCase().startsWith('update opml file')) {
+    return { handled: false, updated: false }
+  }
+
+  const issueNumber = item.number
+  const authorAssociation = item.author_association
+  const token = options.token || getActionInput('token')
+  const octokit = options.octokit || github.getOctokit(token)
+  const owner = context.repo.owner
+  const repo = context.repo.repo
+
+  if (!isAuthorizedAuthor(authorAssociation)) {
+    console.log(
+      `Author association "${authorAssociation}" is not authorized to update OPML.`
+    )
+    await octokit.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: issueNumber,
+      body: `Permission denied: only repository owners or collaborators can update OPML subscriptions via issues.`
+    })
+    return { handled: true, updated: false }
+  }
+
+  const extractedOpml = extractOpmlFromIssueBody(item.body || '')
+  if (!extractedOpml) {
+    console.log('Could not extract valid OPML content from issue body.')
+    await octokit.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: issueNumber,
+      body: `Could not extract valid OPML content from this issue. Please ensure the issue body contains a valid \`\`\`xml\n<opml>...</opml>\n\`\`\` block.`
+    })
+    return { handled: true, updated: false }
+  }
+
+  const workSpace = options.workspacePath || getWorkspacePath()
+  if (!workSpace) {
+    console.log('No workspace path available.')
+    return { handled: true, updated: false }
+  }
+
+  const opmlFile =
+    options.opmlFile || getActionInput('opmlFile') || 'feeds.opml'
+  const sourceBranch =
+    options.sourceBranch ||
+    resolveSourceBranch(
+      context.ref,
+      (context.payload as any)?.repository?.default_branch || 'main'
+    )
+
+  const targetPath = path.join(workSpace, opmlFile)
+  await fs.writeFile(targetPath, extractedOpml, 'utf8')
+
+  run(['git', 'config', 'user.name', 'Feed bots'], workSpace)
+  run(['git', 'config', 'user.email', 'bot@llun.dev'], workSpace)
+  run(['git', 'add', opmlFile], workSpace)
+  run(['git', 'commit', '-m', `Update OPML file (#${issueNumber})`], workSpace)
+
+  const pushResult = run(
+    ['git', 'push', 'origin', `HEAD:${sourceBranch}`],
+    workSpace
+  )
+  if (pushResult && pushResult.status !== 0) {
+    console.error('Failed to push OPML commit to remote.')
+    throw new Error('Failed to push OPML commit to remote.')
+  }
+
+  if (isIssue) {
+    await octokit.rest.issues.update({
+      owner,
+      repo,
+      issue_number: issueNumber,
+      state: 'closed'
+    })
+  } else {
+    await octokit.rest.pulls.update({
+      owner,
+      repo,
+      pull_number: issueNumber,
+      state: 'closed'
+    })
+  }
+
+  await octokit.rest.issues.createComment({
+    owner,
+    repo,
+    issue_number: issueNumber,
+    body: `Successfully updated \`${opmlFile}\` and committed to \`${sourceBranch}\`.`
+  })
+
+  console.log(`Successfully updated ${opmlFile} from issue #${issueNumber}`)
+  return { handled: true, updated: true }
+}

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,5 @@
 import { createFeedDatabase, createFeedFiles } from './action/feeds'
+import { handleOpmlIssue } from './action/issue'
 import {
   buildSite,
   getGithubActionPath,
@@ -8,6 +9,7 @@ import {
 
 async function run() {
   await setup()
+  await handleOpmlIssue()
   await createFeedDatabase(getGithubActionPath())
   await createFeedFiles(getGithubActionPath())
   await buildSite()

--- a/lib/components/OpmlView.tsx
+++ b/lib/components/OpmlView.tsx
@@ -1,13 +1,16 @@
 'use client'
 
 import React, { FC, useState, useRef, useMemo } from 'react'
-import { Folder, Rss } from 'lucide-react'
+import { Folder, Rss, GitPullRequest } from 'lucide-react'
 import { Button } from './Button'
 import {
-  generateOpml,
-  parseOpml,
-  type OpmlCategory
-} from '../opml'
+  describeOpmlDiff,
+  formatOpmlIssueBody,
+  buildIssueUrl,
+  MAX_URL_LENGTH,
+  OPML_ISSUE_TITLE
+} from '../opml-diff'
+import { generateOpml, parseOpml, type OpmlCategory } from '../opml'
 import { Category } from '../storage/types'
 
 interface OpmlViewProps {
@@ -78,6 +81,24 @@ function parseOpmlSafe(src: string): { cats?: OpmlCategory[]; error?: string } {
   }
 }
 
+function getRepositoryName(): string {
+  if (process.env.NEXT_PUBLIC_GITHUB_REPOSITORY) {
+    return process.env.NEXT_PUBLIC_GITHUB_REPOSITORY
+  }
+  if (typeof window !== 'undefined') {
+    const host = window.location.hostname
+    if (host.endsWith('.github.io')) {
+      const owner = host.replace(/\.github\.io$/, '')
+      const parts = window.location.pathname.split('/').filter(Boolean)
+      const repo = parts[0] || 'feeds'
+      return `${owner}/${repo}`
+    }
+    const saved = window.localStorage.getItem('feeds_github_repo')
+    if (saved) return saved
+  }
+  return ''
+}
+
 export const OpmlView: FC<OpmlViewProps> = ({
   active = true,
   onBack,
@@ -92,11 +113,44 @@ export const OpmlView: FC<OpmlViewProps> = ({
   const [src, setSrc] = useState<string>(defaultInitial)
   const [mode, setMode] = useState<'form' | 'xml'>('form')
   const [copied, setCopied] = useState(false)
+  const [repo, setRepo] = useState<string>(() => getRepositoryName())
   const taRef = useRef<HTMLTextAreaElement>(null)
 
   const pristine = defaultInitial
   const dirty = src !== pristine
   const parsed = useMemo(() => parseOpmlSafe(src), [src])
+
+  const diffResult = useMemo(
+    () => describeOpmlDiff(pristine, src),
+    [pristine, src]
+  )
+
+  const issueUrl = useMemo(() => {
+    const targetRepo = repo || 'owner/repo'
+    const body = formatOpmlIssueBody(diffResult.summary, src)
+    return buildIssueUrl(targetRepo, OPML_ISSUE_TITLE, body)
+  }, [repo, diffResult.summary, src])
+
+  const isUrlTooLarge = issueUrl.length > MAX_URL_LENGTH
+
+  const saveOpml = () => {
+    let targetRepo = repo
+    if (!targetRepo && typeof window !== 'undefined') {
+      const input = window.prompt('Enter your GitHub repository (owner/repo):')
+      if (input) {
+        targetRepo = input.trim()
+        window.localStorage.setItem('feeds_github_repo', targetRepo)
+        setRepo(targetRepo)
+      }
+    }
+    if (!targetRepo) return
+
+    const body = formatOpmlIssueBody(diffResult.summary, src)
+    const url = buildIssueUrl(targetRepo, OPML_ISSUE_TITLE, body)
+    if (url.length <= MAX_URL_LENGTH) {
+      window.open(url, '_blank', 'noopener,noreferrer')
+    }
+  }
 
   const copy = () => {
     const done = () => {
@@ -178,18 +232,33 @@ export const OpmlView: FC<OpmlViewProps> = ({
               Reset
             </Button>
             <Button
-              variant="brand"
+              variant="secondary"
               size="sm"
               iconLeft={copied ? 'check' : undefined}
               onClick={copy}
             >
               {copied ? 'Copied' : 'Copy OPML'}
             </Button>
+            <Button
+              variant="brand"
+              size="sm"
+              iconLeft={<GitPullRequest size={14} />}
+              disabled={!dirty || Boolean(parsed.error) || isUrlTooLarge}
+              title={
+                isUrlTooLarge
+                  ? 'OPML is too large for GitHub URL limit. Please copy and commit manually.'
+                  : undefined
+              }
+              onClick={saveOpml}
+            >
+              Save OPML
+            </Button>
           </div>
         </div>
         <p className="fk-opml-hint">
-          Edits are not saved here. Copy the output and commit{' '}
-          <code>feeds.opml</code> to your repository yourself.
+          {isUrlTooLarge
+            ? 'OPML content exceeds the GitHub URL limit. Copy the output and commit feeds.opml to your repository manually.'
+            : 'Save OPML creates a GitHub issue to update feeds.opml automatically, or you can copy and commit manually.'}
         </p>
       </div>
 

--- a/lib/opml-diff.test.ts
+++ b/lib/opml-diff.test.ts
@@ -1,0 +1,157 @@
+import test from 'ava'
+import {
+  describeOpmlDiff,
+  formatOpmlIssueBody,
+  buildIssueUrl,
+  MAX_URL_LENGTH,
+  OPML_ISSUE_TITLE
+} from './opml-diff'
+
+const opmlBase = `<?xml version="1.0" encoding="UTF-8"?>
+<opml version="2.0">
+  <head><title>Feeds</title></head>
+  <body>
+    <outline text="Engineering" title="Engineering">
+      <outline type="rss" text="llun.dev" title="llun.dev" xmlUrl="https://feeds.llun.dev/rss.xml"/>
+      <outline type="rss" text="jvns.ca" title="jvns.ca" xmlUrl="https://jvns.ca/rss.xml"/>
+    </outline>
+    <outline text="Design" title="Design">
+      <outline type="rss" text="Evil Martians" title="Evil Martians" xmlUrl="https://evilmartians.com/rss.xml"/>
+    </outline>
+  </body>
+</opml>`
+
+test('#describeOpmlDiff reports no changes when OPML is identical', (t) => {
+  const result = describeOpmlDiff(opmlBase, opmlBase)
+  t.false(result.hasChanges)
+  t.is(result.addedCount, 0)
+  t.is(result.removedCount, 0)
+  t.true(result.summary.includes('No changes.'))
+})
+
+test('#describeOpmlDiff detects added feeds', (t) => {
+  const opmlWithAdded = `<?xml version="1.0" encoding="UTF-8"?>
+<opml version="2.0">
+  <head><title>Feeds</title></head>
+  <body>
+    <outline text="Engineering" title="Engineering">
+      <outline type="rss" text="llun.dev" title="llun.dev" xmlUrl="https://feeds.llun.dev/rss.xml"/>
+      <outline type="rss" text="jvns.ca" title="jvns.ca" xmlUrl="https://jvns.ca/rss.xml"/>
+      <outline type="rss" text="Hacker News" title="Hacker News" xmlUrl="https://hnrss.org/frontpage"/>
+    </outline>
+    <outline text="Design" title="Design">
+      <outline type="rss" text="Evil Martians" title="Evil Martians" xmlUrl="https://evilmartians.com/rss.xml"/>
+    </outline>
+  </body>
+</opml>`
+
+  const result = describeOpmlDiff(opmlBase, opmlWithAdded)
+  t.true(result.hasChanges)
+  t.is(result.addedCount, 1)
+  t.is(result.removedCount, 0)
+  t.true(result.summary.includes('### Added'))
+  t.true(
+    result.summary.includes(
+      '**Hacker News** (`https://hnrss.org/frontpage`) in *Engineering*'
+    )
+  )
+  t.false(result.summary.includes('### Removed'))
+})
+
+test('#describeOpmlDiff detects removed feeds', (t) => {
+  const opmlWithRemoved = `<?xml version="1.0" encoding="UTF-8"?>
+<opml version="2.0">
+  <head><title>Feeds</title></head>
+  <body>
+    <outline text="Engineering" title="Engineering">
+      <outline type="rss" text="llun.dev" title="llun.dev" xmlUrl="https://feeds.llun.dev/rss.xml"/>
+    </outline>
+    <outline text="Design" title="Design">
+      <outline type="rss" text="Evil Martians" title="Evil Martians" xmlUrl="https://evilmartians.com/rss.xml"/>
+    </outline>
+  </body>
+</opml>`
+
+  const result = describeOpmlDiff(opmlBase, opmlWithRemoved)
+  t.true(result.hasChanges)
+  t.is(result.addedCount, 0)
+  t.is(result.removedCount, 1)
+  t.false(result.summary.includes('### Added'))
+  t.true(result.summary.includes('### Removed'))
+  t.true(
+    result.summary.includes(
+      '**jvns.ca** (`https://jvns.ca/rss.xml`) from *Engineering*'
+    )
+  )
+})
+
+test('#describeOpmlDiff detects simultaneous additions and removals', (t) => {
+  const opmlModified = `<?xml version="1.0" encoding="UTF-8"?>
+<opml version="2.0">
+  <head><title>Feeds</title></head>
+  <body>
+    <outline text="Engineering" title="Engineering">
+      <outline type="rss" text="llun.dev" title="llun.dev" xmlUrl="https://feeds.llun.dev/rss.xml"/>
+      <outline type="rss" text="New Feed" title="New Feed" xmlUrl="https://newfeed.com/rss.xml"/>
+    </outline>
+  </body>
+</opml>`
+
+  const result = describeOpmlDiff(opmlBase, opmlModified)
+  t.true(result.hasChanges)
+  t.is(result.addedCount, 1)
+  t.is(result.removedCount, 2) // jvns.ca removed, Evil Martians removed
+  t.true(result.summary.includes('### Added'))
+  t.true(
+    result.summary.includes(
+      '**New Feed** (`https://newfeed.com/rss.xml`) in *Engineering*'
+    )
+  )
+  t.true(result.summary.includes('### Removed'))
+  t.true(
+    result.summary.includes(
+      '**jvns.ca** (`https://jvns.ca/rss.xml`) from *Engineering*'
+    )
+  )
+  t.true(
+    result.summary.includes(
+      '**Evil Martians** (`https://evilmartians.com/rss.xml`) from *Design*'
+    )
+  )
+})
+
+test('#describeOpmlDiff detects empty categories added or removed', (t) => {
+  const opmlEmptyCat = `<?xml version="1.0" encoding="UTF-8"?>
+<opml version="2.0">
+  <head><title>Feeds</title></head>
+  <body>
+    <outline text="EmptyCategory" title="EmptyCategory"/>
+  </body>
+</opml>`
+
+  const result = describeOpmlDiff(opmlBase, opmlEmptyCat)
+  t.true(result.hasChanges)
+  t.true(result.summary.includes('Category *EmptyCategory*'))
+})
+
+test('#formatOpmlIssueBody wraps summary and XML in code fence', (t) => {
+  const summary = '## Changes\n\n### Added\n- Feed 1'
+  const xml = '<opml version="2.0"><body/></opml>'
+  const body = formatOpmlIssueBody(summary, xml)
+
+  t.true(body.startsWith(summary))
+  t.true(body.includes('## Updated OPML'))
+  t.true(body.includes('```xml\n<opml version="2.0"><body/></opml>\n```'))
+})
+
+test('#buildIssueUrl constructs valid GitHub issue creation URL', (t) => {
+  const url = buildIssueUrl('llun/feeds', OPML_ISSUE_TITLE, 'Test Body')
+  t.is(
+    url,
+    'https://github.com/llun/feeds/issues/new?title=Update+OPML+file&body=Test+Body'
+  )
+})
+
+test('#MAX_URL_LENGTH is 6000', (t) => {
+  t.is(MAX_URL_LENGTH, 6000)
+})

--- a/lib/opml-diff.ts
+++ b/lib/opml-diff.ts
@@ -1,0 +1,142 @@
+import { parseOpml, type OpmlCategory, type OpmlItem } from './opml'
+
+export const MAX_URL_LENGTH = 6000
+export const OPML_ISSUE_TITLE = 'Update OPML file'
+
+export interface OpmlDiffResult {
+  summary: string
+  hasChanges: boolean
+  addedCount: number
+  removedCount: number
+}
+
+function feedKey(category: string, item: OpmlItem): string {
+  const url = (item.xmlUrl || '').trim()
+  const title = (item.title || item.text || '').trim()
+  return `${category.trim()}:::${url}:::${title}`
+}
+
+function feedDisplay(
+  item: OpmlItem,
+  category: string,
+  isRemoval: boolean
+): string {
+  const title = (item.title || item.text || '').trim()
+  const url = (item.xmlUrl || '').trim()
+  const categoryName = category === 'default' ? 'Uncategorized' : category
+
+  const preposition = isRemoval ? 'from' : 'in'
+
+  if (title && url) {
+    return `- **${title}** (\`${url}\`) ${preposition} *${categoryName}*`
+  } else if (url) {
+    return `- \`${url}\` ${preposition} *${categoryName}*`
+  } else if (title) {
+    return `- **${title}** ${preposition} *${categoryName}*`
+  }
+  return `- *(Untitled feed)* ${preposition} *${categoryName}*`
+}
+
+export function describeOpmlDiff(
+  originalOpml: string,
+  newOpml: string
+): OpmlDiffResult {
+  const originalCats: OpmlCategory[] = parseOpml(originalOpml)
+  const newCats: OpmlCategory[] = parseOpml(newOpml)
+
+  const originalFeedsMap = new Map<
+    string,
+    { item: OpmlItem; category: string }
+  >()
+  const newFeedsMap = new Map<string, { item: OpmlItem; category: string }>()
+
+  const originalCatNames = new Set<string>()
+  const newCatNames = new Set<string>()
+
+  for (const cat of originalCats) {
+    originalCatNames.add(cat.category)
+    for (const item of cat.items) {
+      originalFeedsMap.set(feedKey(cat.category, item), {
+        item,
+        category: cat.category
+      })
+    }
+  }
+
+  for (const cat of newCats) {
+    newCatNames.add(cat.category)
+    for (const item of cat.items) {
+      newFeedsMap.set(feedKey(cat.category, item), {
+        item,
+        category: cat.category
+      })
+    }
+  }
+
+  const addedLines: string[] = []
+  const removedLines: string[] = []
+
+  // Added feeds
+  for (const [key, { item, category }] of newFeedsMap.entries()) {
+    if (!originalFeedsMap.has(key)) {
+      addedLines.push(feedDisplay(item, category, false))
+    }
+  }
+
+  // Removed feeds
+  for (const [key, { item, category }] of originalFeedsMap.entries()) {
+    if (!newFeedsMap.has(key)) {
+      removedLines.push(feedDisplay(item, category, true))
+    }
+  }
+
+  // Check empty categories added or removed
+  for (const cat of newCats) {
+    if (cat.items.length === 0 && !originalCatNames.has(cat.category)) {
+      addedLines.push(`- Category *${cat.category}*`)
+    }
+  }
+
+  for (const cat of originalCats) {
+    if (cat.items.length === 0 && !newCatNames.has(cat.category)) {
+      removedLines.push(`- Category *${cat.category}*`)
+    }
+  }
+
+  const hasChanges = addedLines.length > 0 || removedLines.length > 0
+  const sections: string[] = ['## Changes']
+
+  if (!hasChanges) {
+    sections.push('\nNo changes.')
+  } else {
+    if (addedLines.length > 0) {
+      sections.push(`\n### Added\n${addedLines.join('\n')}`)
+    }
+    if (removedLines.length > 0) {
+      sections.push(`\n### Removed\n${removedLines.join('\n')}`)
+    }
+  }
+
+  return {
+    summary: sections.join('\n'),
+    hasChanges,
+    addedCount: addedLines.length,
+    removedCount: removedLines.length
+  }
+}
+
+export function formatOpmlIssueBody(summary: string, opmlXml: string): string {
+  return `${summary.trim()}\n\n## Updated OPML\n\n\`\`\`xml\n${opmlXml.trim()}\n\`\`\``
+}
+
+export function buildIssueUrl(
+  repository: string,
+  title: string,
+  body: string
+): string {
+  const cleanRepo = repository.replace(/^\/+|\/+$/g, '')
+  const params = new URLSearchParams()
+  params.set('title', title)
+  params.set('body', body)
+  return `https://github.com/${cleanRepo}/issues/new?${params.toString()}`
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -9,6 +9,9 @@ export default () => {
         `/${githubRootName.split('/')[1]}`) ||
       ''
   process.env.NEXT_PUBLIC_BASE_PATH = basePath ?? '/'
+  process.env.NEXT_PUBLIC_GITHUB_REPOSITORY = githubRootName
+  process.env.NEXT_PUBLIC_OPML_FILE =
+    process.env['INPUT_OPMLFILE'] || 'feeds.opml'
   // The action rebuilds the site right after fetching feeds, so build time is
   // when the content was last refreshed.
   process.env.NEXT_PUBLIC_BUILD_TIME = new Date().toISOString()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feeds-fetcher",
-  "version": "4.5.1",
+  "version": "4.6.0",
   "description": "Websites feed fetcher and static feeds aggregator",
   "main": "index.js",
   "type": "module",

--- a/readme.md
+++ b/readme.md
@@ -78,6 +78,37 @@ jobs:
           branch: public
 ```
 
+## Updating subscriptions via GitHub Issues
+
+The reader includes an in-app OPML editor (`/opml`) where you can add, remove, and reorganize feeds. Clicking **Save OPML** opens a prefilled GitHub issue describing what is being added or removed and containing the updated OPML.
+
+To automatically apply subscription updates when an issue is created, enable the `issues` trigger in your workflow with the required permissions:
+
+```yaml
+name: Feeds
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+  issues:
+    types: [opened]
+
+jobs:
+  playground:
+    runs-on: ubuntu-latest
+    name: Build Feeds
+    permissions:
+      contents: write
+      issues: write
+    steps:
+      - name: Run Action
+        uses: llun/feeds@4.0.0
+        with:
+          storageType: files
+```
+
+When an issue titled `Update OPML file` is opened by a repository owner or collaborator, the action extracts the OPML, commits and pushes only `feeds.opml` to your source branch, automatically closes the issue, and rebuilds the site.
+
 ## Sample Sites
 
 - https://feeds.llun.dev


### PR DESCRIPTION
## Summary

Adds a **"Save OPML"** button to the Edit OPML page (`/opml`) that enables subscription updates via an automated GitHub IssueOps workflow.

### Key Changes

1. **Diff & Issue URL Generation (`lib/opml-diff.ts`)**:
   - `describeOpmlDiff`: Identifies added/removed feeds (titles, URLs, and categories) and empty categories.
   - `formatOpmlIssueBody`: Formats a Markdown issue body with the diff summary and an XML code block containing the full updated OPML.
   - `buildIssueUrl`: Constructs the GitHub `/issues/new` URL with title `Update OPML file` and the encoded body.
   - `MAX_URL_LENGTH`: Set to `6000` to prevent exceeding GitHub/browser URL length limits.

2. **Frontend OPML Editor (`lib/components/OpmlView.tsx`, `next.config.ts`)**:
   - Added a **"Save OPML"** button in the editor toolbar.
   - Button is disabled when there are no changes (`!dirty`), when XML has errors, or when the OPML exceeds the 6KB URL limit (with tooltip).
   - Clicking "Save OPML" opens the pre-filled GitHub issue in a new browser tab.
   - **No tokens or credentials are stored or requested in the browser.**
   - Exposed `process.env.NEXT_PUBLIC_GITHUB_REPOSITORY` at build time so deployed sites automatically resolve their repository.

3. **GitHub Action Issue Handler (`action/issue.ts`, `index.ts`)**:
   - Handles `issues` events titled `Update OPML file`.
   - Verifies the author has write permissions (`OWNER`, `MEMBER`, or `COLLABORATOR`).
   - Extracts and validates the OPML content from the issue body.
   - Overwrites and commits **only one file (`feeds.opml`)** to the source branch (`main`), then pushes to remote.
   - Closes the issue with a comment confirming the update.
   - Proceeds to rebuild and publish the static site with the new feeds.

4. **Workflow & Documentation (`.github/workflows/opml-update.yml`, `readme.md`)**:
   - Added sample workflow listening on `issues: [opened]` with `contents: write` and `issues: write` permissions.
   - Updated README documentation with setup instructions.

### Testing

- Automated tests: All 253 tests passing (`yarn test`), including 17 new tests across `lib/opml-diff.test.ts` and `action/issue.test.ts`.
- Production build: `yarn build` succeeds with Turbopack and TypeScript.
