### PR TITLE
feat(opml): copy OPML to clipboard on save and prompt manual paste into issue body

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -495,7 +495,11 @@
     color: var(--_fg);
     cursor: pointer;
     user-select: none;
-    transition: color 120ms, background-color 120ms, border-color 120ms, box-shadow 120ms;
+    transition:
+      color 120ms,
+      background-color 120ms,
+      border-color 120ms,
+      box-shadow 120ms;
     text-decoration: none;
     outline: none;
   }
@@ -637,6 +641,31 @@
     display: flex;
     gap: 6px;
     flex-shrink: 0;
+  }
+  .fk-opml-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    margin: 0 16px 10px;
+    padding: 8px 12px;
+    border-radius: var(--radius-sm, 6px);
+    background: var(--sidebar-accent);
+    border: 1px solid var(--border);
+    font-size: 13px;
+    line-height: 1.4;
+    color: var(--foreground);
+  }
+  .fk-opml-bar-content {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+  .fk-opml-bar-content svg {
+    flex-shrink: 0;
+    color: var(--link, #2563eb);
   }
   .fk-opml-hint {
     margin: 0;

--- a/lib/components/OpmlView.tsx
+++ b/lib/components/OpmlView.tsx
@@ -1,13 +1,12 @@
 'use client'
 
 import React, { FC, useState, useRef, useMemo } from 'react'
-import { Folder, Rss, GitPullRequest } from 'lucide-react'
+import { Folder, Rss, GitPullRequest, Info } from 'lucide-react'
 import { Button } from './Button'
 import {
   describeOpmlDiff,
   formatOpmlIssueBody,
   buildIssueUrl,
-  MAX_URL_LENGTH,
   OPML_ISSUE_TITLE
 } from '../opml-diff'
 import { generateOpml, parseOpml, type OpmlCategory } from '../opml'
@@ -101,6 +100,7 @@ export const OpmlView: FC<OpmlViewProps> = ({
   const [src, setSrc] = useState<string>(defaultInitial)
   const [mode, setMode] = useState<'form' | 'xml'>('form')
   const [copied, setCopied] = useState(false)
+  const [showClipboardNotice, setShowClipboardNotice] = useState(false)
   const [repo, setRepo] = useState<string>(() => getRepositoryName())
   const taRef = useRef<HTMLTextAreaElement>(null)
 
@@ -113,13 +113,37 @@ export const OpmlView: FC<OpmlViewProps> = ({
     [pristine, src]
   )
 
-  const issueUrl = useMemo(() => {
-    const targetRepo = repo || 'owner/repo'
-    const body = formatOpmlIssueBody(diffResult.summary, src)
-    return buildIssueUrl(targetRepo, OPML_ISSUE_TITLE, body)
-  }, [repo, diffResult.summary, src])
+  const copyToClipboard = (text: string) => {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(text).catch(() => {
+        fallbackCopy(text)
+      })
+    } else {
+      fallbackCopy(text)
+    }
+  }
 
-  const isUrlTooLarge = issueUrl.length > MAX_URL_LENGTH
+  const fallbackCopy = (text: string) => {
+    if (taRef.current && mode === 'xml') {
+      taRef.current.select()
+      try {
+        document.execCommand('copy')
+      } catch {}
+      window.getSelection()?.removeAllRanges()
+      return
+    }
+    try {
+      const el = document.createElement('textarea')
+      el.value = text
+      el.setAttribute('readonly', '')
+      el.style.position = 'absolute'
+      el.style.left = '-9999px'
+      document.body.appendChild(el)
+      el.select()
+      document.execCommand('copy')
+      document.body.removeChild(el)
+    } catch {}
+  }
 
   const saveOpml = () => {
     let targetRepo = repo
@@ -133,37 +157,18 @@ export const OpmlView: FC<OpmlViewProps> = ({
     }
     if (!targetRepo) return
 
-    const body = formatOpmlIssueBody(diffResult.summary, src)
+    copyToClipboard(src)
+    setShowClipboardNotice(true)
+
+    const body = formatOpmlIssueBody(diffResult.summary)
     const url = buildIssueUrl(targetRepo, OPML_ISSUE_TITLE, body)
-    if (url.length <= MAX_URL_LENGTH) {
-      window.open(url, '_blank', 'noopener,noreferrer')
-    }
+    window.open(url, '_blank', 'noopener,noreferrer')
   }
 
   const copy = () => {
-    const done = () => {
-      setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
-    }
-
-    if (navigator.clipboard && navigator.clipboard.writeText) {
-      navigator.clipboard.writeText(src).then(done, () => {
-        fallback()
-        done()
-      })
-    } else {
-      fallback()
-      done()
-    }
-
-    function fallback() {
-      if (!taRef.current) return
-      taRef.current.select()
-      try {
-        document.execCommand('copy')
-      } catch {}
-      window.getSelection()?.removeAllRanges()
-    }
+    copyToClipboard(src)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
   }
 
   const edit = (fn: (model: OpmlCategory[]) => void) => {
@@ -215,7 +220,10 @@ export const OpmlView: FC<OpmlViewProps> = ({
               variant="ghost"
               size="sm"
               disabled={!dirty}
-              onClick={() => setSrc(pristine)}
+              onClick={() => {
+                setSrc(pristine)
+                setShowClipboardNotice(false)
+              }}
             >
               Reset
             </Button>
@@ -231,22 +239,34 @@ export const OpmlView: FC<OpmlViewProps> = ({
               variant="brand"
               size="sm"
               iconLeft={<GitPullRequest size={14} />}
-              disabled={!dirty || Boolean(parsed.error) || isUrlTooLarge}
-              title={
-                isUrlTooLarge
-                  ? 'OPML is too large for GitHub URL limit. Please copy and commit manually.'
-                  : undefined
-              }
+              disabled={!dirty || Boolean(parsed.error)}
               onClick={saveOpml}
             >
               Save OPML
             </Button>
           </div>
         </div>
+        {showClipboardNotice && (
+          <div className="fk-opml-bar" role="status">
+            <div className="fk-opml-bar-content">
+              <Info size={15} />
+              <span>
+                OPML content copied to clipboard! Please paste it into the issue
+                body manually.
+              </span>
+            </div>
+            <Button
+              variant="ghost"
+              size="sm"
+              iconLeft="x"
+              aria-label="Dismiss message"
+              onClick={() => setShowClipboardNotice(false)}
+            />
+          </div>
+        )}
         <p className="fk-opml-hint">
-          {isUrlTooLarge
-            ? 'OPML content exceeds the GitHub URL limit. Copy the output and commit feeds.opml to your repository manually.'
-            : 'Save OPML creates a GitHub issue to update feeds.opml automatically, or you can copy and commit manually.'}
+          Save OPML opens a GitHub issue and copies the OPML content to your
+          clipboard to paste into the issue body.
         </p>
       </div>
 

--- a/lib/opml-diff.test.ts
+++ b/lib/opml-diff.test.ts
@@ -3,7 +3,6 @@ import {
   describeOpmlDiff,
   formatOpmlIssueBody,
   buildIssueUrl,
-  MAX_URL_LENGTH,
   OPML_ISSUE_TITLE
 } from './opml-diff'
 
@@ -142,6 +141,15 @@ test('#formatOpmlIssueBody wraps summary and XML in code fence', (t) => {
   t.true(body.startsWith(summary))
   t.true(body.includes('## Updated OPML'))
   t.true(body.includes('```xml\n<opml version="2.0"><body/></opml>\n```'))
+})
+
+test('#formatOpmlIssueBody defaults to PASTE_OPML_HERE placeholder', (t) => {
+  const summary = '## Changes\n\n### Added\n- Feed 1'
+  const body = formatOpmlIssueBody(summary)
+
+  t.true(body.startsWith(summary))
+  t.true(body.includes('## Updated OPML'))
+  t.true(body.includes('```xml\nPASTE_OPML_HERE\n```'))
 })
 
 test('#buildIssueUrl constructs valid GitHub issue creation URL', (t) => {

--- a/lib/opml-diff.ts
+++ b/lib/opml-diff.ts
@@ -1,6 +1,5 @@
 import { parseOpml, type OpmlCategory, type OpmlItem } from './opml'
 
-export const MAX_URL_LENGTH = 60000
 export const OPML_ISSUE_TITLE = 'Update OPML file'
 
 export interface OpmlDiffResult {
@@ -125,8 +124,12 @@ export function describeOpmlDiff(
   }
 }
 
-export function formatOpmlIssueBody(summary: string, opmlXml: string): string {
-  return `${summary.trim()}\n\n## Updated OPML\n\n\`\`\`xml\n${opmlXml.trim()}\n\`\`\``
+export function formatOpmlIssueBody(
+  summary: string,
+  opmlXml: string = 'PASTE_OPML_HERE'
+): string {
+  const content = opmlXml && opmlXml.trim() ? opmlXml.trim() : 'PASTE_OPML_HERE'
+  return `${summary.trim()}\n\n## Updated OPML\n\n\`\`\`xml\n${content}\n\`\`\``
 }
 
 export function buildIssueUrl(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feeds-fetcher",
-  "version": "4.6.2",
+  "version": "4.6.3",
   "description": "Websites feed fetcher and static feeds aggregator",
   "main": "index.js",
   "type": "module",

--- a/readme.md
+++ b/readme.md
@@ -89,7 +89,7 @@ jobs:
 
 ## Updating subscriptions via GitHub Issues
 
-The reader includes an in-app OPML editor (`/opml`) where you can add, remove, and reorganize feeds. Clicking **Save OPML** opens a prefilled GitHub issue describing what is being added or removed and containing the updated OPML.
+The reader includes an in-app OPML editor (`/opml`) where you can add, remove, and reorganize feeds. Clicking **Save OPML** copies the updated OPML to your clipboard and opens a prefilled GitHub issue describing what is being added or removed. You then paste the OPML into the issue body to submit.
 
 To automatically apply subscription updates when an issue is created, enable the `issues` trigger in your workflow with the required permissions:
 


### PR DESCRIPTION
## Summary
- Removes the URL length limit constraint when saving OPML subscriptions.
- Copies the OPML content to the clipboard when clicking **Save OPML** and opens the prefilled GitHub issue without inlining large XML into the query string.
- Displays a notification bar advising the user to paste the OPML from their clipboard into the issue body manually.
- Updates `formatOpmlIssueBody` to default to `PASTE_OPML_HERE` placeholder in the issue body.
- Bumps package version to `4.6.3`.